### PR TITLE
Update p tag to prevent overflow

### DIFF
--- a/css/devcenter.css
+++ b/css/devcenter.css
@@ -11,6 +11,7 @@ body,
 #wrapper,
 .dev-center-content-container {
   flex-grow: 1;
+  max-width: 100%;
 }
 #wrapper {
   margin-top: 2rem;

--- a/css/vendors.css
+++ b/css/vendors.css
@@ -11,6 +11,10 @@ body {
   margin: 0
 }
 
+p {
+  word-break: break-word;
+}
+
 article,
 aside,
 details,

--- a/css/vendors.css
+++ b/css/vendors.css
@@ -11,7 +11,8 @@ body {
   margin: 0
 }
 
-p {
+p,
+code {
   word-break: break-word;
 }
 


### PR DESCRIPTION
While doing post deploy checks for the docs app, I noticed this URL was a bit funky on mobile:
https://algorithmia.com/developers/algorithm-development/algorithm-management-api

This adds a word break to prevent this text (`https://api.algorithmia.com/v1/algorithms/USERNAME/ALGORITHMNAME/versions`) from breaking the layout.