### PR TITLE
Remove Unused E2E Configs

### DIFF
--- a/e2e/config.js
+++ b/e2e/config.js
@@ -1,7 +1,5 @@
-const { E2E_USERNAME, E2E_PASSWORD, E2E_USE_TUNNEL } = process.env
+const { E2E_USE_TUNNEL } = process.env
 
-const USERNAME = E2E_USERNAME || 'e2e_test_acct'
-const PASSWORD = E2E_PASSWORD || 'allGR33Nplease!'
 const E2E_BASE_URL = process.env.E2E_BASE_URL || 'https://test.algorithmia.com'
 const E2E_RUN_IN_CLOUD = process.env.E2E_RUN_IN_CLOUD || false
 const LOCAL_PLATFORM = process.platform
@@ -10,8 +8,6 @@ const TUNNEL_ENABLED = E2E_RUN_IN_CLOUD && E2E_USE_TUNNEL
 const IS_RUNNING_E2E_LOCALLY = !E2E_RUN_IN_CLOUD || TUNNEL_ENABLED
 
 module.exports = {
-  USERNAME,
-  PASSWORD,
   E2E_BASE_URL,
   E2E_RUN_IN_CLOUD,
   LOCAL_PLATFORM,

--- a/e2e/tests/developers.spec.js
+++ b/e2e/tests/developers.spec.js
@@ -3,7 +3,7 @@ const { isEquivalent } = require('../utilities/url')
 const page = require('../pages/developerCenter')
 const gettingStartedPage = require('../pages/gettingStarted')
 const modelGuidesPage = require('../pages/modelGuides')
-const { E2E_BASE_URL, USERNAME } = require('../config')
+const { E2E_BASE_URL } = require('../config')
 
 describe('Developer Center', () => {
   describe('Deployment redirect', () => {


### PR DESCRIPTION
We no longer use `USERNAME` or `PASSWORD` anywhere in our dev-center E2E tests, removing to keep things tidy.