### PR TITLE
FRONTEND-1756 Add support for canonical links

### DIFF
--- a/_config-docs-app.yml
+++ b/_config-docs-app.yml
@@ -1,0 +1,6 @@
+# This file contains config values that will be necessary when the docs app
+# stands on its own two feet, without being rendered by the web client.
+# Once the migration is complete we can simply move these values into the normal
+# config.
+
+setCanonicalLink: true

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,6 +10,9 @@
       {% assign author = site.data.authors[page.author] %}{% else %}{% assign author = site.owner %}
     {% endif %}
     {% include open-graph.html %}
+    {% if site.setCanonicalLink %}
+      <link rel="canonical" href="{{ page.url | absolute_url | replace:'index.html','' | no_trailing_slash }}">
+    {% endif %}
     <link rel="stylesheet" href="{{ site.cdnurl }}{{ site.baseurl }}/css/pygments-github.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/css/vendors.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/synapse/dist/scoped-synapse.css">

--- a/_plugins/no_trailing_slash.rb
+++ b/_plugins/no_trailing_slash.rb
@@ -1,0 +1,13 @@
+require 'uri'
+
+module Jekyll
+  module TrailingSlashFilter
+    def no_trailing_slash(url)
+      uri = URI(url)
+      uri.path = uri.path.chomp('/')
+      uri.to_s
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::TrailingSlashFilter)


### PR DESCRIPTION
Resolves [FRONTEND-1756](https://algorithmia.atlassian.net/browse/FRONTEND-1756)

Note: We can't actually enable the canonical links within Jekyll itself until the dev-center is officially removed from the web client, otherwise we'd have two canonical links set due to the one that the web client adds. I've added a temporary `_config-docs-app.yml` file that can be used when building/serving to enable canonical urls. I'll ensure this is set properly as part of the prod cluster deploy.

To see it in action:
```
bundle exec jekyll serve --config _config.yml,_config-dev.yml,_config-docs-app.yml
```