### PR TITLE
Fix Build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ variables:
   GIT_SUBMODULE_STRATEGY: recursive
 
 services:
-  - docker:18.09.7-dind
+  - docker:19.03.4-dind
 
 stages:
   - build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,6 @@
 image: docker:stable
 
 variables:
-  DOCKER_HOST: tcp://docker:2375
-  DOCKER_DRIVER: overlay2
   BUILDER_TAG: index.docker.io/algorithmiahq/dev-center:latest
   IMAGE_TAG: index.docker.io/algorithmiahq/dev-center:$CI_COMMIT_SHA
   GIT_SUBMODULE_STRATEGY: recursive

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ variables:
   GIT_SUBMODULE_STRATEGY: recursive
 
 services:
-  - docker:19.03.4-dind
+  - docker:19.03.4
 
 stages:
   - build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ variables:
   GIT_SUBMODULE_STRATEGY: recursive
 
 services:
-  - docker:19.03.4
+  - docker:18.09.7
 
 stages:
   - build


### PR DESCRIPTION
Now that the Docker socket is mounted directly into our runners, to support tests for system check, we can do away with our dind config.