### PR TITLE
Use utf8 encoding during generate_from to avoid ascii encoding warnin…

### DIFF
--- a/_plugins/generate_from_url.rb
+++ b/_plugins/generate_from_url.rb
@@ -30,7 +30,7 @@ Jekyll::Hooks.register :pages, :pre_render do |page, payload|
   end
 
   # Try to get the readme data for this path and strip first two lines (redundant title)
-  readme_content = File.readlines(cache_path)
+  readme_content = File.readlines(cache_path, :encoding => 'UTF-8')
 
   # use the `ignore_section`
   ignore_sections = page.data['ignore_sections'] || []


### PR DESCRIPTION
…gs on Xenial