### PR TITLE
Ensure the default brand title appears

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -35,7 +35,7 @@
           class="syn-page-header-divider vertical syn-ml-16 syn-mr-16 syn-hidden-lg syn-hidden-md syn-hidden-sm"
           id="before-brand-title"
         ></div>
-        <span class="syn-font-mono syn-caption syn-text-tertiary syn-mb-0 syn-hidden-lg syn-hidden-md syn-hidden-sm" id="brand-title">AI LAYER</span>
+        <span class="syn-font-mono syn-caption syn-text-tertiary syn-mb-0 syn-hidden-lg syn-hidden-md syn-hidden-sm" id="brand-title"></span>
       </div>
       <div>
         {% unless site.enterprise %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,6 +39,10 @@
     {% else %}
       {% assign webserver = "https://algorithmia.com" %}
     {% endif %}
+
+    <script>
+      window.__ENTERPRISE = {{ site.enterprise }}
+    </script>
   </head>
 
   <body>

--- a/js/stageCustomization.js
+++ b/js/stageCustomization.js
@@ -19,23 +19,24 @@
       .classList.remove('syn-hidden-lg', 'syn-hidden-md', 'syn-hidden-sm')
   }
 
-  function setBrandTitle(customizationVals) {
+  function setBrandTitle(customizationVals = []) {
+    const defaultBrandTitle = window.__ENTERPRISE ? '' : 'AI LAYER'
     const brandTitle =
-      customizationVals.find(val => val.keyname === 'brandTitle') || {}
+      customizationVals.find(val => val.keyname === 'brandTitle') || {
+        value: defaultBrandTitle
+      }
 
     if (brandTitle && brandTitle.value) {
       document.getElementById('brand-title').innerText = brandTitle.value
+      showBrandTitle()
     }
-
-    showBrandTitle()
   }
 
+  let customizationVals = []
   try {
-    const customizationVals = await getStageCustomization()
-
-    setBrandTitle(customizationVals)
+    customizationVals = await getStageCustomization()
   } catch (err) {
-    // If we can't get customization values, leave brand title as is.
-    showBrandTitle()
+    // If we can't get customization values, use default brand title.
   }
+  setBrandTitle(customizationVals)
 })()

--- a/js/stageCustomization.js
+++ b/js/stageCustomization.js
@@ -2,28 +2,32 @@
   async function getStageCustomization() {
     const response = await fetch('/v1/config/frontend', {
       headers: {
-        accept: 'application/json, text/plain, */*',
-      },
+        accept: 'application/json, text/plain, */*'
+      }
     })
 
     const customizationInfo = await response.json()
     return customizationInfo.results
   }
 
+  function showBrandTitle() {
+    document
+      .getElementById('brand-title')
+      .classList.remove('syn-hidden-lg', 'syn-hidden-md', 'syn-hidden-sm')
+    document
+      .getElementById('before-brand-title')
+      .classList.remove('syn-hidden-lg', 'syn-hidden-md', 'syn-hidden-sm')
+  }
+
   function setBrandTitle(customizationVals) {
-    const brandTitle = customizationVals.find(
-      val => val.keyname === 'brandTitle'
-    )
-    document.getElementById('brand-title').innerText =
-      brandTitle.value || 'AI LAYER'
-    if (brandTitle.value) {
-      document
-        .getElementById('brand-title')
-        .classList.remove('syn-hidden-lg', 'syn-hidden-md', 'syn-hidden-sm')
-      document
-        .getElementById('before-brand-title')
-        .classList.remove('syn-hidden-lg', 'syn-hidden-md', 'syn-hidden-sm')
+    const brandTitle =
+      customizationVals.find(val => val.keyname === 'brandTitle') || {}
+
+    if (brandTitle && brandTitle.value) {
+      document.getElementById('brand-title').innerText = brandTitle.value
     }
+
+    showBrandTitle()
   }
 
   try {
@@ -32,5 +36,6 @@
     setBrandTitle(customizationVals)
   } catch (err) {
     // If we can't get customization values, leave brand title as is.
+    showBrandTitle()
   }
 })()


### PR DESCRIPTION
After deploying to prod just now, I realized the brand title no longer rendered as a result of us not having a `brandTitle` value in the API config response. This change does two things:

• In cases where the call to API config fails (localhost), it just reveals the text that already exists in the header HTML.
• In cases where the call to API config succeeds, but there isn't a value for `brandTitle`, it just reveals the default value that exists in the HTML.