### PR TITLE
Fix Build (Once More)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,12 +1,14 @@
 image: docker:stable
 
 variables:
+  DOCKER_HOST: tcp://docker:2375
+  DOCKER_DRIVER: overlay2
   BUILDER_TAG: index.docker.io/algorithmiahq/dev-center:latest
   IMAGE_TAG: index.docker.io/algorithmiahq/dev-center:$CI_COMMIT_SHA
   GIT_SUBMODULE_STRATEGY: recursive
 
 services:
-  - docker:18.09.7
+  - docker:18.09.7-dind
 
 stages:
   - build


### PR DESCRIPTION
Reverts algorithmiaio/dev-center#229. Looks like the Docker socket was _unmounted_ from our shared runners, resulting in build failures.