### PR TITLE
Serve Assets from CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ gem install --install-dir vendor/bundle/ruby/<ruby_version_numbwe> nokogiri -v "
  2. Clone *your forked repository* with `git clone https://github.com/YOURUSERNAME/dev-center.git`
  3. `cd dev-center`
  4. Install all dependencies: `bundle install`. If you are having trouble with some of the gems, try running `bundle update`, then run `bundle install` again.  If `bundle` is not available, `gem install bundler`.
- 5. Start the test server: `bundle exec jekyll serve`
+ 5. Start the test server: `bundle exec jekyll serve` (append `--config _config.yml,_config-dev.yml` to use dev cdn config)
 
 You can now see the developer center at <http://localhost:4000>.
 

--- a/_config-dev.yml
+++ b/_config-dev.yml
@@ -1,0 +1,4 @@
+# Dev Config Overrides
+
+# URL for assets we serve via CDN
+cdnurl: http://localhost:9000

--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,9 @@ locale: en_US
 # Do not include a trailing /.
 url: https://algorithmia.com
 
+# URL for assets we serve via CDN
+cdnurl: https://cdn.algorithmia.com
+
 # The entire site is nested under this baseurl
 baseurl: /developers
 

--- a/_includes/latest-posts-grid.html
+++ b/_includes/latest-posts-grid.html
@@ -3,7 +3,7 @@
   <ul class="th-grid">
   {% capture category_name %}{{ page.categories | first }}{% endcapture %}
   {% for post in site.categories.[category_name] limit:4 %}
-    <li><a href="{{ post.url | relative_url }}" title="{{ post.title }}"><img src="{{ post.image.thumb | prepend:'/images/' | relative_url }}" alt=""></a></li>
+    <li><a href="{{ post.url | relative_url }}" title="{{ post.title }}"><img src="{{ site.cdnurl }}{{ post.image.thumb | prepend:'/images/' | relative_url }}" alt=""></a></li>
   {% endfor %}
   </ul>
 </div><!-- /.archive-wrap -->

--- a/_includes/post-grid-with-excerpt.html
+++ b/_includes/post-grid-with-excerpt.html
@@ -1,9 +1,9 @@
 <div class="col-xs-6 col-sm-6 col-md-4" style="text-decoration: none!important;">
   <a href="{{ post.url | relative_url }}" title="{{ post.title }}" class="post-teaser lang-tile lang-tile-large" style="text-decoration: none!important;">
     {% if post.image.teaser %}
-      <img src="{{ post.image.teaser | prepend:'/images' | relative_url }}" alt="" itemprop="image" class="lang-icon">
+      <img src="{{ site.cdnurl }}{{ post.image.teaser | prepend:'/images' | relative_url }}" alt="" itemprop="image" class="lang-icon">
     {% else %}
-      <img class="larger_icon" src="{{ post.image.teaser | prepend:'/images' | relative_url }}" alt="icon" itemprop="image">
+      <img class="larger_icon" src="{{ site.cdnurl }}{{ post.image.teaser | prepend:'/images' | relative_url }}" alt="icon" itemprop="image">
     {% endif %}
 
     <header itemprop="name" class="lg mb-0">{{ post.title }}</header>

--- a/_includes/post-grid.html
+++ b/_includes/post-grid.html
@@ -1,9 +1,9 @@
 <div class="col-xs-6 col-sm-6 col-md-3">
 	  <a href="{{ post.url | relative_url }}" title="{{ post.title }}" class="post-teaser lang-tile">
 	    {% if post.image.teaser %}
-	      <img src="{{ post.image.teaser | prepend:'/images' | relative_url }}" alt="" itemprop="image" class="lang-icon">
+	      <img src="{{ site.cdnurl }}{{ post.image.teaser | prepend:'/images' | relative_url }}" alt="" itemprop="image" class="lang-icon">
 	    {% else %}
-	      <img class="larger_icon" src="{{ post.image.teaser | prepend:'/images' | relative_url }}" alt="icon" itemprop="image">
+	      <img class="larger_icon" src="{{ site.cdnurl }}{{ post.image.teaser | prepend:'/images' | relative_url }}" alt="icon" itemprop="image">
 	    {% endif %}
 	    {{ post.title }}
 	  </a>

--- a/_includes/title-icon.html
+++ b/_includes/title-icon.html
@@ -1,3 +1,3 @@
 {% if page.image.teaser %}
-	<img src="{{ page.image.teaser | prepend:'/images' | relative_url }}" alt="" itemprop="image" class="title-icon">
+	<img src="{{ site.cdnurl }}{{ page.image.teaser | prepend:'/images' | relative_url }}" alt="" itemprop="image" class="title-icon">
 {% endif %}

--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -5,7 +5,7 @@ layout: default
 {% if page.image.feature %}
 <div class="page-feature">
 	<div class="page-image">
-		<img src="{{ page.image.feature | prepend:'/images/' | relative_url }}" class="page-feature-image" alt="{{ page.title }}">
+		<img src="{{ site.cdnurl }}{{ page.image.feature | prepend:'/images/' | relative_url }}" class="page-feature-image" alt="{{ page.title }}">
 		{% if page.image.credit %}{% include image-credit.html %}{% endif %}
 	</div><!-- /.page-image -->
 </div><!-- /.page-feature -->

--- a/_layouts/article_snippets.html
+++ b/_layouts/article_snippets.html
@@ -6,7 +6,7 @@ layout: default
 	{% if page.image.feature %}
 	<div class="page-feature">
 		<div class="page-image">
-			<img src="{{ page.image.feature | prepend:'/images/' | relative_url }}" class="page-feature-image" alt="{{ page.title }}" itemprop="image">
+			<img src="{{ site.cdnurl }}{{ page.image.feature | prepend:'/images/' | relative_url }}" class="page-feature-image" alt="{{ page.title }}" itemprop="image">
 			{% if page.image.credit %}{% include image-credit.html %}{% endif %}
 		</div><!-- /.page-image -->
 	</div><!-- /.page-feature -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,7 @@
     {% endif %}
     {% include open-graph.html %}
     <link rel="canonical" href="{{ page.url | absolute_url | replace:'index.html','' }}">
-    <link rel="stylesheet" href="{{ site.baseurl }}/css/pygments-github.css">
+    <link rel="stylesheet" href="{{ site.cdnurl }}{{ site.baseurl }}/css/pygments-github.css">
     <!-- END_HEAD_EMBED -->
 
     <link href="{{ site.url }}{{ site.baseurl }}/atom.xml" type="application/atom+xml" rel="alternate" title="{{ site.title }} Atom Feed">
@@ -70,7 +70,7 @@
     <script src="//s3.amazonaws.com/algorithmia-assets/js/angular/1.6.1/angular.min.js"></script>
 
     <!-- BEGIN_SCRIPTS_EMBED -->
-    <script src="{{ site.baseurl }}/js/search.min.js" type="text/javascript" charset="utf-8"></script>
+    <script src="{{ site.cdnurl }}{{ site.baseurl }}/js/search.min.js" type="text/javascript" charset="utf-8"></script>
     <script type="text/javascript">
     $(function() {
       $('#search-query').lunrSearch({

--- a/_layouts/media.html
+++ b/_layouts/media.html
@@ -6,7 +6,7 @@ layout: default
 			{% if page.image.feature %}
 			<div class="page-feature">
 				<div class="page-image">
-					<img src="{{ site.url }}/images/{{ page.image.feature }}" class="page-feature-image" alt="{{ page.title }}" itemprop="image">
+					<img src="{{ site.cdnurl }}{{ site.url }}/images/{{ page.image.feature }}" class="page-feature-image" alt="{{ page.title }}" itemprop="image">
 					{% if page.image.credit %}{% include image-credit.html %}{% endif %}
 				</div><!-- /.page-image -->
 			</div><!-- /.page-feature -->

--- a/_pages/algorithm-development.md
+++ b/_pages/algorithm-development.md
@@ -7,7 +7,7 @@ excerpt: "Basic Guides for Algorithm Developers"
 show_related: false
 ---
 
-<p>Welcome to deploying your algorithms and models using Algorithmia's AI Layer. You can create algorithms using Java, Python, R, Rust, Scala, Ruby, and JavaScript by following along with one of our <a href="{{ site.baseurl }}/algorithm-development/languages/">Language Guides</a>.</p> 
+<p>Welcome to deploying your algorithms and models using Algorithmia's AI Layer. You can create algorithms using Java, Python, R, Rust, Scala, Ruby, and JavaScript by following along with one of our <a href="{{ site.baseurl }}/algorithm-development/languages/">Language Guides</a>.</p>
 
 
 <p>If you have a trained machine or deep learning model and want to deploy it on our platform, check out the <a href="{{ site.baseurl }}/algorithm-development/model-guides/">Model Deployment Guides</a> where you'll see tutorials for popular frameworks such as <a href ="{{ site.baseurl }}/model-deployment/scikit/">Scikit-learn</a>, <a href ="{{ site.baseurl }}/algorithm-development/model-guides/pytorch/">PyTorch</a>, and <a href ="{{ site.baseurl }}/model-deployment/tensorflow/">Tensorflow</a>.</p>
@@ -16,8 +16,8 @@ show_related: false
   <div class="col-md-12">
     <h3>Get Started</h3>
     <div class="dev-card">
-      <img src="{{ site.baseurl }}/images/get_started.png" alt="Get Started" class="img-fill get-started-img">
-      <img src="{{ site.baseurl }}/images/icons/hexicon_desktop.svg" alt="icon" class="hexicon">
+      <img src="{{ site.cdnurl }}{{ site.baseurl }}/images/get_started.png" alt="Get Started" class="img-fill get-started-img">
+      <img src="{{ site.cdnurl }}{{ site.baseurl }}/images/icons/hexicon_desktop.svg" alt="icon" class="hexicon">
       <div class="dev-card-text">
         <p class="lead">Learn how to create and publish your algorithms</p>
         <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/" class="btn btn-default btn-accent">Get Started Now</a>

--- a/_pages/algorithm-development/algorithm-basics/algorithm-checklist.md
+++ b/_pages/algorithm-development/algorithm-basics/algorithm-checklist.md
@@ -39,7 +39,7 @@ Make sure to describe what the algorithm does. It is better to use clear and sim
 
 The algorithm description is front-and-center on the algorithm profile page. Use the description to write a clear explanation of what the algorithm does, what kind of input it takes, and what kind of output the user can expect. Be sure to highlight the various ways your algorithm can be used so that users get a thorough understanding of what types of problems the algorithm solves.
 
-<img src="{{ site.baseurl }}/images/post_images/algorithm_checklist/description.png" alt="Algorithm description" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algorithm_checklist/description.png" alt="Algorithm description" class="screenshot img-md">
 
 #### Describe the inputs & expected output
 
@@ -47,7 +47,7 @@ Be sure to quickly describe the input needed to call the algorithm and the types
 
 It is also helpful to explain what the output of the algorithm should be. If your algorithm returns an output that corresponds to a value system, be sure to explain what it means. For example, in the algorithm for Sentiment Analysis, the user gets an output of a number between 0 and 4. The algorithm description describes what these numbers mean; in this case, the sentiment rating of very negative, negative, neutral, positive, and very positive.
 
-<img src="{{ site.baseurl }}/images/post_images/algorithm_checklist/io.png" alt="inputs and outputs" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algorithm_checklist/io.png" alt="inputs and outputs" class="screenshot img-md">
 
 #### Configure error handling
 
@@ -57,7 +57,7 @@ To make your algorithm easy to use, it's key to implement informative error hand
 
 If your algorithm is based off an academic paper or external library, you should also include a link to this documentation to give the users a chance to read more. Giving credit to the original source that your algorithm is based on is a best practice and allows curious users to take a deeper dive into the internal workings of the algorithm. Plus it's good karma!
 
-<img src="{{ site.baseurl }}/images/post_images/algorithm_checklist/credits.png" alt="inputs and outputs" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algorithm_checklist/credits.png" alt="inputs and outputs" class="screenshot img-md">
 
 ### Give It a Tagline:
 
@@ -67,7 +67,7 @@ The tagline is a succinct way to describe your algorithm. The tagline will appea
 
 Determine sentiment from text
 
-<img src="{{ site.baseurl }}/images/post_images/algorithm_checklist/search.png" alt="inputs and outputs" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algorithm_checklist/search.png" alt="inputs and outputs" class="screenshot img-md">
 
 ### Add Tags:
 
@@ -92,7 +92,7 @@ Sample input is one of the most important parts of your algorithm profile. Users
 
 `4`
 
-<img src="{{ site.baseurl }}/images/post_images/algorithm_checklist/sample_input.png" alt="inputs and outputs" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algorithm_checklist/sample_input.png" alt="inputs and outputs" class="screenshot img-md">
 
 A common gotcha for setting and updating the sample input is that you must publish your algorithm before you can save the sample input. If you are unable to save your sample input, double check that the algorithm has been published before continuing.
 {: .notice-warning }
@@ -101,11 +101,11 @@ A common gotcha for setting and updating the sample input is that you must publi
 
 If you are publishing a new version of your algorithm, you can update the pricing of each call. This will be displayed on the pricing section of your algorithm profile. Remember, you can set the royalty price even if your code is open source!
 
-<img src="{{ site.baseurl }}/images/post_images/algorithm_checklist/cost.png" alt="inputs and outputs" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algorithm_checklist/cost.png" alt="inputs and outputs" class="screenshot img-md">
 
 ### Check Permissions & Source Code Visibility:
 
 * Permissions: Any special permissions that this algorithm requires.
 * Source Availability: The license and source visibility of an algorithm.
 
-<img src="{{ site.baseurl }}/images/post_images/algorithm_checklist/permissions.png" alt="inputs and outputs" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algorithm_checklist/permissions.png" alt="inputs and outputs" class="screenshot img-md">

--- a/_pages/algorithm-development/algorithm-basics/git.md
+++ b/_pages/algorithm-development/algorithm-basics/git.md
@@ -15,7 +15,7 @@ redirect_from:
 Every algorithm on Algorithmia has a dedicated git repository. Using this repository allows you to seamlessly integrate Algorithmia with your current workflows,
 such as your code editor, IDE, or deployment pipelines. If you're unfamiliar with git we recommend <a rel="nofollow" target="_blank" href="http://rogerdudler.github.io/git-guide/">this brief guide</a>.
 
-<img src="{{ site.baseurl }}/images/post_images/legit/legit-demo.gif" alt="Demo for Git" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/legit/legit-demo.gif" alt="Demo for Git" class="screenshot">
 
 ## Accessing a repository
 

--- a/_pages/algorithm-development/algorithm-basics/your-first-algo.md
+++ b/_pages/algorithm-development/algorithm-basics/your-first-algo.md
@@ -12,7 +12,7 @@ redirect_from:
   - /algorithm-development/your-first-algo/
 ---
 
-One of the great things about Algorithmia is that the platform allows you to put your own work online and make it available to other developers through the API. This guide will show you how with a walk-through of making and publishing a classic "Hello World" algorithm. 
+One of the great things about Algorithmia is that the platform allows you to put your own work online and make it available to other developers through the API. This guide will show you how with a walk-through of making and publishing a classic "Hello World" algorithm.
 
 Note that this example shows how to create a Python algorithm, however all the steps shown are the same in all languages. To see specific code examples in the languages we support, check out <a href="{{ site.baseurl }}/algorithm-development/languages/">Algorithm Development Languages</a>.
 
@@ -27,11 +27,11 @@ Table of Contents
 
 Let's start by creating an algorithm. First navigate to [Algorithmia](https://algorithmia.com) and by hovering over your profile avatar at the top right of the navbar, you'll see a dropdown with a link that says "Add Algorithm". Go ahead and click that link.
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/add_algorithm.png" alt="Add algorithm navigation" class="screenshot img-smallest">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/add_algorithm.png" alt="Add algorithm navigation" class="screenshot img-smallest">
 
 When you click the "Add Algorithm" link, you'll see a form for creating your algorithm that we'll fill out step by step below:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/create_algorithm_python.png" alt="Create an algorithm in Python" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/create_algorithm_python.png" alt="Create an algorithm in Python" class="screenshot img-sm">
 
 **Algorithmia Name:** The first thing you'll notice in the form is the field "Algorithm Name" which will be the name of your algorithm. You'll want to name your algorithm something descriptive based on what the algorithm does.
 
@@ -39,7 +39,7 @@ For example this is the beginning portion of the <a href="{{ site.baseurl }}/alg
 
 **Algorithm ID:** The unique AlgoURL path users will use to call your algorithm.
 
-**Language:** Next you'll pick the language of your choice. 
+**Language:** Next you'll pick the language of your choice.
 
 **Source Code:** Because we want to make this algorithm open source and available for everyone to view the source code, we'll choose "Open Source".
 
@@ -54,7 +54,7 @@ You can find out more about algorithm permissions in the [Algorithm Permissions 
 
 Now hit the "Create" button on the bottom lower right of the form and you'll see this modal:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/create-algo-cli.png" alt="cli info modal" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/create-algo-cli.png" alt="cli info modal" class="screenshot img-md">
 
 You can now clone your Algorithm (via Git) and install the CLI to edit/test locally, **or** you can close the modal and continue to create your algorithm in the Web IDE.
 
@@ -64,7 +64,7 @@ The preferred way to edit and test your Algorithm's code is to install the CLI o
 
 To learn more about this process, Algorithmia's [CLI]({{ site.baseurl }}/clients/cli/) and [Git]({{ site.baseurl }}/algorithm-development/git/) guides. If you're already familiar with the CLI and Git, the basic steps you need to take are:
 
-1. Install the CLI: `curl -sSLf https://algorithmia.com/install.sh | sh` (Windows instructions [here](https://algorithmia.com/developers/clients/cli/#installing-the-algorithmia-cli) ) 
+1. Install the CLI: `curl -sSLf https://algorithmia.com/install.sh | sh` (Windows instructions [here](https://algorithmia.com/developers/clients/cli/#installing-the-algorithmia-cli) )
 2. Clone your algorithm: `algo clone username/algoname`
 3. Use your preferred editor to modify the code
 4. Test your algorithm: `cd algoname; algo runlocal -D [JSON FILE]`
@@ -82,17 +82,17 @@ If you're using Python, you must [set an environment variable](https://www.schro
 
 If you prefer to continue creating your algorithm in the Web IDE, simply close the modal and you should see the algorithm description page for your newly created algorithm:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/generic_algorithm_description.png" alt="Algorithm descrption page" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/generic_algorithm_description.png" alt="Algorithm descrption page" class="screenshot img-md">
 
 Notice the tabs: **Run**, **Docs**, **Cost**, **Discussion**, **Manage**, and **Source**.
 
-The tab currently showing **Run** is where users can run the algorithm with the default input that you will provide during the publishing step of the algorithm or they can run their own input to test out your algorithm. Also, on this tab, you can add a short summary stating what your algorithm is and why people might be interested in it (for example how it solves a particular problem in a use case). 
+The tab currently showing **Run** is where users can run the algorithm with the default input that you will provide during the publishing step of the algorithm or they can run their own input to test out your algorithm. Also, on this tab, you can add a short summary stating what your algorithm is and why people might be interested in it (for example how it solves a particular problem in a use case).
 
 **Docs** consists of the section that you will want to show how to use your algorithm including complete information about the input types allowed and what the expected outputs will be.
 
 **Cost** will be filled out automatically once you publish your algorithm and will show if you've chosen to charge royalites or if you've decided to open source your algorithm. It will also give the estimated cost so the user consuming your algorithm can see how much it will cost.
 
-The **Discussion** tab shows the comments and questions from users so you can keep up to date regarding user feedback. 
+The **Discussion** tab shows the comments and questions from users so you can keep up to date regarding user feedback.
 
 Under the **Manage** tab you can see how to clone your algorithm, see what items are checked off in the Algorithm Checklist and see permissions for your algorithm which were set when you created your algorithm.
 
@@ -109,20 +109,20 @@ To run this algorithm first hit the "Compile" button on the top right hand corne
 Compiling your algorithm will also save your work, but note that the first time you compile your algorithm it might take some time while subsequent compiles will be quicker.
 {: .notice-info}
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
 
-Once you have finished editing and want to run the algorithm, click the blue **Compile** button at the top right of the editor. This will save your algorithm by committing your code to your personal git repository and will try to compile your code. 
+Once you have finished editing and want to run the algorithm, click the blue **Compile** button at the top right of the editor. This will save your algorithm by committing your code to your personal git repository and will try to compile your code.
 
-Once your algorithm has successfully complied, you can test it out by passing input though the console at the bottom of the screen. For instance, after compiling this algorithm, you can test the "Hello World" code by typing in "World" in the console: 
+Once your algorithm has successfully complied, you can test it out by passing input though the console at the bottom of the screen. For instance, after compiling this algorithm, you can test the "Hello World" code by typing in "World" in the console:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/compile_test_algorithm_python.png" alt="Run basic algorithm in console Python" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/compile_test_algorithm_python.png" alt="Run basic algorithm in console Python" class="screenshot">
 
 ## Publish your Algorithm
 Last is publishing your algorithm. The best part of hosting your model on Algorithmia is that users can access it via an API that takes only a few lines of code to use! Here is what you can set when publishing your algorithm:
 
 On the upper right hand side of the algorithm page you'll see a purple button **Publish** which will bring up a modal:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
 
 In this modal, you'll see a **Changes** tab, a **Sample I/O** tab, and one called **Versioning**.
 
@@ -160,4 +160,4 @@ Now that you've published your first simple algorithm on the platform, you can f
 
 #### Next Steps
 
-After you've finished this tutorial, you'll probably want to check out the <a href="{{ site.baseurl }}/algorithm-development/languages/">Language Guides</a> for how to write algorithms in the language you prefer, such as R, Python, Rust, Ruby, Java, Scala, or JavaScript. 
+After you've finished this tutorial, you'll probably want to check out the <a href="{{ site.baseurl }}/algorithm-development/languages/">Language Guides</a> for how to write algorithms in the language you prefer, such as R, Python, Rust, Ruby, Java, Scala, or JavaScript.

--- a/_pages/algorithm-development/languages/java.md
+++ b/_pages/algorithm-development/languages/java.md
@@ -35,7 +35,7 @@ via the <a href="{{ site.baseurl }}/clients/java/">Algorithmia Java Client</a>.
 
 ## Write your First Algorithm
 
-If you've followed the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice in your algorithm editor, there is boilerplate code that returns "Hello" and whatever you input to the console. 
+If you've followed the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice in your algorithm editor, there is boilerplate code that returns "Hello" and whatever you input to the console.
 
 The main thing to note about the algorithm is that it's wrapped in the apply() function.
 
@@ -44,7 +44,7 @@ The apply() function defines the input point of the algorithm. We use the apply(
 
 Go ahead and remove the boilerplate code below that's inside the apply() function because we'll be writing a different algorithm in this tutorial:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_java.png" alt="Algorithm console Java" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_java.png" alt="Algorithm console Java" class="screenshot">
 
 ## Managing Dependencies
 
@@ -53,7 +53,7 @@ Algorithmia supports adding 3rd party dependencies via Maven packages. Specifica
 
 On the algorithm editor page there is a button on the top right that says "Dependencies". Click that button and you'll see a modal window:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/java_dependencies.png" alt="Java Dependency File" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/java_dependencies.png" alt="Java Dependency File" class="screenshot img-md">
 
 If you have any dependencies you can add them by typing in the package name to the dependency file in the following form:
 
@@ -332,7 +332,7 @@ Go ahead and try the above code sample in the Algorithmia code editor and then t
 
 This returns a Map of an ArrayList of words:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/tokenize_url.png" alt="Run basic algorithm in console" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/tokenize_url.png" alt="Run basic algorithm in console" class="screenshot">
 
 As you can see from these examples, fields that are passed into your algorithm by the user such as scalar values and sequences such as lists, maps, arrays and bytearray (binary byte sequence such as an image file) can be handled as you would any Java data structure within your algorithm.
 
@@ -365,7 +365,7 @@ Once you've developed your algorithm, you can publish it and make it available f
 
 On the upper right hand side of the algorithm page you'll see a purple button "Publish" which will bring up a modal:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
 
 In this modal, you'll see a Changes tab, a Sample I/O tab, and one called Versioning.
 
@@ -377,7 +377,7 @@ Under the Versioning tab, you can select whether your algorithm will be for publ
 
 Check out [Algorithm Pricing]({{ site.baseurl }}/pricing/) for more information on how much algorithms will cost to run.
 
-Under Semantic Versioning you can choose which kind of release your change should fall under: Major, Minor, or Revision. 
+Under Semantic Versioning you can choose which kind of release your change should fall under: Major, Minor, or Revision.
 
 If you are satisfied with your algorithm and settings, go ahead and hit publish. Congratulations, you’re an algorithm developer!
 

--- a/_pages/algorithm-development/languages/javascript.md
+++ b/_pages/algorithm-development/languages/javascript.md
@@ -35,7 +35,7 @@ via the <a href="{{ site.baseurl }}/clients/node/">Algorithmia NodeJS Client</a>
 
 ## Write your First Algorithm
 
-If you've followed the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice in your algorithm editor, there is boilerplate code that returns "Hello" and whatever you input to the console. 
+If you've followed the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice in your algorithm editor, there is boilerplate code that returns "Hello" and whatever you input to the console.
 
 The main thing to note about the algorithm is that it's wrapped in the apply() function.
 
@@ -44,15 +44,15 @@ The apply() function defines the input point of the algorithm. We use the apply(
 
 Go ahead and remove the boilerplate code below that's inside the apply() function because we'll be writing a different algorithm in this tutorial:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_Javascript.png" alt="Algorithm console JavaScript" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_Javascript.png" alt="Algorithm console JavaScript" class="screenshot">
 
 ## Managing Dependencies
 
-Now that you have created your algorithm, you can add dependencies.  The algorithm we are about to create does not have any dependencies other than `algorithmia` (which is added by default), but it is important to know how to do this - so for now we'll add `lodash` just as an example.  
+Now that you have created your algorithm, you can add dependencies.  The algorithm we are about to create does not have any dependencies other than `algorithmia` (which is added by default), but it is important to know how to do this - so for now we'll add `lodash` just as an example.
 
 Algorithmia supports adding 3rd party dependencies via the <a href="https://www.npmjs.com/" target="_blank">NPM Javascript package manager <i class="fa fa-external-link"></i></a>.  You don't need to create the package.json file manually.  Instead, on the algorithm editor page there is a button on the top right that says "Dependencies". Click that button and you'll see a modal window:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/dependencies_javascript.png" alt="JavaScript Dependency File" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/dependencies_javascript.png" alt="JavaScript Dependency File" class="screenshot img-md">
 
 Add dependencies by including the package name and version inside the `dependencies` section.  To add `lodash` version 4.17.4, edit that section as follows:
 
@@ -244,7 +244,7 @@ Once you've developed your algorithm, you can publish it and make it available f
 
 On the upper right hand side of the algorithm page you'll see a purple button "Publish" which will bring up a modal:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
 
 In this modal, you'll see a Changes tab, a Sample I/O tab, and one called Versioning.
 
@@ -256,7 +256,7 @@ Under the Versioning tab, you can select whether your algorithm will be for publ
 
 Check out [Algorithm Pricing]({{ site.baseurl }}/pricing/) for more information on how much algorithms will cost to run.
 
-Under Semantic Versioning you can choose which kind of release your change should fall under: Major, Minor, or Revision. 
+Under Semantic Versioning you can choose which kind of release your change should fall under: Major, Minor, or Revision.
 
 If you are satisfied with your algorithm and settings, go ahead and hit publish. Congratulations, you’re an algorithm developer!
 

--- a/_pages/algorithm-development/languages/python.md
+++ b/_pages/algorithm-development/languages/python.md
@@ -37,7 +37,7 @@ via the <a href="{{ site.baseurl }}/clients/python/">Algorithmia Python Client</
 
 ## Write your First Algorithm
 
-If you've followed the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice in your algorithm editor, there is boilerplate code that returns "Hello" and whatever you input to the console. 
+If you've followed the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice in your algorithm editor, there is boilerplate code that returns "Hello" and whatever you input to the console.
 
 The main thing to note about the algorithm is that it's wrapped in the apply() function.
 
@@ -46,7 +46,7 @@ The apply() function defines the input point of the algorithm. We use the apply(
 
 Go ahead and remove the boilerplate code below that's inside the apply() function because we'll be writing a different algorithm in this tutorial:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
 
 
 ## Managing Dependencies
@@ -55,7 +55,7 @@ Algorithmia supports adding 3rd party dependencies via the <a href="https://pypi
 
 On the algorithm editor page there is a button on the top right that says "Dependencies". Click that button and you'll see a modal window:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/dependencies_python.png" alt="Python Dependency File" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/dependencies_python.png" alt="Python Dependency File" class="screenshot img-md">
 
 If you have any dependencies you can add them by typing in the package name to the `requirements.txt` file.
 
@@ -84,7 +84,7 @@ Now let's get started on the hands-on portion of the guide:
 
 The first algorithm that we'll create will take a JSON formatted object passed as input by the user which is deserialized into a Python dictionary before the algorithm is called.
 
-It will output a JSON formatted object which the user will consume with an API call to the algorithm path. 
+It will output a JSON formatted object which the user will consume with an API call to the algorithm path.
 
 This path is based on your Algorithmia user name and the name of your algorithm, so if you are “AdaDeveloper” and your algorithm is “TokenizeText”, then the path for version 0.1.1 of your algorithm will be AdaDeveloper/TokenizeText/0.1.1
 
@@ -275,7 +275,7 @@ Go ahead and try the above code sample in the Algorithmia code editor and then t
 
 This returns a list of words:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/tokenize_url.png" alt="Run basic algorithm in console" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/tokenize_url.png" alt="Run basic algorithm in console" class="screenshot">
 
 As you can see from these examples, fields that are passed into your algorithm by the user such as scalar values and sequences such as lists, dictionaries, tuples and bytearrays (binary byte sequence such as an image file) can be handled as you would any Python data structure within your algorithm.
 
@@ -335,7 +335,7 @@ To learn how to publish your algorithm: <a href="{{ site.baseurl }}/algorithm-de
 #### Algorithms with multiple files
 Putting everything in one source file sometimes doesn't make sense and makes stuff hard to maintain, many times you'll want to break your code into multiple source files.
 
-Importing your secondary files contains some ceavats when 
+Importing your secondary files contains some ceavats when
 executing your algorithm on Algorithmia, in particular the import paths you use locally may vary from ours.
 
 This means that if your project looks like this:
@@ -350,7 +350,7 @@ This means that if your project looks like this:
       sub_module /
                   __init__.py
                   special_stuff.py
-      
+
 ```
 with main_file being your main python module, your import code might look something like this:
 ```python

--- a/_pages/algorithm-development/languages/r.md
+++ b/_pages/algorithm-development/languages/r.md
@@ -36,7 +36,7 @@ via the <a href="{{ site.baseurl }}/clients/r/">Algorithmia R language Client</a
 
 ## Write your First Algorithm
 
-If you've followed the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice in your algorithm editor, there is boilerplate code that returns "Hello" and whatever you input to the console. 
+If you've followed the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice in your algorithm editor, there is boilerplate code that returns "Hello" and whatever you input to the console.
 
 The main thing to note about the algorithm is that it's wrapped in the algorithm() function.
 
@@ -45,7 +45,7 @@ The algorithm() function defines the input point of the algorithm. We use the al
 
 Go ahead and remove the boilerplate code below that's inside the algorithm() function because we'll be writing a different algorithm in this tutorial:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_r.png" alt="Algorithm console R" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_r.png" alt="Algorithm console R" class="screenshot">
 
 ## Saving and Loading R Models
 When you have an R model that has been serialized as an .rds file, you can deploy it easily on Algorithmia. All you need to do is save your model:
@@ -69,16 +69,16 @@ Algorithmia supports adding 3rd party dependencies via the <a href="https://cran
 
 On the algorithm editor page there is a button on the top right that says "Dependencies". Click that button and you'll see a modal window:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/dependencies_r.png" alt="Set your dependencies" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/dependencies_r.png" alt="Set your dependencies" class="screenshot img-md">
 
-As you can see in the dependency file above, there are four different ways you can load packages in R. 
+As you can see in the dependency file above, there are four different ways you can load packages in R.
 If you want the latest version from CRAN, than you simply type in the dependency name (this example uses the package e1071):
 
 {% highlight bash %}
 e1071
 {% endhighlight %}
 
-If you wanted that same package in an older version, all you have to do is install from CRAN the exact version by finding it in the packages archive, which in this instance, should be listed in the <a href="https://cran.r-project.org/web/packages/e1071/index.html">e1071</a> docs found under “Old Sources”. There you’ll find the <a href="https://cran.r-project.org/src/contrib/Archive/e1071/">archived packages</a>, so simply choose your version and load your dependency: 
+If you wanted that same package in an older version, all you have to do is install from CRAN the exact version by finding it in the packages archive, which in this instance, should be listed in the <a href="https://cran.r-project.org/web/packages/e1071/index.html">e1071</a> docs found under “Old Sources”. There you’ll find the <a href="https://cran.r-project.org/src/contrib/Archive/e1071/">archived packages</a>, so simply choose your version and load your dependency:
 
 {% highlight bash %}
 https://cran.r-project.org/src/contrib/Archive/e1071/e1071_1.6-6.tar.gz
@@ -305,7 +305,7 @@ algorithm <- function(input){
 
 This should return a split up list of strings:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/tokenize_url.png" alt="Run basic algorithm in console" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/tokenize_url.png" alt="Run basic algorithm in console" class="screenshot">
 
 As you can see from these examples, fields that are passed into your algorithm by the user such as scalar values and sequences such as lists, dictionaries, tuples and bytearrays (binary byte sequence such as an image file) can be handled as you would any Python data structure within your algorithm.
 
@@ -353,7 +353,7 @@ Once you've developed your algorithm, you can publish it and make it available f
 
 On the upper right hand side of the algorithm page you'll see a purple button "Publish" which will bring up a modal:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
 
 In this modal, you'll see a Changes tab, a Sample I/O tab, and one called Versioning.
 
@@ -365,7 +365,7 @@ Under the Versioning tab, you can select whether your algorithm will be for publ
 
 Check out [Algorithm Pricing]({{ site.baseurl }}/pricing/) for more information on how much algorithms will cost to run.
 
-Under Semantic Versioning you can choose which kind of release your change should fall under: Major, Minor, or Revision. 
+Under Semantic Versioning you can choose which kind of release your change should fall under: Major, Minor, or Revision.
 
 If you are satisfied with your algorithm and settings, go ahead and hit publish. Congratulations, you’re an algorithm developer!
 

--- a/_pages/algorithm-development/languages/ruby.md
+++ b/_pages/algorithm-development/languages/ruby.md
@@ -35,7 +35,7 @@ Furthermore, algorithms can call other algorithms and manage data on the Algorit
 
 ## Write your First Algorithm
 
-If you've followed the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice in your algorithm editor, there is boilerplate code that returns "Hello" and whatever you input to the console. 
+If you've followed the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice in your algorithm editor, there is boilerplate code that returns "Hello" and whatever you input to the console.
 
 The main thing to note about the algorithm is that it's wrapped in the apply() function.
 
@@ -44,7 +44,7 @@ The apply() function defines the input point of the algorithm. We use the apply(
 
 Go ahead and remove the boilerplate code below that's inside the apply() function because we'll be writing a different algorithm in this tutorial:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_ruby.png" alt="Algorithm console Ruby" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_ruby.png" alt="Algorithm console Ruby" class="screenshot">
 
 ## Managing Dependencies
 
@@ -52,7 +52,7 @@ The algorithm we are about to create does not have any dependencies other than `
 
 Algorithmia supports adding 3rd partr.md#publish-algorithm <a href="https://rubygems.org/" target="_blank">Ruby Gems</a> using a Gemfile, but you don't need to create the Gemfile file manually.  Instead, on the algorithm editor page there is a button on the top right that says "Dependencies". Click that button and you'll see a modal window:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/dependencies_ruby.png" alt="Ruby Dependency File" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/dependencies_ruby.png" alt="Ruby Dependency File" class="screenshot img-md">
 
 Add dependencies by adding the package name to the `Gemfile`.  For example, to make use of phony, you would include the line
 
@@ -223,7 +223,7 @@ Once you've developed your algorithm, you can publish it and make it available f
 
 On the upper right hand side of the algorithm page you'll see a purple button "Publish" which will bring up a modal:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
 
 In this modal, you'll see a Changes tab, a Sample I/O tab, and one called Versioning.
 
@@ -235,7 +235,7 @@ Under the Versioning tab, you can select whether your algorithm will be for publ
 
 Check out [Algorithm Pricing]({{ site.baseurl }}/pricing/) for more information on how much algorithms will cost to run.
 
-Under Semantic Versioning you can choose which kind of release your change should fall under: Major, Minor, or Revision. 
+Under Semantic Versioning you can choose which kind of release your change should fall under: Major, Minor, or Revision.
 
 If you are satisfied with your algorithm and settings, go ahead and hit publish. Congratulations, you’re an algorithm developer!
 

--- a/_pages/algorithm-development/languages/rust.md
+++ b/_pages/algorithm-development/languages/rust.md
@@ -34,7 +34,7 @@ Furthermore, algorithms can call other algorithms and manage data on the Algorit
 
 ## Write your First Algorithm
 
-If you've followed the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice in your algorithm editor, there is boilerplate code that returns "Hello" and whatever you input to the console. 
+If you've followed the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice in your algorithm editor, there is boilerplate code that returns "Hello" and whatever you input to the console.
 
 The main thing to note about the algorithm is that it's wrapped in the apply() function.
 
@@ -43,13 +43,13 @@ The apply() function defines the input point of the algorithm. We use the apply(
 
 Go ahead and remove the boilerplate code below that's inside the apply() function because we'll be writing a different algorithm in this tutorial:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_rust.png" alt="Algorithm console Rust" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_rust.png" alt="Algorithm console Rust" class="screenshot">
 
 ## Managing Dependencies
 
 Algorithmia supports adding 3rd party dependencies via Cargo. Cargo dependencies typically come from <a href="https://crates.io/" target="_blank">Crates.io</a> (though it is also possible to specify dependencies from a git URL). If working locally, you can edit `Cargo.toml` and run `cargo install` to update your lockfile. Alternatively, from the web IDE, there is a button on the top right that says "Dependencies". Click that button and you'll see a modal window:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/dependencies_rust.png" alt="Rust Dependency File" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/dependencies_rust.png" alt="Rust Dependency File" class="screenshot img-md">
 
 Add dependencies at the end of the file, under the `[dependencies]` section (for details on versioning and on git-based dependencies, see the <a href="http://doc.crates.io/specifying-dependencies.html" target="_blank">cargo documentation</a>).  Then click "Save dependencies" to close the modal window.
 
@@ -241,7 +241,7 @@ Once you've developed your algorithm, you can publish it and make it available f
 
 On the upper right hand side of the algorithm page you'll see a purple button "Publish" which will bring up a modal:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
 
 In this modal, you'll see a Changes tab, a Sample I/O tab, and one called Versioning.
 
@@ -253,7 +253,7 @@ Under the Versioning tab, you can select whether your algorithm will be for publ
 
 Check out [Algorithm Pricing]({{ site.baseurl }}/pricing/) for more information on how much algorithms will cost to run.
 
-Under Semantic Versioning you can choose which kind of release your change should fall under: Major, Minor, or Revision. 
+Under Semantic Versioning you can choose which kind of release your change should fall under: Major, Minor, or Revision.
 
 If you are satisfied with your algorithm and settings, go ahead and hit publish. Congratulations, you’re an algorithm developer!
 

--- a/_pages/basics/algorithm-profiles.md
+++ b/_pages/basics/algorithm-profiles.md
@@ -16,7 +16,7 @@ Each algorithm is showcased on the marketplace through the profile page. Below, 
 
 The profile overview provides a rich source of information about the algorithm. In the overview, you can find the name of the algorithm, the tagline, and quickly see the version, royalty and permissions. Additionally, you'll also see the number of stars and followers an algorithm as, as well as the number of times the algorithm has been called.
 
-![Algorithm Profile header]({{ site.baseurl }}/images/post_images/algorithm_profiles/header.png)
+![Algorithm Profile header]({{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algorithm_profiles/header.png)
 
 The tagline lives underneath the title of the algorithm and is a succinct way to let you quickly understand what it does. This tagline also appears under the title of the algorithm in marketplace search results for quick reference. In the case of Nudity Detection, you can see that the author has provided the tagline "Detect nudity in pictures" so you know exactly what to expect!
 
@@ -30,11 +30,11 @@ Finally, the last section of the algorithm header is the Permissions section. He
 
 The algorithm README documentation is easily available on the algorithm profile page by clicking the "Docs" tab. The Docs is where the algorithm developer writes an explanation of what the algorithm does, what kind of input you need to use, and what kind of output you can expect from the algorithm. Many algorithms also use this space to link to papers or other sites that more fully explain the technical implementation of the algorithm.
 
-![Algorithm Profile docs]({{ site.baseurl }}/images/post_images/algorithm_profiles/description.png)
+![Algorithm Profile docs]({{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algorithm_profiles/description.png)
 
 By using the next tab on the profile page, "Cost", you can see see the pricing and permissions information for the algorithm.
 
-![Algorithm Profile pricing]({{ site.baseurl }}/images/post_images/algorithm_profiles/pricing.png)
+![Algorithm Profile pricing]({{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algorithm_profiles/pricing.png)
 
 The Cost tab, shown above, is an interactive section of the profile where you can estimate the cost of the algorithm. It uses the average duration of calls across the system and the number of API calls to calculate the estimated cost in credits.
 
@@ -45,14 +45,14 @@ The estimate is based off the average duration of API calls. Your call duration 
 
 Trying out each algorithm is incredibly easy and can be done using the console included on every algorithm profile.  The console appears below the header and allows you to quickly experiment with the algorithm. You will see two large black boxes side-by-side labeled "Type you input" and "See the result". If the algorithm developer has provided sample input, you will see it in left-hand box. Simply click the purple "Run" button to have the algorithm run on the sample input and you will see results in the output box on the right!
 
-![Algorithm Profile console]({{ site.baseurl }}/images/post_images/algorithm_profiles/console.png)
+![Algorithm Profile console]({{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algorithm_profiles/console.png)
 
 
 #### Source Availability
 
 If the algorithm developer has published under an Open Source license, you will see an additional tab in the algorithm profile header that says "Source" that takes you directly to the source code.
 
-![Algorithm Profile View Source Code tab]({{ site.baseurl }}/images/post_images/algorithm_profiles/viewsource.png)
+![Algorithm Profile View Source Code tab]({{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algorithm_profiles/viewsource.png)
 
 
  Click this button to see the algorithm code!

--- a/_pages/basics/customizing-api-keys.md
+++ b/_pages/basics/customizing-api-keys.md
@@ -17,11 +17,11 @@ To call algorithms and interact with the Data API, you'll use an API key to auth
 
 To view your API keys, head on over to your profile on Algorithmia and click on the "My API Keys" option in the menu. For more information about your profile, be sure to check out the [Your Profile guide]({{ site.baseurl }}/basics/your-profile/) for more information.
 
-<img src="{{ site.baseurl }}/images/post_images/api_keys/my_api_keys_from_profile.png" alt="My API Keys from Profile Menu" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/api_keys/my_api_keys_from_profile.png" alt="My API Keys from Profile Menu" class="screenshot img-sm">
 
 When you sign up for Algorithmia, your account is created with a default API key. Conveniently, it is named `default-key`! This key will show up in the code snippets on an algorithm profile page when you are signed in, allowing you to easily make calls to the algorithm either through the web console or by copying the code directly to include in your program.
 
-<img src="{{ site.baseurl }}/images/post_images/api_keys/default-key.png" alt="API keys home" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/api_keys/default-key.png" alt="API keys home" class="screenshot img-sm">
 
 If you delete your `default-key`, it will no longer show up in the code snippets on the algorithm profile pages. Simply create a new key and name it `default-key` to have it appear again!
 {: .notice-info }
@@ -30,7 +30,7 @@ If you delete your `default-key`, it will no longer show up in the code snippets
 
 Let's walk through the process of adding an additional API key to your account. Click the purple "New simple key" button below the list of active keys. You'll be prompted with a dialog that allows you to name your new key and set the permissions on it:
 
-<img src="{{ site.baseurl }}/images/post_images/api_keys/new-simple-key.png" alt="API keys dialog" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/api_keys/new-simple-key.png" alt="API keys dialog" class="screenshot img-sm">
 
 ## Access options
 
@@ -44,12 +44,12 @@ One way you can restrict access with an API key is to only white list the algori
 
 You can do this by adding the shorthand name for the algorithms you want the API key to access like so:
 
-<img src="{{ site.baseurl }}/images/post_images/api_keys/algo_restrictions.png" alt="caller origin" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/api_keys/algo_restrictions.png" alt="caller origin" class="screenshot img-sm">
 
 Note that `algo://` is the prefix you'll need to use before the owner name and algorithm name. Let's say that I have a project that has its own API key that I want to restrict to only call the algorithms I specify. I'll name my key after the project, then add the algorithms it can call. If I want to use [SiteMap](https://algorithmia.com/algorithms/web/SiteMap), I'll format the alias like this: `algo://` + the algorithm owner + the algorithm name. Thus Generate Paragraph from Trigram would end ups as `algo://web/SiteMap` (where in this case the username is web).
 
 
-<img src="{{ site.baseurl }}/images/post_images/api_keys/algo_restrictions_no_star.png" alt="caller origin" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/api_keys/algo_restrictions_no_star.png" alt="caller origin" class="screenshot img-sm">
 
 By default, any key can call any algorithm on the platform. You can see in the above screenshot that under the Algorithm Access section, there is an entry `algo://*`, which is highlighted. This is a wildcard that matches all of the algorithms. To make sure your key is restricted to calling only the algorithms you've specified above, be sure to remove this wildcard entry by clicking on the trashcan icon.
 
@@ -57,11 +57,11 @@ By default, any key can call any algorithm on the platform. You can see in the a
 
 Another way to customize your API keys and the permissions is to restrict the permissions on where API calls can originate. There are two options you can check in the dialog, native clients and web browser:
 
-<img src="{{ site.baseurl }}/images/post_images/api_keys/call_origin.png" alt="caller origin" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/api_keys/call_origin.png" alt="caller origin" class="screenshot img-sm">
 
 If you are only calling Algorithmia through a client, you can leave that box checked and your key will work as you make API calls. However, if you plan to use this key on a website where you will be making CORS requests, select the web browser permission. When you check that box, another field will appear allowing for more customization:
 
-<img src="{{ site.baseurl }}/images/post_images/api_keys/call_origin_web.png" alt="caller origin web host" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/api_keys/call_origin_web.png" alt="caller origin web host" class="screenshot img-sm">
 
 As you can see, when you allow cross-origin requests to use your authentication, you can restrict the access by referrer hostname. This is a security measure that allows you to say that the API key can only be used when the request is coming from your website.
 
@@ -69,11 +69,11 @@ As you can see, when you allow cross-origin requests to use your authentication,
 
 The third method to customize your API key access is to change its permissions relating to the Data API. By default, when you create a new API key data access is set to none.
 
-<img src="{{ site.baseurl }}/images/post_images/api_keys/data_none.png" alt="data default" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/api_keys/data_none.png" alt="data default" class="screenshot img-sm">
 
 You have two options to change the Data API access: you can either let your API key have permission to read only or to allow read and write access.
 
-<img src="{{ site.baseurl }}/images/post_images/api_keys/data_all.png" alt="data all" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/api_keys/data_all.png" alt="data all" class="screenshot img-sm">
 
 By selecting read only, you've set up your API key permissions to let it access data in through the API but not write to your data. This is good if you have an application that needs to be able to read a trained model or data file that you've stored in order to run the algorithm but won't be saving any data from the API call.
 

--- a/_pages/basics/your-profile.md
+++ b/_pages/basics/your-profile.md
@@ -18,11 +18,11 @@ This guide will usher you through your user profile and cover how to find your A
 
 To access your profile, simple click on the user drop down next to the notifications icon in the top right of the navigation bar:
 
-![Accessing the user drop down]({{ site.baseurl }}/images/post_images/your_profile/user_drop_down.png)
+![Accessing the user drop down]({{ site.cdnurl }}{{ site.baseurl }}/images/post_images/your_profile/user_drop_down.png)
 
 Once inside the profile section, you'll find a horizontal menu of profile sections such as Credentials, Earnings, Account, and Payment Info. We'll go over each section to understand your profile below, but first let's start with the main profile page:
 
-![profile main]({{ site.baseurl }}/images/post_images/your_profile/profile.png)
+![profile main]({{ site.cdnurl }}{{ site.baseurl }}/images/post_images/your_profile/profile.png)
 
 The main area of your profile also includes some basis stats like the number of API calls you have made and the number of times your algorithms have been called. Additionally, you can find quick links to the algorithms you've published.
 
@@ -30,7 +30,7 @@ The main area of your profile also includes some basis stats like the number of 
 
 The credentials section of your profile is where you can find and manage your API keys. Below, you'll see that your profile comes with a pre-populated API key that was created when you signed up. This key, will be labeled "default-key", and will show up in the algorithm console when trying out algorithms in the browser.
 
-![Credentials]({{ site.baseurl }}/images/post_images/your_profile/credentials.png)
+![Credentials]({{ site.cdnurl }}{{ site.baseurl }}/images/post_images/your_profile/credentials.png)
 
 Click the pencil icon to edit the permissions and update the key. You can also create and delete new API keys if you are looking for more modular API key permissions. Follow this [Customizing API Keys & Access guide]({{ site.baseurl }}/basics/customizing-api-keys/) to learn more.
 
@@ -38,7 +38,7 @@ Click the pencil icon to edit the permissions and update the key. You can also c
 
 The account section of your profile is where you'll find the information about your account usage and your credits.
 
-![Credits main]({{ site.baseurl }}/images/post_images/your_profile/credits_main.png)
+![Credits main]({{ site.cdnurl }}{{ site.baseurl }}/images/post_images/your_profile/credits_main.png)
 
 The graph on the left shows your account balance history over the last 30 day period. On the right, you'll more details about your account, such as the number of free credits remaining in this 30 day cycle as well as the total number of credits available, including your purchased credits. You can also purchase more credits through this page by clicking on the purple button.
 
@@ -47,7 +47,7 @@ If you have earned credits by publishing your own algorithms, you'll see the amo
 Below the account overview, you'll see menu options to view your Usage, Earnings, and Transactions.
 
 ### Usage
-![Usage]({{ site.baseurl }}/images/post_images/your_profile/usage.png)
+![Usage]({{ site.cdnurl }}{{ site.baseurl }}/images/post_images/your_profile/usage.png)
 
 The usage section displays the date, the algorithms you've called, and the stats on your usage.
 
@@ -62,7 +62,7 @@ For more information about pricing check out [Pricing]({{ site.baseurl }}/pricin
 
 The next section, Earnings, is where you will find the records of the calls made to your algorithms:
 
-![earnings]({{ site.baseurl }}/images/post_images/your_profile/earning.png)
+![earnings]({{ site.cdnurl }}{{ site.baseurl }}/images/post_images/your_profile/earning.png)
 
 In this section, you'll see the algorithm listed by date as well as the version number for the algorithm. This is important if you are updating your algorithms and notice that people are still calling old versions. Knowing which versions of your algorithms that people are using will help you understand what backwards-compatibility you need as well as which versions are improvements for the algorithm callers.
 
@@ -72,7 +72,7 @@ In the case of earnings, you will only see the number of billable calls and thei
 
 Find the history of your credits in the transactions section.
 
-![Transactions]({{ site.baseurl }}/images/post_images/your_profile/transactions.png)
+![Transactions]({{ site.cdnurl }}{{ site.baseurl }}/images/post_images/your_profile/transactions.png)
 
 Here you'll see any purchases you've made for more credits as well as any credits that have been granted to your account.
 

--- a/_pages/clients.md
+++ b/_pages/clients.md
@@ -14,8 +14,8 @@ author: steph_kim
   <div class="col-md-12">
     <h3>Get Started</h3>
     <div class="dev-card">
-      <img src="{{ site.baseurl }}/images/get_started.png" alt="Get Started" class="img-fill get-started-img">
-      <img src="{{ site.baseurl }}/images/icons/hexicon_desktop.svg" alt="icon" class="hexicon">
+      <img src="{{ site.cdnurl }}{{ site.baseurl }}/images/get_started.png" alt="Get Started" class="img-fill get-started-img">
+      <img src="{{ site.cdnurl }}{{ site.baseurl }}/images/icons/hexicon_desktop.svg" alt="icon" class="hexicon">
       <div class="dev-card-text">
         <p class="lead">Get up to speed with the Algorithmia marketplace</p>
         <a href="{{ site.baseurl }}/getting-started" class="btn btn-default btn-accent">Get Started Now</a>
@@ -28,7 +28,7 @@ After you learn how to call algorithms, check out our <a href="{{ site.baseurl }
 
 For how to chain algorithms together to build useful pipelines or call our API from Android, iOS, or R Shiny check out our <a href="{{ site.baseurl }}/tutorials/">Tutorials</a>.
 
-And if you're looking to call the API in Spark Streaming, H2O, and more check out 
+And if you're looking to call the API in Spark Streaming, H2O, and more check out
 <a href="{{ site.baseurl }}/integrations">Integrations</a>.
 
 Also, after checking out the Getting Started Guide above, go through a more thorough tutorial in your preferred language. The guides below will take you step-by-step showing you how to work with data, call algorithms and get the response:

--- a/_pages/data.md
+++ b/_pages/data.md
@@ -26,7 +26,7 @@ If you have any questions about Algorithmia please <a href="mailto:support@algor
       <div class="col-xs-4 col-sm-4 col-md-3">
         <a  href="{{ post.url | relative_url }}" class="lang-tile">
           {% if post.image.teaser %}
-            <img  src="{{ post.image.teaser | prepend:'/images' | relative_url }}" alt="" itemprop="image" class="lang-icon">
+            <img  src="{{ site.cdnurl }}{{ post.image.teaser | prepend:'/images' | relative_url }}" alt="" itemprop="image" class="lang-icon">
           {% endif %}
           {{ post.title }}
         </a>

--- a/_pages/data/dropbox.md
+++ b/_pages/data/dropbox.md
@@ -19,25 +19,25 @@ All data sources have a protocol and a label that you will use to reference your
 ## Create a New Data Connection to Dropbox
 To create a new data connection first navigate to <a href="{{ site.baseurl }}/data">Algorithmia's Data Portal</a> where you'll notice there is a panel that says 'Add New Data Source':
 
-<img src="{{ site.baseurl }}/images/post_images/data_connectors/data_portal.png" alt="Data Portal" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/data_connectors/data_portal.png" alt="Data Portal" class="screenshot img-md">
 
 On that panel click the button that says **"Add Data Source"** which will bring up a panel that lets you chose between configuring a new data source for AWS S3 or Dropbox:
 
-<img src="{{ site.baseurl }}/images/post_images/data_connectors/create_data_connector.png" alt="Create a data connector" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/data_connectors/create_data_connector.png" alt="Create a data connector" class="screenshot img-md">
 
 Select **'Connect to Dropbox'** and you will be prompted to login to your Dropbox account. You'll be asked if you want to grant Algorithmia access to your account via OAuth authentication. Once that's done a new panel will be created which will have the Dropbox icon on it and a unique label for that Dropbox connection.
 
 ## Configure a Data Source
 Set path restrictions and manage the read and write permissions by clicking the button **"Manage Dropbox"** on the middle panel holding the unique data connector that was just created.
 
-<img src="{{ site.baseurl }}/images/post_images/data_connectors/manage_connector_all.png" alt="Manage a data connector" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/data_connectors/manage_connector_all.png" alt="Manage a data connector" class="screenshot img-md">
 
 **NOTE:** the unique label on your new Dropbox connection follows the protocol: 'dropbox+unique_connection_name://*' that defaults to allowing everything to be accessible in your Dropbox path.
 
 ### Update Labels For Data Connections
 If you would like to change the unique label that was automatically provided when you created the data connection, simply update it under **'Label'** and give it a unique name:
 
-<img src="{{ site.baseurl }}/images/post_images/data_connectors/dropbox_manage_connector_change_label.png" alt="Change a data connector's label" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/data_connectors/dropbox_manage_connector_change_label.png" alt="Change a data connector's label" class="screenshot img-sm">
 
 **Note** We create these unique labels because you may want to add multiple connections to the same Dropbox account and they will each need a unique label for later reference in your algorithm. The reason you might want to have multiple connections to the same source is so you can set different access permissions to each connection such as read from one file and write to a different folder.
 
@@ -49,7 +49,7 @@ The default path restrictions are set to allow access to all paths in your Dropb
 
 Here we are setting our path restrictions to everything in the Dropbox folder 'Algorithmia':
 
-<img src="{{ site.baseurl }}/images/post_images/data_connectors/dropbox_path_restrictions.png" alt="Change a data connector's label" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/data_connectors/dropbox_path_restrictions.png" alt="Change a data connector's label" class="screenshot img-sm">
 
 **NOTE:** 'Algorithmia*' might match more than you’d like, so if you want to match a directory exactly end with a '/'.
 
@@ -58,14 +58,14 @@ The default access for your data source is set to read only, but you can change 
 
 **NOTE:** Write access also means you can ***delete*** anything in the path you've specified in the previous step so be careful that you want read-write-delete access to the path you set in 'Path Restriction'. Also, if your data source has Read/Write privileges, then an algorithm that you call also has Read/Write privileges to your data source.
 
-<img src="{{ site.baseurl }}/images/post_images/data_connectors/dropbox_manage_connector_access.png" alt="Manage a data connector" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/data_connectors/dropbox_manage_connector_access.png" alt="Manage a data connector" class="screenshot img-sm">
 
 ### Setting your Default Dropbox
 The benefit to setting a data connection as your default Dropbox data source is when you choose **'Make Default'** you can access this data source by a shortened path: 'dropbox://' rather than: 'dropbox+your_unique_label://'.
 
 In the example below, 'archimedes' is the default Dropbox data source's unique label, the path restriction is set as 'Algorithmia/\*' to access all files in the 'Algorithmia' folder and it can be accessed via the path: 'dropbox://Algorithmia/\*'.
 
-<img src="{{ site.baseurl }}/images/post_images/data_connectors/dropbox_manage_connector_modal.png" alt="Manage a data connector" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/data_connectors/dropbox_manage_connector_modal.png" alt="Manage a data connector" class="screenshot img-sm">
 
 ## Accessing your Data
 Accessing your Dropbox data via the <a href="http://docs.algorithmia.com/#data-api-specification">Algorithmia Data API</a> is easy. Whether you're writing your application in Rust, Ruby, Python, Scala, Java or JavaScript simply import your data with a couple lines of code. With your Dropbox data connection now configured you can read and write data to and from it via <a href="http://docs.algorithmia.com/#data-api-specification">Algorithmia's Data API</a> by specifying the protocol and label as your path to your data:

--- a/_pages/data/hosted.md
+++ b/_pages/data/hosted.md
@@ -26,11 +26,11 @@ This guide will show how to create a collection and walk you through the differe
 
 To create a new data collection first navigate to <a href="{{ site.baseurl }}/data" target="_blank">Algorithmia's Data Portal</a>. On the panel that says "Algorithmia Hosted Data" click the button that says **"Browse Files"** which takes you to <a href="{{ site.baseurl }}/data/hosted">Data Collections</a>.
 
-<img src="{{ site.baseurl }}/images/post_images/data_connectors/manage_connector_all.png" alt="Create a data connector" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/data_connectors/manage_connector_all.png" alt="Create a data connector" class="screenshot img-md">
 
 Then you will find yourself in the collections panel where you can click on **"Add Collection"** under the 'My Collections' section on your data collections page:
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/add_collections_visual.png" alt="Create a data collection" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/add_collections_visual.png" alt="Create a data collection" class="screenshot img-md">
 
 Notice that when you create a collection you can set the read and write access by using the drop downs shown in the above screenshot. Below are the details regarding access permissions for user collections and what they mean.
 

--- a/_pages/data/s3.md
+++ b/_pages/data/s3.md
@@ -19,15 +19,15 @@ All data sources have a protocol and a label that you will use to reference your
 ## Configure a New Data Connection to S3
 To create a new data connection first navigate to <a href="{{ site.baseurl }}/data">Algorithmia's Data Portal</a> where you'll notice there is a panel that says 'Add New Data Source':
 
-<img src="{{ site.baseurl }}/images/post_images/data_connectors/data_portal.png" alt="Data Portal" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/data_connectors/data_portal.png" alt="Data Portal" class="screenshot img-md">
 
 On that panel click the button that says **"Add Data Source"** which will bring up a panel that lets you chose between configuring a new data source for AWS S3 or Dropbox:
 
-<img src="{{ site.baseurl }}/images/post_images/data_connectors/create_data_connector.png" alt="Create a data connector" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/data_connectors/create_data_connector.png" alt="Create a data connector" class="screenshot img-md">
 
 Select **'Connect to Amazon S3'** and a modal window will open to configure an S3 connection. Here you will need to enter your AWS credentials. S3 authorization is done by adding your AWS Access Key ID and AWS Secret Access Key, which can me managed in [IAM](https://console.aws.amazon.com/iam/home). AWS supports setting restrictions on access tokens by service and operation.
 
-<img src="{{ site.baseurl }}/images/post_images/data_connectors/s3_create_data_connector.png" alt="Create a data connector in modal" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/data_connectors/s3_create_data_connector.png" alt="Create a data connector in modal" class="screenshot img-sm">
 
 **NOTE:** While an algorithm NEVER sees credentials used to access data in S3, it is recommended that you provide an access key that:
 
@@ -39,7 +39,7 @@ If you would like to change the unique label that was automatically provided whe
 
 We create these unique labels because you may want to add multiple connections to the same S3 account and they will each need a unique label for later reference in your algorithm. The reason you might want to have multiple connections to the same source is so you can set different access permissions to each connection such as read from one file and write to a different folder.
 
-<img src="{{ site.baseurl }}/images/post_images/data_connectors/s3_manage_connector_change_label.png" alt="Change a data connector's label" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/data_connectors/s3_manage_connector_change_label.png" alt="Change a data connector's label" class="screenshot img-sm">
 
 **NOTE:** The unique label follows the protocol: '+unique_label://restricted_path'
 
@@ -53,14 +53,14 @@ The default path restrictions are set to allow access to all paths in your S3 ac
 
 Here we are setting our path restrictions to everything in the S3 bucket 'Algorithmia':
 
-<img src="{{ site.baseurl }}/images/post_images/data_connectors/s3_restricted_paths.png" alt="Add path restrictions" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/data_connectors/s3_restricted_paths.png" alt="Add path restrictions" class="screenshot img-sm">
 
 ### Setting Read and Write Access
 The default access for your data source is set to read only, but you can change this to read *and* write access by checking the **'Write Access'** box.
 
 **NOTE:** Write access also means you can ***delete*** anything in the path you've specified in the previous step so be careful that you want read-write-delete access to the path you set in 'Path Restriction'. Also, if your data source has Read/Write privileges, then an algorithm that you call also has Read/Write privileges to your data source.
 
-<img src="{{ site.baseurl }}/images/post_images/data_connectors/s3_write_access.png" alt="Manage a data connector" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/data_connectors/s3_write_access.png" alt="Manage a data connector" class="screenshot img-sm">
 
 ## Accessing your Data
 Accessing your S3 data via the <a href="http://docs.algorithmia.com/#data-api-specification">Algorithmia Data API</a> is easy. Whether you're writing your algorithm in Rust, Ruby, Python, Scala, Java or JavaScript simply import your data with a couple lines of code. With your S3 data connection now configured you can read and write data to and from it via <a href="http://docs.algorithmia.com/#data-api-specification">Algorithmia's Data API</a> by specifying the protocol and label as your path to your data:

--- a/_pages/faqs/can-i-use-external-libraries.md
+++ b/_pages/faqs/can-i-use-external-libraries.md
@@ -3,7 +3,7 @@ layout: faq
 title:  "Can I use external libraries with my algorithms?"
 categories: faqs
 tags: [algo-dev-faq]
-show_related: true 
+show_related: true
 image:
   teaser: /icons/fa-bolt.png
 ---
@@ -12,11 +12,11 @@ Of course! Dependencies are added to the algorithm through the Dependencies dial
 
 In the action bar at the top of the editor, you will see the gray button labeled “Dependencies” in between the Summary button and the Save button:
 
-<img src="{{ site.baseurl }}/images/post_images/faqs/faq_dependencies.png" alt="Dependencies Button" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/faqs/faq_dependencies.png" alt="Dependencies Button" class="screenshot img-md">
 
 When you click the Dependencies button, you will see a pop-up dialog that allows you to list any external libraries that you want to import into your algorithm. This allows you to customize your algorithm as you see fit and ensures that every time the algorithm is called, all necessary libraries will be included:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/dependencies_python.png" alt="Python Dependency File" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/dependencies_python.png" alt="Python Dependency File" class="screenshot img-md">
 
 Use this dialog the same way you would specific the dependencies of any other project of the same language. For example, you would format your dependencies for a Python algorithm in the same manner as you would in a `requirements.txt` file.
 

--- a/_pages/getting-started.md
+++ b/_pages/getting-started.md
@@ -17,7 +17,7 @@ We'll show an example in cURL, Python, Java, Rust, R, Node, Ruby, JavaScript, Sc
 
 To get started, find an algorithm you'd like to call. You can do this by using the search bar or browsing the marketplace by tags & categories:
 
-<img src="{{ site.baseurl }}/images/face_detection.jpg" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/face_detection.jpg" class="screenshot img-sm">
 
 Each algorithm has an owner and an algorithm name; you'll need both to format your request. This information is listed under the algorithm name on the description page as well as in the format of the algorithm's URL.
 
@@ -399,7 +399,7 @@ Each algorithm returns a response in JSON. It will include the `"result"` as wel
   <div class="tab-pane code__pane gs-pane" ng-cloak>
   <pre class="getting-started-code"><code class="demo-code-sample hljs bash">curl -X POST <span class="hljs-_">-d</span> <span class="hljs-string">'"<span class="hover-info">YOUR_USERNAME<div class="hover-content card pa-16" ng-bind-html="cardContent"></div></span>"'</span> -H <span class="hljs-string">'Content-Type: application/json'</span> -H <span class="hljs-string">'Authorization: Simple <span class="hover-info">YOUR_API_KEY<div class="hover-content card pa-16" ng-bind-html="cardContent"></div></span>'</span> https://api.algorithmia.com/v1/algo/demo/Hello/
 
-{ 
+{
   <span class="hljs-string">"result"</span>: <span class="hljs-string">"Hello <span class="hover-info">YOUR_USERNAME<div class="hover-content card pa-16" ng-bind-html="cardContent"></div></span>"</span>,
   <span class="hljs-string">"metadata"</span>: {
      <span class="hljs-string">"content_type"</span>: <span class="hljs-string">"text"</span>,
@@ -409,7 +409,7 @@ Each algorithm returns a response in JSON. It will include the `"result"` as wel
 
   <textarea id="result-copy-text" class="copy-text curl">curl -X POST -d '"YOUR_USERNAME"' -H 'Content-Type: application/json' -H 'Authorization: Simple YOUR_API_KEY' https://api.algorithmia.com/v1/algo/demo/Hello/
 
-{ 
+{
   "result": "Hello YOUR_USERNAME",
   "metadata": {
      "content_type": "text",

--- a/_pages/model-deployment/caffe.md
+++ b/_pages/model-deployment/caffe.md
@@ -37,7 +37,7 @@ You'll want to do the training and saving of your model on your local machine, o
 After training your Caffe model, you'll want to save the model and weights so you can upload it to Algorithmia.
 
 ### Create a Data Collection
-Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>. 
+Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>.
 
 In this guide we'll use Algorithmia's <a href="{{ site.baseurl }}/data/hosted/">Hosted Data Collection</a>, but you can host it in <a href="{{ site.baseurl }}/data/s3/">S3</a> or <a href="{{ site.baseurl }}/data/dropbox/">Dropbox</a> as well. Alternatively, if your data lies in a database, <a href="https://algorithmia.com/developers/data/dynamodb/">check out</a> how we connected to a DynamoDB database.
 
@@ -49,7 +49,7 @@ First, you'll want to create a data collection to host your pre-trained model.
 
 - After you create your collection you can set the read and write access on your data collection.
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
 
 For more information check out: <a href="{{ site.baseurl }}/data/hosted/">Data Collection Types</a>.
 
@@ -64,12 +64,12 @@ Next, upload your model files to your newly created data collection.
     - data://username/collections_name/file_name.prototxt.txt,
     - data://username/collections_name/file_name.caffemodel
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/caffe_update_collections.png" alt="Create a data collection" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/caffe_update_collections.png" alt="Create a data collection" class="screenshot img-md">
 
 ## Create your Algorithm
 Hopefully you've already followed along with the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a> for algorithm development. If not, you might want to check it out in order to understand the various permission types, how to enable a GPU environment, and use the CLI.
 
-Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console. 
+Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console.
 
 The main thing to note about the algorithm is that it's wrapped in the `apply()` function.
 
@@ -77,7 +77,7 @@ The apply() function defines the input point of the algorithm. We use the apply(
 
 Go ahead and remove the boilerplate code below that's inside the `apply()` function on line 6, but leave the `apply()` function intact:
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/deep_learning_algorithm_console.png" alt="Algorithm console Python" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/deep_learning_algorithm_console.png" alt="Algorithm console Python" class="screenshot">
 
 ### Set your Dependencies
 Now is the time to set your dependencies that your model relies on.
@@ -88,7 +88,7 @@ Here are some Caffe wheels for different versions as well as CPU and GPU wheels:
 -   **Caffe 0.1 (GPU)**: https://s3.amazonaws.com/algorithmia-wheels/caffe-0.1.0_gpu-py2-none-any.whl
 -   **Caffe 1.05 (CPU)**: https://s3.amazonaws.com/algorithmia-wheels/caffe-01.05.16_b86b0aea60a_cpu-py2-none-any.whl
 -   **Caffe 1.05 (CGU)**: https://s3.amazonaws.com/algorithmia-wheels/caffe-01.05.16_b86b0aea60a_gpu-py2-none-any.whl
--   **Caffe build tag 99466 (GPU)**: https://s3.amazonaws.com/algorithmia-wheels/caffe-27.11.17_99466_gpu-py2-none-any.whl 
+-   **Caffe build tag 99466 (GPU)**: https://s3.amazonaws.com/algorithmia-wheels/caffe-27.11.17_99466_gpu-py2-none-any.whl
 
 
 Click on the **"Dependencies"** button at the top right of the UI and list your packages under the required ones already listed and click **"Save Dependencies"** on the bottom right corner.
@@ -96,14 +96,14 @@ Click on the **"Dependencies"** button at the top right of the UI and list your 
 Please note that you will need to use the **protobuf==3.0.0b2.post1** package to be able to run a caffe algorithm.
 {: .notice-warning}
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/caffe_dependencies.png" alt="Set your dependencies" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/caffe_dependencies.png" alt="Set your dependencies" class="screenshot img-md">
 
 ## Load your Model
 Here is where you load and run your model which will be called by the apply() function.
 
 When you load your model, our recommendation is to preload your model in a separate function external to the apply() function.
 
-This is because when a model is first loaded it can take time to load depending on the file size. 
+This is because when a model is first loaded it can take time to load depending on the file size.
 
 Then, with all subsequent calls only the apply() function gets called which will be much faster since your model is already loaded.
 
@@ -171,7 +171,7 @@ Last is publishing your algorithm. The best part of hosting your model on Algori
 
 On the upper right hand side of the algorithm page you'll see a purple button "Publish" which will bring up a modal:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
 
 In this modal, you'll see a Changes tab, a Sample I/O tab, and one called Versioning.
 

--- a/_pages/model-deployment/cntk.md
+++ b/_pages/model-deployment/cntk.md
@@ -36,7 +36,7 @@ Here you'll want to create a data collection to host your model.
 
 - After you create your collection you can set the read and write access on your data collection. For more information check out: <a href="{{ site.baseurl }}/data/hosted/">Data Collection Types</a>
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
 
 ### Upload your Model into a Collection
 
@@ -46,7 +46,7 @@ After your collection is created, you're going to want to upload your saved grap
 
 - Note the path to your files: `data://username/collections_name/cntk.model`
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
 
 ## Create your Algorithm
 
@@ -59,7 +59,7 @@ Creating your algorithm is easy!
 
 **Note**: Make sure that your version of python is the same between your development environment and the algorithm. There may be version conflicts otherwise.
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/create_new_alg_dl_python3.png" alt="Create your algorithm" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/create_new_alg_dl_python3.png" alt="Create your algorithm" class="screenshot img-sm">
 
 
 ### set your dependencies
@@ -68,7 +68,7 @@ Now is the time to set the depenencies your model relies on.
 
 - Click on the **"Dependencies"** button at the top right of the UI and list your packages under the required ones already listed and click **"Save Dependencies"** on the bottom right corner.
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/cntk_dependencies.png" alt="Set your dependencies" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/cntk_dependencies.png" alt="Set your dependencies" class="screenshot img-md">
 
 
 ### Load your Model
@@ -174,7 +174,7 @@ Last is publishing your algorithm. The best part of hosting your model on Algori
 
 On the upper right hand side of the algorithm page you'll see a purple button "Publish" which will bring up a modal:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
 
 In this modal, you'll see a Changes tab, a Sample I/O tab, and one called Versioning.
 

--- a/_pages/model-deployment/keras.md
+++ b/_pages/model-deployment/keras.md
@@ -42,7 +42,7 @@ Note that when developing a model with Keras, they recommend you to [save the mo
 {: .notice-info}
 
 ### Create a Data Collection
-Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>. 
+Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>.
 
 In this guide we'll use Algorithmia's <a href="{{ site.baseurl }}/data/hosted/">Hosted Data Collection</a>, but you can host it in <a href="{{ site.baseurl }}/data/s3/">S3</a> or <a href="{{ site.baseurl }}/data/dropbox/">Dropbox</a> as well. Alternatively, if your data lies in a database, <a href="https://algorithmia.com/developers/data/dynamodb/">check out</a> how we connected to a DynamoDB database.
 
@@ -54,7 +54,7 @@ First, you'll want to create a data collection to host your pre-trained model.
 
 - After you create your collection you can set the read and write access on your data collection.
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
 
 For more information check out: <a href="{{ site.baseurl }}/data/hosted/">Data Collection Types</a>.
 
@@ -67,13 +67,13 @@ Next, upload your saved model to your newly created data collection.
 
 - Note the path to your files: data://username/collections_name/mnist_model.h5
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/keras_data_collection.png" alt="Create a data collection" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/keras_data_collection.png" alt="Create a data collection" class="screenshot img-md">
 
 ## Create your Algorithm
 
 Hopefully you've already followed along with the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a> for algorithm development. If not, you might want to check it out in order to understand the various permission types, how to enable a GPU environment, and use the CLI.
 
-Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console. 
+Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console.
 
 The main thing to note about the algorithm is that it's wrapped in the `apply()` function.
 
@@ -81,14 +81,14 @@ The apply() function defines the input point of the algorithm. We use the apply(
 
 Go ahead and remove the boilerplate code below that's inside the `apply()` function on line 6, but leave the `apply()` function intact:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
 
 ### Set your Dependencies
 Now is the time to set your dependencies that your model relies on.
 
 - Click on the **"Dependencies"** button at the top right of the UI and list your packages under the required ones already listed and click **"Save Dependencies"** on the bottom right corner.
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/keras_dependencies.png" alt="Set your dependencies" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/keras_dependencies.png" alt="Set your dependencies" class="screenshot img-md">
 
 For easy copy and paste:
 {% highlight python %}
@@ -104,7 +104,7 @@ Here is where you load and run your model which will be called by the apply() fu
 
 When you load your model, our recommendation is to preload your model in a separate function external to the apply() function.
 
-This is because when a model is first loaded it can take time to load depending on the file size. 
+This is because when a model is first loaded it can take time to load depending on the file size.
 
 Then, with all subsequent calls only the apply() function gets called which will be much faster since your model is already loaded.
 
@@ -201,7 +201,7 @@ Last is publishing your algorithm. The best part of hosting your model on Algori
 
 On the upper right hand side of the algorithm page you'll see a purple button "Publish" which will bring up a modal:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
 
 In this modal, you'll see a Changes tab, a Sample I/O tab, and one called Versioning.
 

--- a/_pages/model-deployment/mxnet.md
+++ b/_pages/model-deployment/mxnet.md
@@ -36,7 +36,7 @@ You'll want to do the training and saving of your model on your local machine, o
 After training your MXNet model, you'll want to save the model and weights so you can upload it to Algorithmia.
 
 ### Create a Data Collection
-Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>. 
+Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>.
 
 In this guide we'll use Algorithmia's <a href="{{ site.baseurl }}/data/hosted/">Hosted Data Collection</a>, but you can host it in <a href="{{ site.baseurl }}/data/s3/">S3</a> or <a href="{{ site.baseurl }}/data/dropbox/">Dropbox</a> as well. Alternatively, if your data lies in a database, <a href="https://algorithmia.com/developers/data/dynamodb/">check out</a> how we connected to a DynamoDB database.
 
@@ -48,7 +48,7 @@ First, you'll want to create a data collection to host your pre-trained model.
 
 - After you create your collection you can set the read and write access on your data collection.
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
 
 For more information check out: <a href="{{ site.baseurl }}/data/hosted/">Data Collection Types</a>.
 
@@ -64,13 +64,13 @@ Next, upload your model files to your newly created data collection.
     - data://username/collections_name/resnet-152-symbol.json,
     - data://username/collections_name/synset.txt
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/mxnet_update_collections.png" alt="Create a data collection" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/mxnet_update_collections.png" alt="Create a data collection" class="screenshot img-md">
 
 ## Create your Algorithm
 
 Hopefully you've already followed along with the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a> for algorithm development. If not, you might want to check it out in order to understand the various permission types, how to enable a GPU environment, and use the CLI.
 
-Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console. 
+Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console.
 
 The main thing to note about the algorithm is that it's wrapped in the `apply()` function.
 
@@ -78,7 +78,7 @@ The apply() function defines the input point of the algorithm. We use the apply(
 
 Go ahead and remove the boilerplate code below that's inside the `apply()` function on line 6, but leave the `apply()` function intact:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
 
 ### Set your Dependencies
 Now is the time to set your dependencies that your model relies on.
@@ -96,14 +96,14 @@ import sys
 sys.path.remove("/opt/anaconda2/lib/python2.7/site-packages/mxnet-0.9.4-py2.7-linux-x86_64.egg")
 {% endhighlight %}
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/mxnet_dependencies.png" alt="Set your dependencies" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/mxnet_dependencies.png" alt="Set your dependencies" class="screenshot img-md">
 
 ## Load your Model
 Here is where you load and run your model which will be called by the apply() function.
 
 When you load your model, our recommendation is to preload your model in a separate function external to the apply() function.
 
-This is because when a model is first loaded it can take time to load depending on the file size. 
+This is because when a model is first loaded it can take time to load depending on the file size.
 
 Then, with all subsequent calls only the apply() function gets called which will be much faster since your model is already loaded.
 
@@ -227,7 +227,7 @@ Last is publishing your algorithm. The best part of hosting your model on Algori
 
 On the upper right hand side of the algorithm page you'll see a purple button "Publish" which will bring up a modal:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
 
 In this modal, you'll see a Changes tab, a Sample I/O tab, and one called Versioning.
 

--- a/_pages/model-deployment/nltk.md
+++ b/_pages/model-deployment/nltk.md
@@ -37,7 +37,7 @@ You'll want to do the training and saving of your model on your local machine, o
 After training your NLTK model, you'll want to save the pickled model with `pickle.dump()` so you can upload it to Algorithmia.
 
 ### Create a Data Collection
-Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>. 
+Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>.
 
 In this guide we'll use Algorithmia's <a href="{{ site.baseurl }}/data/hosted/">Hosted Data Collection</a>, but you can host it in <a href="{{ site.baseurl }}/data/s3/">S3</a> or <a href="{{ site.baseurl }}/data/dropbox/">Dropbox</a> as well. Alternatively, if your data lies in a database, <a href="https://algorithmia.com/developers/data/dynamodb/">check out</a> how we connected to a DynamoDB database.
 
@@ -49,7 +49,7 @@ First, you'll want to create a data collection to host your pre-trained model.
 
 - After you create your collection you can set the read and write access on your data collection.
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
 
 For more information check out: <a href="{{ site.baseurl }}/data/hosted/">Data Collection Types</a>.
 
@@ -62,12 +62,12 @@ Next, upload your pickled model to your newly created data collection.
 
 - Note the path to your files: data://username/collections_name/pickled_model.pkl
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/add_collections_visual.png" alt="Create a data collection" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/add_collections_visual.png" alt="Create a data collection" class="screenshot img-md">
 
 ## Create your Algorithm
 Hopefully you've already followed along with the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a> for algorithm development. If not, you might want to check it out in order to understand the various permission types, how to enable a GPU environment, and use the CLI.
 
-Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console. 
+Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console.
 
 The main thing to note about the algorithm is that it's wrapped in the `apply()` function.
 
@@ -75,14 +75,14 @@ The apply() function defines the input point of the algorithm. We use the apply(
 
 Go ahead and remove the boilerplate code below that's inside the `apply()` function on line 6, but leave the `apply()` function intact:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
 
 ### Set your Dependencies
 Now is the time to set your dependencies that your model relies on.
 
 - Click on the **"Dependencies"** button at the top right of the UI and list your packages under the required ones already listed and click **"Save Dependencies"** on the bottom right corner.
 
-<img src="{{ site.baseurl }}//images/post_images/model_hosting/dependencies_nltk.png" alt="Set your dependencies" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}//images/post_images/model_hosting/dependencies_nltk.png" alt="Set your dependencies" class="screenshot img-md">
 
 For easy copy and paste:
 {% highlight python %}
@@ -96,7 +96,7 @@ Here is where you load and run your model which will be called by the apply() fu
 
 When you load your model, our recommendation is to preload your model in a separate function external to the apply() function.
 
-This is because when a model is first loaded it can take time to load depending on the file size. 
+This is because when a model is first loaded it can take time to load depending on the file size.
 
 Then, with all subsequent calls only the apply() function gets called which will be much faster since your model is already loaded.
 
@@ -167,7 +167,7 @@ Last is publishing your algorithm. The best part of hosting your model on Algori
 
 On the upper right hand side of the algorithm page you'll see a purple button "Publish" which will bring up a modal:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
 
 In this modal, you'll see a Changes tab, a Sample I/O tab, and one called Versioning.
 

--- a/_pages/model-deployment/opencv.md
+++ b/_pages/model-deployment/opencv.md
@@ -29,11 +29,11 @@ Before you get started hosting your model on Algorithmia there are a few things 
 
 ### Create a Data Collection
 
-Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>. 
+Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>.
 
 In this guide we'll use Algorithmia's <a href="{{ site.baseurl }}/data/hosted/">Hosted Data Collection</a>, but you can host it in <a href="{{ site.baseurl }}/data/s3/">S3</a> or <a href="{{ site.baseurl }}/data/dropbox/">Dropbox</a> as well. Alternatively, if your data lies in a database, <a href="https://algorithmia.com/developers/data/dynamodb/">check out</a> how we connected to a DynamoDB database.
 
-First, you'll want to create a data collection to host your graph and variables. 
+First, you'll want to create a data collection to host your graph and variables.
 
 - Log into your Algorithmia account and create a data collection via the <a href="{{ site.baseurl }}/data/hosted">Data Collections</a> page.
 
@@ -41,7 +41,7 @@ First, you'll want to create a data collection to host your graph and variables.
 
 - After you create your collection you can set the read and write access on your data collection.
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
 
 For more information check out: <a href="{{ site.baseurl }}/data/hosted/">Data Collection Types</a>.
 
@@ -123,7 +123,7 @@ The last line will save your model to the data collection you've created.
 
 Hopefully you've already followed along with the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a> for algorithm development. If not, you might want to check it out in order to understand the various permission types, how to enable a GPU environment, and use the CLI.
 
-Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console. 
+Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console.
 
 The main thing to note about the algorithm is that it's wrapped in the `apply()` function.
 
@@ -131,7 +131,7 @@ The apply() function defines the input point of the algorithm. We use the apply(
 
 Go ahead and remove the boilerplate code below that's inside the `apply()` function on line 6, but leave the `apply()` function intact:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
 
 **Note**: Make sure that your version of python is the same between your development environment and the algorithm. There may be version conflicts otherwise.
 
@@ -146,7 +146,7 @@ Here is where you load and run your model which will be called by the apply() fu
 
 When you load your model, our recommendation is to preload your model in a separate function external to the apply() function.
 
-This is because when a model is first loaded it can take time to load depending on the file size. 
+This is because when a model is first loaded it can take time to load depending on the file size.
 
 Then, with all subsequent calls only the apply() function gets called which will be much faster since your model is already loaded.
 
@@ -283,7 +283,7 @@ Last is publishing your algorithm. The best part of hosting your model on Algori
 
 On the upper right hand side of the algorithm page you'll see a purple button "Publish" which will bring up a modal:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
 
 In this modal, you'll see a Changes tab, a Sample I/O tab, and one called Versioning.
 

--- a/_pages/model-deployment/pmml.md
+++ b/_pages/model-deployment/pmml.md
@@ -35,7 +35,7 @@ Before you get started deploying your pre-trained model on Algorithmia, there ar
 You'll want to do the training and saving of your model on your local machine, or the platform you're using for training, before you deploy it to production on the Algorithmia platform.
 
 ### Create a Data Collection
-Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>. 
+Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>.
 
 In this guide we'll use Algorithmia's <a href="{{ site.baseurl }}/data/hosted/">Hosted Data Collection</a>, but you can host it in <a href="{{ site.baseurl }}/data/s3/">S3</a> or <a href="{{ site.baseurl }}/data/dropbox/">Dropbox</a> as well. Alternatively, if your data lies in a database, <a href="https://algorithmia.com/developers/data/dynamodb/">check out</a> how we connected to a DynamoDB database.
 
@@ -47,7 +47,7 @@ First, you'll want to create a data collection to host any data associated with 
 
 - After you create your collection you can set the read and write access on your data collection.
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
 
 For more information check out: <a href="{{ site.baseurl }}/data/hosted/">Data Collection Types</a>.
 
@@ -60,13 +60,13 @@ Next, upload your serialized model to your newly created data collection.
 
 - Note the path to your data collection and the zip folder: data://user_name/collections_name/model.zip
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/pmml_data_collection.png" alt="Create a data collection" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/pmml_data_collection.png" alt="Create a data collection" class="screenshot img-md">
 
 ## Create your Algorithm
 
 Hopefully you've already followed along with the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a> for algorithm development. If not, you might want to check it out in order to understand the various permission types, how to enable a GPU environment, and use the CLI.
 
-Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console. 
+Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console.
 
 The main thing to note about the algorithm is that it's wrapped in the `apply()` function.
 
@@ -74,14 +74,14 @@ The apply() function defines the input point of the algorithm. We use the apply(
 
 Go ahead and remove the boilerplate code below that's inside the `apply()` function on line 6, but leave the `apply()` function intact:
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/scala_console.png" alt="Algorithm console Scala" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/scala_console.png" alt="Algorithm console Scala" class="screenshot">
 
 ### Set your Dependencies
 Now is the time to set your dependencies that your model relies on.
 
 - Click on the **"Dependencies"** button at the top right of the UI and list your packages under the required ones already listed and click **"Save Dependencies"** on the bottom right corner.
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/scala_pmml_dependencies.png" alt="Set your dependencies" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/scala_pmml_dependencies.png" alt="Set your dependencies" class="screenshot img-md">
 
 ## Load your Model
 
@@ -89,7 +89,7 @@ Here is where you load and run your model which will be called by the apply() fu
 
 When you load your model, our recommendation is to preload your model in a separate function external to the apply() function.
 
-This is because when a model is first loaded it can take time to load depending on the file size. 
+This is because when a model is first loaded it can take time to load depending on the file size.
 
 Then, with all subsequent calls only the apply() function gets called which will be much faster since your model is already loaded.
 
@@ -122,9 +122,9 @@ import scala.collection.JavaConversions._
 
 object LoadPmmlKmeans{
   val client = Algorithmia.client()
-  
+
   val model = loadModel()
-  
+
   def loadModel(): Evaluator = {
     // Download the file
     val XMLFilePath = "data://YOUR_USERNAME/YOUR_DATACOLLECTION/kmeans.xml"
@@ -146,7 +146,7 @@ object LoadPmmlKmeans{
     println(results)
     results.toString
   }
-  
+
 
   // Reads the PMML File and returns a PMML object
   def readPMML(filename: String): PMML = {
@@ -181,7 +181,7 @@ Last is publishing your algorithm. The best part of hosting your model on Algori
 
 On the upper right hand side of the algorithm page you'll see a purple button "Publish" which will bring up a modal:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
 
 In this modal, you'll see a Changes tab, a Sample I/O tab, and one called Versioning.
 

--- a/_pages/model-deployment/pytorch.md
+++ b/_pages/model-deployment/pytorch.md
@@ -41,10 +41,10 @@ Install the `ergo-pytorch` package using <a href="https://pypi.org/">Pypi</a> wi
 
 ##### 2. Save Your Model Using Our Ergonomics Package
 
-Instead of using Pytorch’s built in `model.save()` functionality, use `ergonomics.model_ergonomics.save_portable(source_path)`. This will save your model along with the class code, so you don’t need to copy and paste that later on. 
+Instead of using Pytorch’s built in `model.save()` functionality, use `ergonomics.model_ergonomics.save_portable(source_path)`. This will save your model along with the class code, so you don’t need to copy and paste that later on.
 
 ### Create a Data Collection
-Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>. 
+Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>.
 
 In this guide we'll use Algorithmia's <a href="{{ site.baseurl }}/data/hosted/">Hosted Data Collection</a>, but you can host it in <a href="{{ site.baseurl }}/data/s3/">S3</a> or <a href="{{ site.baseurl }}/data/dropbox/">Dropbox</a> as well. Alternatively, if your data lies in a database, <a href="https://algorithmia.com/developers/data/dynamodb/">check out</a> how we connected to a DynamoDB database.
 
@@ -56,7 +56,7 @@ First, you'll want to create a data collection to host your pre-trained model.
 
 - After you create your collection you can set the read and write access on your data collection.
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
 
 For more information check out: <a href="{{ site.baseurl }}/data/hosted/">Data Collection Types</a>.
 
@@ -69,12 +69,12 @@ Next, upload your pickled model to your newly created data collection.
 
 - Note the path to your files: data://username/collections_name/file_name.zip
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/pytorch_add_collection.png" alt="Create a data collection" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/pytorch_add_collection.png" alt="Create a data collection" class="screenshot img-md">
 
 ## Create your Algorithm
 Hopefully you've already followed along with the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a> for algorithm development. If not, you might want to check it out in order to understand the various permission types, how to enable a GPU environment, and use the CLI.
 
-Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console. 
+Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console.
 
 The main thing to note about the algorithm is that it's wrapped in the `apply()` function.
 
@@ -82,14 +82,14 @@ The apply() function defines the input point of the algorithm. We use the apply(
 
 Go ahead and remove the boilerplate code below that's inside the `apply()` function on line 6, but leave the `apply()` function intact:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
 
 ### Set your Dependencies
 Now is the time to set your dependencies that your model relies on.
 
 - Click on the **"Dependencies"** button at the top right of the UI and list your packages under the required ones already listed and click **"Save Dependencies"** on the bottom right corner.
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/pytorch_dependencies.png" alt="Set your dependencies" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/pytorch_dependencies.png" alt="Set your dependencies" class="screenshot img-md">
 
 For easy copy and paste:
 {% highlight python %}
@@ -105,7 +105,7 @@ Here is where you load and run your model which will be called by the apply() fu
 
 When you load your model, our recommendation is to preload your model in a separate function external to the apply() function.
 
-This is because when a model is first loaded it can take time to load depending on the file size. 
+This is because when a model is first loaded it can take time to load depending on the file size.
 
 Then, with all subsequent calls only the apply() function gets called which will be much faster since your model is already loaded.
 
@@ -114,11 +114,11 @@ If you are authoring an algorithm, avoid using the ‘.my’ pseudonym in the so
 
 Note that you always want to create valid JSON input and output in your algorithm. For examples see the <a href="/algorithm-development/languages/python/#io-for-your-algorithms">Client Guides</a>.
 
-### CPUs vs. GPUs on Pytorch 
+### CPUs vs. GPUs on Pytorch
 
-Pytorch offers a few different distributions for download that are split by CPU and GPU. The Pytorch files for CPU usage are normal sized, but when using the GPU packages the files can get very large. 
+Pytorch offers a few different distributions for download that are split by CPU and GPU. The Pytorch files for CPU usage are normal sized, but when using the GPU packages the files can get very large.
 
-For GPU based implementations we've created a workaround that loads the files much faster than the default. When using the workaround, the main file stays the same (see example hosted model below) but you'll need to create an extra file that executes the workaround. See the second example `implement.py` for how to do this. 
+For GPU based implementations we've created a workaround that loads the files much faster than the default. When using the workaround, the main file stays the same (see example hosted model below) but you'll need to create an extra file that executes the workaround. See the second example `implement.py` for how to do this.
 
 ### Example Hosted Model (Main):
 
@@ -143,7 +143,7 @@ client = Algorithmia.client()
 def load_model(path):
     newCNN = ergonomics.serialization.load_portable('MODEL_PATH')
     return newCNN
-    
+
 def preprocess(input_image):
     file_url = client.file(input_image).getFile().name
     #Normalize and resize image
@@ -153,7 +153,7 @@ def preprocess(input_image):
     img.load()
     output = composed(img)
     return output
-    
+
 def predict(input, newCNN):
     outputs = newCNN(Variable(torch.stack([input])))
     _, predicted = torch.max(outputs.data, 1)
@@ -167,7 +167,7 @@ def apply(input):
         processed = preprocess(input_url)
         output = predict(processed, newCNN)
         outputs.append(classes[output])
-        
+
     return {"output" : outputs}
 
 
@@ -191,9 +191,9 @@ def load_pytorch_model():
     filename = 'data://gagejustins/Pytorch/simpleCNN.zip'
     model_loc = client.file(filename).getFile().name
     return model_loc
-    
+
 model_loc = load_pytorch_model()
-    
+
 def parseInputs(input):
     #Iterate through input and append urls to input_urls list
     output = {'urls': []}
@@ -204,9 +204,9 @@ def parseInputs(input):
             output['urls'] = input['test_data']
         else:
             raise AlgorithmError("AlgoError3000: Invalid input")
-    
+
     return output
-    
+
 
 def apply(input):
     #Define classes
@@ -215,7 +215,7 @@ def apply(input):
     formatted['local_model_path'] = model_loc
     #Apply algorithm to inputs and append output to outputs list
     output = execute_workaround(formatted, "src/main.py", "execute")
-        
+
     return output
 
 {% endhighlight %}
@@ -245,7 +245,7 @@ Last is publishing your algorithm. The best part of hosting your model on Algori
 
 On the upper right hand side of the algorithm page you'll see a purple button "Publish" which will bring up a modal:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
 
 In this modal, you'll see a Changes tab, a Sample I/O tab, and one called Versioning.
 

--- a/_pages/model-deployment/scikit.md
+++ b/_pages/model-deployment/scikit.md
@@ -37,7 +37,7 @@ You'll want to do the training and saving of your model on your local machine, o
 After training your Scikit-learn model, you'll want to save the pickled model so you can upload it to Algorithmia.
 
 ### Create a Data Collection
-Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>. 
+Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>.
 
 In this guide we'll use Algorithmia's <a href="{{ site.baseurl }}/data/hosted/">Hosted Data Collection</a>, but you can host it in <a href="{{ site.baseurl }}/data/s3/">S3</a> or <a href="{{ site.baseurl }}/data/dropbox/">Dropbox</a> as well. Alternatively, if your data lies in a database, <a href="https://algorithmia.com/developers/data/dynamodb/">check out</a> how we connected to a DynamoDB database.
 
@@ -49,7 +49,7 @@ First, you'll want to create a data collection to host your pre-trained model.
 
 - After you create your collection you can set the read and write access on your data collection.
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
 
 For more information check out: <a href="{{ site.baseurl }}/data/hosted/">Data Collection Types</a>.
 
@@ -62,12 +62,12 @@ Next, upload your pickled model to your newly created data collection.
 
 - Note the path to your files: data://username/collections_name/pickled_model.pkl
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/add_collections_visual.png" alt="Create a data collection" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/add_collections_visual.png" alt="Create a data collection" class="screenshot img-md">
 
 ## Create your Algorithm
 Hopefully you've already followed along with the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a> for algorithm development. If not, you might want to check it out in order to understand the various permission types, how to enable a GPU environment, and use the CLI.
 
-Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console. 
+Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console.
 
 The main thing to note about the algorithm is that it's wrapped in the `apply()` function.
 
@@ -75,14 +75,14 @@ The apply() function defines the input point of the algorithm. We use the apply(
 
 Go ahead and remove the boilerplate code below that's inside the `apply()` function on line 6, but leave the `apply()` function intact:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
 
 ### Set your Dependencies
 Now is the time to set your dependencies that your model relies on.
 
 - Click on the **"Dependencies"** button at the top right of the UI and list your packages under the required ones already listed and click **"Save Dependencies"** on the bottom right corner.
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/dependencies_scikit.png" alt="Set your dependencies" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/dependencies_scikit.png" alt="Set your dependencies" class="screenshot img-md">
 
 If you're following along with this tutorial, go ahead and copy and paste the libraries listed into the dependency file, adding to the ones already there:
 
@@ -91,7 +91,7 @@ numpy
 scikit-learn>=0.14,<0.18
 {% endhighlight %}
 
-The dependency file is the equivalent to a requirements.txt file which pulls the dependencies listed from PyPi. 
+The dependency file is the equivalent to a requirements.txt file which pulls the dependencies listed from PyPi.
 {: .notice-info}
 
 ## Load your Model
@@ -99,7 +99,7 @@ Here is where you load and run your model which will be called by the apply() fu
 
 When you load your model, our recommendation is to preload your model in a separate function external to the apply() function.
 
-This is because when a model is first loaded it can take time to load depending on the file size. 
+This is because when a model is first loaded it can take time to load depending on the file size.
 
 Then, with all subsequent calls only the apply() function gets called which will be much faster since your model is already loaded.
 
@@ -161,7 +161,7 @@ def apply(input):
 
 Now when you run this code, the expected input is:
 {% highlight python %}
-"data://YOUR_USERNAME/YOUR_DATA_COLLECTION/boston_test_data.csv" 
+"data://YOUR_USERNAME/YOUR_DATA_COLLECTION/boston_test_data.csv"
 {% endhighlight %}
 
 A sample of the expected output:
@@ -179,7 +179,7 @@ Last is publishing your algorithm. The best part of hosting your model on Algori
 
 On the upper right hand side of the algorithm page you'll see a purple button "Publish" which will bring up a modal:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
 
 In this modal, you'll see a Changes tab, a Sample I/O tab, and one called Versioning.
 

--- a/_pages/model-deployment/spacy.md
+++ b/_pages/model-deployment/spacy.md
@@ -27,7 +27,7 @@ This guide is designed as an introduction to hosting a spaCy model and publishin
 ## Create your Algorithm
 Hopefully you've already followed along with the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a> for algorithm development. If not, you might want to check it out in order to understand the various permission types, how to enable a GPU environment, and use the CLI.
 
-Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console. 
+Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console.
 
 The main thing to note about the algorithm is that it's wrapped in the `apply()` function.
 
@@ -35,14 +35,14 @@ The apply() function defines the input point of the algorithm. We use the apply(
 
 Go ahead and remove the boilerplate code below that's inside the `apply()` function on line 6, but leave the `apply()` function intact:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
 
 ### Set your Dependencies
 Now is the time to set your dependencies that your model relies on.
 
 - Click on the **"Dependencies"** button at the top right of the UI and list your packages under the required ones already listed and click **"Save Dependencies"** on the bottom right corner.
 
-<img src="{{ site.baseurl }}//images/post_images/model_hosting/dependencies_spaCy.png" alt="Set your dependencies" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}//images/post_images/model_hosting/dependencies_spaCy.png" alt="Set your dependencies" class="screenshot img-md">
 
 For easy copy and paste:
 {% highlight python %}
@@ -56,7 +56,7 @@ Here is where you load and run your model which will be called by the apply() fu
 
 When you load your model, our recommendation is to preload your model in a separate function external to the apply() function.
 
-This is because when a model is first loaded it can take time to load depending on the file size. 
+This is because when a model is first loaded it can take time to load depending on the file size.
 
 Then, with all subsequent calls only the apply() function gets called which will be much faster since your model is already loaded.
 
@@ -112,7 +112,7 @@ Last is publishing your algorithm. The best part of hosting your model on Algori
 
 On the upper right hand side of the algorithm page you'll see a purple button "Publish" which will bring up a modal:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
 
 In this modal, you'll see a Changes tab, a Sample I/O tab, and one called Versioning.
 

--- a/_pages/model-deployment/tensorflow.md
+++ b/_pages/model-deployment/tensorflow.md
@@ -135,11 +135,11 @@ In the above code, the Manual Builder API is used to save your graph using a Met
 Now that you've trained and saved your Tensorflow model elsewhere, we'll deploy it on Algorithmia.
 
 ### Create a Data Collection
-Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>. 
+Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>.
 
 In this guide we'll use Algorithmia's <a href="{{ site.baseurl }}/data/hosted/">Hosted Data Collection</a>, but you can host it in <a href="{{ site.baseurl }}/data/s3/">S3</a> or <a href="{{ site.baseurl }}/data/dropbox/">Dropbox</a> as well. Alternatively, if your data lies in a database, <a href="https://algorithmia.com/developers/data/dynamodb/">check out</a> how we connected to a DynamoDB database.
 
-First, you'll want to create a data collection to host your graph and variables. 
+First, you'll want to create a data collection to host your graph and variables.
 
 - Log into your Algorithmia account and create a data collection via the <a href="{{ site.baseurl }}/data/hosted">Data Collections</a> page.
 
@@ -147,7 +147,7 @@ First, you'll want to create a data collection to host your graph and variables.
 
 - After you create your collection you can set the read and write access on your data collection.
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
 
 For more information check out: <a href="{{ site.baseurl }}/data/hosted/">Data Collection Types</a>.
 
@@ -160,7 +160,7 @@ Next, upload your Tensorflow variables and graph to your newly created data coll
 
 - Note the path to your data collection and the zip folder: data://user_name/collections_name/model.zip
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/tensorflow_data_collection.png" alt="Create a data collection" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/tensorflow_data_collection.png" alt="Create a data collection" class="screenshot img-md">
 
 ## Create your Algorithm
 
@@ -169,7 +169,7 @@ Hopefully you've already followed along with the <a href="{{ site.baseurl }}/alg
 Note, that for this guide we are showing a model meant to run on a GPU enabled environment. To run the same model on CPU's check out this code sample: <a href="https://algorithmia.com/algorithms/demo/tensorflowmnistcpu">Tensorflow MNIST CPU Demo</a>
 {: .notice-info}
 
-Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console. 
+Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console.
 
 The main thing to note about the algorithm is that it's wrapped in the `apply()` function.
 
@@ -177,14 +177,14 @@ The apply() function defines the input point of the algorithm. We use the apply(
 
 Go ahead and remove the boilerplate code below that's inside the `apply()` function on line 6, but leave the `apply()` function intact:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
 
 ### Set your Dependencies
 Now is the time to set your dependencies that your model relies on.
 
 - Click on the **"Dependencies"** button at the top right of the UI and list your packages under the required ones already listed and click **"Save Dependencies"** on the bottom right corner.
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/tensorflow_dependencies_gpu.png" alt="Set your dependencies" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/tensorflow_dependencies_gpu.png" alt="Set your dependencies" class="screenshot img-md">
 
 If you plan on using tensorflow with GPU support, make sure to use the
 <code>tensorflow-gpu</code> python package instead of the <code>tensorflow</code> one, with the version number
@@ -196,7 +196,7 @@ We've recently added tensorflow 1.3.0 support, however it uses custom wheels whi
 <li> python 2 - https://s3.amazonaws.com/algorithmia-wheels/tensorflow-1.3.0-cp27-cp27mu-linux_x86_64.whl </li>
 <li> python 3 - https://s3.amazonaws.com/algorithmia-wheels/tensorflow-1.3.0-cp35-cp35m-linux_x86_64.whl </li>
 </ul>
-If you run into any issues with these wheels, please get in touch with us using intercom. 
+If you run into any issues with these wheels, please get in touch with us using intercom.
 
 Note that with the Python 2 wheel you also must add your protobuf version to the dependency. For example:
 <code>protobuf==3.0.0b2.post1</code>
@@ -210,7 +210,7 @@ Now that you've seen how to save your model using SavedModelBuilder, you can loa
 
 When you load your model, our recommendation is to preload your model in a separate function external to the apply() function.
 
-This is because when a model is first loaded it can take time to load depending on the file size. 
+This is because when a model is first loaded it can take time to load depending on the file size.
 
 Then, with all subsequent calls only the apply() function gets called which will be much faster since your model is already loaded.
 
@@ -226,13 +226,13 @@ This is where we'll show how to deploy your saved model to make predictions on t
 
 The following code sample is adapted from <a href="https://www.tensorflow.org/versions/r0.9/tutorials/mnist/beginners/index.html">MNIST for Beginners</a> tutorial from Tensorflow.
 
-If you want to follow along, you can add the <a href="http://yann.lecun.com/exdb/mnist/">MNIST data files</a> to your data collection, but make sure you update the username and path to match your own. 
+If you want to follow along, you can add the <a href="http://yann.lecun.com/exdb/mnist/">MNIST data files</a> to your data collection, but make sure you update the username and path to match your own.
 
 You will also need the file in the <a href="https://algorithmia.com/algorithms/demo/TensorflowDemoGPU">Tensorflow Demo GPU</a> called loadmnistdata.py shown here to deal with unpacking the mnist files:
 
 ```python
 """
-Functions to handle MNIST data extraction and loading 
+Functions to handle MNIST data extraction and loading
 
 Adopted from https://github.com/tensorflow/tensorflow/blob/v0.6.0/tensorflow/examples/tutorials/mnist/input_data.py
 """
@@ -310,10 +310,10 @@ import shutil
 from .loadmnistdata import load_mnist
 
 client = Algorithmia.client()
-    
+
 def load_data(input):
     """
-    Pass in {"mnist_images": "data://demo/tensorflow_mnist_data/t10k-images-idx3-ubyte.gz", 
+    Pass in {"mnist_images": "data://demo/tensorflow_mnist_data/t10k-images-idx3-ubyte.gz",
         "mnist_labels": "data://demo/tensorflow_mnist_data/t10k-labels-idx1-ubyte.gz"
     }
     """
@@ -335,11 +335,11 @@ def extract_zip():
     """
     Get zipped model file from data collections
     """
-    # Saved model protocol buffer and variables 
+    # Saved model protocol buffer and variables
     filename = "data://demo/tensorflow_mnist_model/model.zip"
     model_file = client.file(filename).getFile().name
     return model_file
-    
+
 def extract_model():
     """
     Unzip model files from data collections
@@ -355,14 +355,14 @@ def extract_model():
     zipped_file = zipfile.ZipFile(input_zip)
     # Extract unzipped files into directory created earlier returns none
     return zipped_file.extractall("unzipped_files")
-    
+
 def generate_gpu_config(memory_fraction):
     config = tf.ConfigProto()
     config.gpu_options.allow_growth = True
     config.gpu_options.per_process_gpu_memory_fraction = memory_fraction
     return config
-    
-# Unzip model files to directory 
+
+# Unzip model files to directory
 extract_model()
 
 # Load model outside of apply() in global state so it only gets loaded one time
@@ -372,7 +372,7 @@ def create_session():
     fraction = 0.6
     session = tf.Session(config=generate_gpu_config(fraction))
     path_to_graph = "./unzipped_files/model"
-    
+
     tf.saved_model.loader.load(
         session,
         [tf.saved_model.tag_constants.SERVING],
@@ -405,13 +405,13 @@ def apply(input):
     data = load_data(input)
     inference = predict(data)
     tf_version = tf.__version__
-    return "MNIST Predictions: {0}, TF version: {1}".format(inference, tf_version) 
+    return "MNIST Predictions: {0}, TF version: {1}".format(inference, tf_version)
 ```
 
 Now when you run this code, the expected input is:
 
 {% highlight python %}
-{"mnist_images": "data://YOUR_USERNAME/YOUR_DATA_COLLECTION/t10k-images-idx3-ubyte.gz", "mnist_labels": "data://YOUR_USERNAME/YOUR_DATA_COLLECTION/t10k-labels-idx1-ubyte.gz"} 
+{"mnist_images": "data://YOUR_USERNAME/YOUR_DATA_COLLECTION/t10k-images-idx3-ubyte.gz", "mnist_labels": "data://YOUR_USERNAME/YOUR_DATA_COLLECTION/t10k-labels-idx1-ubyte.gz"}
 {% endhighlight %}
 
 With the expected output:
@@ -431,7 +431,7 @@ import os
 from numpy import array, float32, object
 client = Algorithmia.client()
 
-    
+
 def _create_float(v):
     return tf.train.Feature(float_list=tf.train.FloatList(value=[v]))
 
@@ -466,7 +466,7 @@ def apply(input):
     occupation = _create_str(input['occupation'])
     relationship = _create_str(input['relationship'])
     workclass = _create_str(input['workclass'])
-    
+
     features = {
         'age': age,
         'capital_gain': capital_gain,
@@ -495,7 +495,7 @@ If you want to create a custom graph session (aka with gpu memory optimizations 
 
 ### GPU memory tricks
 Are you running into out of memory exceptions? Tensorflow attempts to allocate all available
-gpu memory. 
+gpu memory.
 By defining a configuration with a max memory fraction you can ensure algorithm stability.
 Also, uncomment `allow_growth` if you aren't sure how much memory your algorithm needs, tensorflow will grow it's gpu memory allocation as necessary.
 
@@ -512,7 +512,7 @@ Last is publishing your algorithm. The best part of hosting your model on Algori
 
 On the upper right hand side of the algorithm page you'll see a purple button "Publish" which will bring up a modal:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
 
 In this modal, you'll see a Changes tab, a Sample I/O tab, and one called Versioning.
 

--- a/_pages/model-deployment/theano.md
+++ b/_pages/model-deployment/theano.md
@@ -35,7 +35,7 @@ You'll want to do the training and saving of your model on your local machine, o
 After training your Theano model, you'll want to save the pickled model using either [pickle or cPickle](http://deeplearning.net/software/theano/tutorial/loading_and_saving.html) so you can upload it to Algorithmia.
 
 ### Create a Data Collection
-Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>. 
+Host your data where you want and serve it to your model with Algorithmia's <a href="http://docs.algorithmia.com/">Data API</a>.
 
 In this guide we'll use Algorithmia's <a href="{{ site.baseurl }}/data/hosted/">Hosted Data Collection</a>, but you can host it in <a href="{{ site.baseurl }}/data/s3/">S3</a> or <a href="{{ site.baseurl }}/data/dropbox/">Dropbox</a> as well. Alternatively, if your data lies in a database, <a href="https://algorithmia.com/developers/data/dynamodb/">check out</a> how we connected to a DynamoDB database.
 
@@ -47,7 +47,7 @@ First, you'll want to create a data collection to host your pre-trained model.
 
 - After you create your collection you can set the read and write access on your data collection.
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/add_collection.png" alt="Create a data collection" class="screenshot img-sm">
 
 For more information check out: <a href="{{ site.baseurl }}/data/hosted/">Data Collection Types</a>.
 
@@ -60,13 +60,13 @@ Next, upload your pickled model to your newly created data collection.
 
 - Note the path to your files: data://username/collections_name/pickled_model.pkl
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/theano_update_collections.png" alt="Create a data collection" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/theano_update_collections.png" alt="Create a data collection" class="screenshot img-md">
 
 ## Create your Algorithm
 
 Hopefully you've already followed along with the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a> for algorithm development. If not, you might want to check it out in order to understand the various permission types, how to enable a GPU environment, and use the CLI.
 
-Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console. 
+Once you've gone through the <a href="{{ site.baseurl }}/algorithm-development/algorithm-basics/your-first-algo/">Getting Started Guide</a>, you'll notice that when you've created your algorithm, there is boilerplate code in the editor that returns "Hello" and whatever you input to the console.
 
 The main thing to note about the algorithm is that it's wrapped in the `apply()` function.
 
@@ -74,14 +74,14 @@ The apply() function defines the input point of the algorithm. We use the apply(
 
 Go ahead and remove the boilerplate code below that's inside the `apply()` function on line 6, but leave the `apply()` function intact:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/algorithm_console_python.png" alt="Algorithm console Python" class="screenshot">
 
 ### Set your Dependencies
 Now is the time to set your dependencies that your model relies on.
 
 - Click on the **"Dependencies"** button at the top right of the UI and list your packages under the required ones already listed and click **"Save Dependencies"** on the bottom right corner.
 
-<img src="{{ site.baseurl }}/images/post_images/model_hosting/theano_dependencies.png" alt="Set your dependencies" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/model_hosting/theano_dependencies.png" alt="Set your dependencies" class="screenshot img-md">
 
 For easy copy and paste:
 {% highlight python %}
@@ -93,7 +93,7 @@ Here is where you load and run your model which will be called by the apply() fu
 
 When you load your model, our recommendation is to preload your model in a separate function external to the apply() function.
 
-This is because when a model is first loaded it can take time to load depending on the file size. 
+This is because when a model is first loaded it can take time to load depending on the file size.
 
 Then, with all subsequent calls only the apply() function gets called which will be much faster since your model is already loaded.
 
@@ -160,7 +160,7 @@ Last is publishing your algorithm. The best part of hosting your model on Algori
 
 On the upper right hand side of the algorithm page you'll see a purple button "Publish" which will bring up a modal:
 
-<img src="{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/algo_dev_lang/publish_algorithm.png" alt="Publish an algorithm" class="screenshot img-sm">
 
 In this modal, you'll see a Changes tab, a Sample I/O tab, and one called Versioning.
 

--- a/_pages/teams.md
+++ b/_pages/teams.md
@@ -15,7 +15,7 @@ If you are looking to share algorithms privately or publish algorithms under the
 
 The profile overview provides a rich source of information about the organization. In the overview, you can find the name of the organization, the number of members, the number of algorithms, and the aggregate amount of API requests received. If you are the owner of the organization you will also be able to Add/Delete members as well as Edit basic information regarding the organization.
 
-<img src="{{ site.baseurl }}/images/post_images/organizations/org_profile.png" alt="organizations profile" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/organizations/org_profile.png" alt="organizations profile" class="screenshot img-md">
 
 
 #### Things to know about Organizations:
@@ -31,7 +31,7 @@ The profile overview provides a rich source of information about the organizatio
 To create your new organization simply go to your profile page and click "+Create Organization"
 
 
-<img src="{{ site.baseurl }}/images/post_images/organizations/new_organization.png" alt="create organization" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/organizations/new_organization.png" alt="create organization" class="screenshot">
 
 At this time you will be asked to fill out some information regarding your organization:
 
@@ -43,11 +43,11 @@ This will determine the URL where your organization will be showcased. It is req
 * *Url:* Your organization's website.
 
 
-<img src="{{ site.baseurl }}/images/post_images/organizations/org_info.png" alt="Organization info" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/organizations/org_info.png" alt="Organization info" class="screenshot img-sm">
 
 Once your organization has been created you can edit all the provided information as well as add a logo and a Terms of Use document.
 
-<img src="{{ site.baseurl }}/images/post_images/organizations/org_edit_info.png" alt="Organization info" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/organizations/org_edit_info.png" alt="Organization info" class="screenshot img-sm">
 
 **Note**: The Terms of Use are organization specific. When users accept an invite to your organization they will be accepting the Terms of Use uploaded. Algorithmia records the date when the terms where accepted. These terms are completely independent of the Algorthmia Terms of Use.
 
@@ -58,24 +58,24 @@ You can invite users to your organization either by using their Algorithmia user
 
 To invite a user simply click 'Invite User':
 
-<img src="{{ site.baseurl }}/images/post_images/organizations/org_invite_user.png" alt="Inviting Users" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/organizations/org_invite_user.png" alt="Inviting Users" class="screenshot">
 
 After clicking 'Invite User' a form will appear and you can enter the users name or email address:
 
-<img src="{{ site.baseurl }}/images/post_images/organizations/org_invite_form.png" alt="Inviting Users" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/organizations/org_invite_form.png" alt="Inviting Users" class="screenshot img-sm">
 
 #### Approving Algorithms:
 Once members of your organization have created an algorithm and submitted it for approval, a purple indicator with the version to be published will show on your organization profile under algorithms.
 
-<img src="{{ site.baseurl }}/images/post_images/organizations/org_approve_algo.png" alt="Approving Algorithms" class="screenshot img-sm">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/organizations/org_approve_algo.png" alt="Approving Algorithms" class="screenshot img-sm">
 
 **Note:** Every new version of the algorithm to be published will require independent approval.
 
 At this time you will be able to set the royalty (if any) for that algorithm and finalize publishing to Algorithmia's marketplace.
 
-<img src="{{ site.baseurl }}/images/post_images/organizations/org_approve_set_royalty.png" alt="Set royalty for team algorithms" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/organizations/org_approve_set_royalty.png" alt="Set royalty for team algorithms" class="screenshot">
 
 #### Check Earnings:
 To view your organization's earnings and a break down of all algorithms that are called, simply access "View Earnings" on your organization's profile.
 
-<img src="{{ site.baseurl }}/images/post_images/organizations/org_earnings.png" alt="Check earnings" class="screenshot img-md">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/organizations/org_earnings.png" alt="Check earnings" class="screenshot img-md">

--- a/_pages/tutorials.md
+++ b/_pages/tutorials.md
@@ -13,7 +13,7 @@ Here you will find sample apps and recipes (which are a little bit different).
 {% for post in pages %}
   <div class="col-xs-12 overview-brief">
   	<div class="col-md-2 overview-icon">
-    	<a href="{{ post.url | relative_url}}"><img src="{{ post.image.teaser | prepend:'/images' | relative_url }}" alt="" itemprop="image"></a>
+    	<a href="{{ post.url | relative_url}}"><img src="{{ site.cdnurl }}{{ post.image.teaser | prepend:'/images' | relative_url }}" alt="" itemprop="image"></a>
   	</div>
   	<div class="col-xs-10">
    		<h3><a href="{{ post.url | relative_url}}">{{ post.title | downcase }}</a></h3>

--- a/_pages/tutorials/sample-apps/android-car-dl-app.md
+++ b/_pages/tutorials/sample-apps/android-car-dl-app.md
@@ -21,7 +21,7 @@ In this tutorial, we'll go through how to use a deep learning algorithm that pre
 The full sample code can be found in the GitHub repo: <a href="https://github.com/algorithmiaio/sample-apps/tree/master/android/CarMakeModelApp" class="btn btn-default btn-primary"><i class="fa fa-github" aria-hidden="true"></i> FORK</a>
 
 
-You can either clone the repo directly and follow along with the README instructions to see the fully complete app, or you can follow the tutorial below to build an Android app that utilizes deep learning. 
+You can either clone the repo directly and follow along with the README instructions to see the fully complete app, or you can follow the tutorial below to build an Android app that utilizes deep learning.
 
 We'll use the native <a href="https://developer.android.com/reference/android/hardware/camera2/package-summary.html">Camera2 API</a> to take a picture of a car, then we'll use the [Car Make and Model](https://algorithmia.com/algorithms/LgoBE/CarMakeandModelRecognition) algorithm on Algorithmia to process the image in order to display the car's make and model along with other metadata.
 
@@ -31,7 +31,7 @@ First things first, let's create a new app in Android Studio.
 
 Select New Project and follow along with the New Project wizard. You can feel free to give your new app any name you like. Then, select your target devices and when prompted with the Add Activity screen, select "Empty Activity":
 
-<img src="{{ site.baseurl }}/images/post_images/android/create_new_blank.png" alt="Add Blank Activity in Android Studio" class="screenshot">
+<img src="{{ site.cdnurl }}{{ site.baseurl }}/images/post_images/android/create_new_blank.png" alt="Add Blank Activity in Android Studio" class="screenshot">
 
 Then name it "MainActivity". This activity will hold the code that we'll write to access the camera and save the picture. Then we'll use File Provider to pass the URI to the next activity which we'll create now.
 
@@ -293,7 +293,7 @@ public class MainActivity extends AppCompatActivity {
 }
 {% endhighlight %}
 
-Now let's go through the code. 
+Now let's go through the code.
 
 Directly inside our "MainActivity" class, notice the [onCreate](https://developer.android.com/guide/components/activities/activity-lifecycle.html) method where we initialize our view: "setContentView(R.layout.activity_main)". This will display our button for taking a picture.
 
@@ -301,7 +301,7 @@ In the "getOutputMediaFileUri" method we check [External Storage](https://develo
 
 First arg is our application context (MainActivity.this), then the authority that we set in our Manifest file that allows for URI permissions (R.string.file_provider_authority), and finally the timestamped file that we just created.
 
-If we print out the URI we created, it looks like this: 
+If we print out the URI we created, it looks like this:
 
 {% highlight java %}
 content://com.example.carmakemodelapp.fileprovider/external_files/Android/data/com.example.carmakemodelapp/files/Pictures/pic_20171016_115903.jpg
@@ -415,14 +415,14 @@ Note that you can also use [Dropbox or Amazon S3 to host your data](https://algo
 
 Finally, our last method is "onClickRun" where we set our TextView and use an [AsyncTask](http://developer.android.com/training/basics/network-ops/connecting.html) to call our algorithm.
 
-In the [doInBackground](https://developer.android.com/reference/android/os/AsyncTask.html#doInBackground) method we create our [Algorithmia Client](https://algorithmia.com/developers/clients/android/) and pass in our API string from our "res/values/strings.xml". 
+In the [doInBackground](https://developer.android.com/reference/android/os/AsyncTask.html#doInBackground) method we create our [Algorithmia Client](https://algorithmia.com/developers/clients/android/) and pass in our API string from our "res/values/strings.xml".
 
-We then create a DataDirectory object that references a directory in your [data collection](https://algorithmia.com/data/hosted). If you haven't used Data sources check out our [Android Client Guide](https://algorithmia.com/developers/clients/android/). 
+We then create a DataDirectory object that references a directory in your [data collection](https://algorithmia.com/data/hosted). If you haven't used Data sources check out our [Android Client Guide](https://algorithmia.com/developers/clients/android/).
 
 Remember to replace "YOUR_DATA_COLLECTION" in `DataDirectory imageDir = client.dir("data://.my/YOUR_DATA_COLLECTION");` with your own data collection name from one of our [data sources](https://algorithmia.com/developers/data/).
 {: .notice-warning}
 
-Now we upload our byteArray to our data collection in a file called "myImage.jpg" and then immediately download the file path. Then we call the algorithm and use the "pipe()" method to pass in our data URL to the Car Make and Model algorithm. The reason why we do this is because algorithms don't accept data uploaded from just any data source like a local file. 
+Now we upload our byteArray to our data collection in a file called "myImage.jpg" and then immediately download the file path. Then we call the algorithm and use the "pipe()" method to pass in our data URL to the Car Make and Model algorithm. The reason why we do this is because algorithms don't accept data uploaded from just any data source like a local file.
 
 In "onPostExecute()" we'll handle the algorithm response. All we are doing here is handling a null case and when we get an "AlgoSuccess" response, we get that as a JSON string and set the view's text to show the algorithm's response. Then, we have some error handling in case our algorithm call isn't successful!
 

--- a/_pages/tutorials/sample-apps/basic-android.md
+++ b/_pages/tutorials/sample-apps/basic-android.md
@@ -28,7 +28,7 @@ First things first, let's create a new app in Android Studio.
 
 Select New Project and follow along with the New Project wizard. You can feel free to give your new app any name you like. Then, select your target devices and when prompted with the Add Activity screen, select "Empty Activity":
 
-![Add Blank Activity in Android Studio]({{ site.baseurl }}/images/post_images/android/create_new_blank.png)
+![Add Blank Activity in Android Studio]({{ site.cdnurl }}{{ site.baseurl }}/images/post_images/android/create_new_blank.png)
 
 Since our app is just a simple example app, we'll use put our code in `MainActivity.java`. But first, we need to do a little bit more set up.
 
@@ -215,7 +215,7 @@ on [GitHub](https://github.com/algorithmiaio/sample-apps/blob/master/android/bas
 
 When you run the app in the emulator, you'll see this:
 
-![Android App]({{ site.baseurl }}/images/post_images/android/emulator.png)
+![Android App]({{ site.cdnurl }}{{ site.baseurl }}/images/post_images/android/emulator.png)
 
 ## Next Steps
 

--- a/_pages/tutorials/sample-apps/ios.md
+++ b/_pages/tutorials/sample-apps/ios.md
@@ -30,7 +30,7 @@ If you didn't do so on first run, switch Xcode to developer mode: `sudo xcode-se
 
 Download the [sample project](https://github.com/algorithmiaio/algorithmia-swift/) and use Xcode to open the *directory* "algorithmia-swift" (*not* the file "AlgorithmiaSwift.xcodeproj").
 
-Now you're almost ready to run the project... there are just a few options to configure first. 
+Now you're almost ready to run the project... there are just a few options to configure first.
 
 ## Settings, Permissions, & API Key
 
@@ -42,9 +42,9 @@ Make sure you have [added a developer profile](http://stackoverflow.com/a/412174
 
 On your [Algorithmia credentials page](algorithmia.com/user#credentials), create a new Key.  Set its **Algorithm Access** to `'algo://deeplearning/DeepFilter'` and set the **Data access** to `read and write`.  Save this API key.
 
-Now we need to add this API key to your Environment.  From the menu, pick Product > Scheme > Edit Scheme.  In the popup, select "Run", then "Arguments".  Add an entry under "Environment Variables" with the name "ALGORITHMIA_API_KEY", and paste your API Key in as its value. 
+Now we need to add this API key to your Environment.  From the menu, pick Product > Scheme > Edit Scheme.  In the popup, select "Run", then "Arguments".  Add an entry under "Environment Variables" with the name "ALGORITHMIA_API_KEY", and paste your API Key in as its value.
 
-![Set environment variables]({{ site.baseurl }}/images/post_images/ios/envs.png)
+![Set environment variables]({{ site.cdnurl }}{{ site.baseurl }}/images/post_images/ios/envs.png)
 
 **Create a Data Collection to store your images during processing**
 
@@ -58,7 +58,7 @@ Before changing any code, build and run the app to test out the default function
 
 If all is working properly, you'll see a mostly-blank screen with options to take a photo or pick one from your phone's library. Once you've selected a photo, it will upload it to the `sourcePath` specified earlier, run Algorithmia's [DeepFilter algorithm](https://algorithmia.com/algorithms/deeplearning/DeepFilter) on the image, and render the result on the screen (as well as storing it your [Hosted Data](https://algorithmia.com/data/hosted) under `resultPath`):
 
-![Running the app in the iPhone Simulator]({{ site.baseurl }}/images/post_images/ios/demo.png) 
+![Running the app in the iPhone Simulator]({{ site.cdnurl }}{{ site.baseurl }}/images/post_images/ios/demo.png)
 
 
 ## Revising the Code
@@ -86,7 +86,7 @@ Now scroll down a bit and take a look at the three functions we use to createupl
             self.processImage(file: file)
         }
     }
-    
+
     func processImage(file:AlgoDataFile) {
         let param:[String:Any] = [
             "images": [
@@ -97,7 +97,7 @@ Now scroll down a bit and take a look at the three functions we use to createupl
             ],
             "filterName": "space_pizza"
         ]
-        
+
         // Process with DeepFilter algorithm
         self.client.algo(algoUri: "algo://deeplearning/DeepFilter").pipe(json: param, completion: { (response, error) in
             if let error = error {
@@ -108,7 +108,7 @@ Now scroll down a bit and take a look at the three functions we use to createupl
             self.downloadOutput(file: self.client.file(self.resultPath))
         })
     }
-    
+
     func downloadOutput(file:AlgoDataFile) {
         // Download output file
         file.getData { (data, error) in
@@ -122,7 +122,7 @@ Now scroll down a bit and take a look at the three functions we use to createupl
                 self.statusLabel.text = " "
             }
         }
-        
+
     }
 {% endhighlight %}
 
@@ -147,7 +147,7 @@ Lastly, replace `"algo://deeplearning/DeepFilter"` with `"algo://deeplearning/Sa
             "image": file.toDataURI(),
             "location": resultPath
         ]
-        
+
         // Process with SalNet algorithm
         self.client.algo(algoUri: "algo://deeplearning/SalNet").pipe(json: param, completion: { (response, error) in
             if let error = error {

--- a/_pages/tutorials/sample-apps/sample.md
+++ b/_pages/tutorials/sample-apps/sample.md
@@ -22,7 +22,7 @@ First things first, let's create a new app in Android Studio.
 
 Select New Project and follow along with the New Project wizard. You can feel free to give your new app any name you like. Then, select your target devices and when prompted with the Add Activity screen, select "Empty Activity":
 
-![Add Blank Activity in Android Studio]({{ site.baseurl }}/images/post_images/android/create_new_blank.png)
+![Add Blank Activity in Android Studio]({{ site.cdnurl }}{{ site.baseurl }}/images/post_images/android/create_new_blank.png)
 
 Since our app is just a simple example app, we'll use put our code in `MainActivity.java`. But first, we need to do a little bit more set up.
 
@@ -209,7 +209,7 @@ on [GitHub](https://github.com/algorithmiaio/sample-apps/blob/master/android/bas
 
 When you run the app in the emulator, you'll see this:
 
-![Android App]({{ site.baseurl }}/images/post_images/android/emulator.png)
+![Android App]({{ site.cdnurl }}{{ site.baseurl }}/images/post_images/android/emulator.png)
 
 ## Next Steps
 

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ exclude_from_search: true
 <div class="row mb-64">
 <!--   <div class="col-sm-12 hidden-md hidden-lg hidden-xl"><a href="{{ site.baseurl }}/algorithm-development/model-guides/" class="btn btn-primary btn-raised hidden-xs hidden-sm">Deploy Models</a></div> -->
   <div class="col-md-5">
-    <img src="{{ site.baseurl }}/images/face_detection_desc.jpg" alt="Sample Apps" class="img-fill">
+    <img src="{{ site.cdnurl }}{{ site.baseurl }}/images/face_detection_desc.jpg" alt="Sample Apps" class="img-fill">
   </div>
   <div class="clearfix visible-sm-block"></div>
   <div class="col-md-7">
@@ -53,8 +53,8 @@ exclude_from_search: true
 
 <div class="row mb-64">
   <div class="col-md-5">
-    <img src="{{ site.baseurl }}/images/sample_apps.jpg" alt="Contribute" class="img-fill">
-    <img src="{{ site.baseurl }}/images/icons/hexicon_box.svg" alt="icon" class="hexicon">
+    <img src="{{ site.cdnurl }}{{ site.baseurl }}/images/sample_apps.jpg" alt="Contribute" class="img-fill">
+    <img src="{{ site.cdnurl }}{{ site.baseurl }}/images/icons/hexicon_box.svg" alt="icon" class="hexicon">
   </div>
   <div class="col-md-7">
     <p class="lead">Contribute to the marketplace by adding your own algorithms:</p>
@@ -68,7 +68,7 @@ exclude_from_search: true
     <a href="{{ site.baseurl }}/data/" class="btn btn-primary btn-raised hidden-xs hidden-sm">Data Source Guides</a>
   </div>
   <div class="col-md-7">
-    <img src="{{ site.baseurl }}/images/test_smallest_data_icons.jpg" alt="Sample Apps" class="img-fill">
+    <img src="{{ site.cdnurl }}{{ site.baseurl }}/images/test_smallest_data_icons.jpg" alt="Sample Apps" class="img-fill">
   </div>
   <div class="col-sm-12 hidden-md hidden-lg hidden-xl">
     <p class="lead">Connect to your Data</p>


### PR DESCRIPTION
Resolves [FRONTEND-345](https://algorithmia.atlassian.net/browse/FRONTEND-345)

Images, stylesheets, and other assets served from the dev center can be routed through our CDN; just prepend `site.cdnurl` to a relative path (ex: `/developers/images/test_img.jpg`). Default CDN url is our prod CDN. However, I added a dev config to point the CDN at `localhost:9000`