### PR TITLE
Feature/frontend 1888 - search.json

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -84,7 +84,7 @@
     <script type="text/javascript">
     $(function() {
       $('#search-query').lunrSearch({
-        indexUrl: '{{ site.baseurl }}/js/index.json',
+        indexUrl: '{{ site.baseurl }}/js/search.json',
         results:  '#search-results',
         template: '#search-results-template',
         titleMsg: '<h3><small>SEARCH RESULTS</small></h3>',
@@ -106,7 +106,7 @@
 
       // If there is a query string that will get picked up by lunrSearch
       //   then hide the page content by default
-      // Note: the search input field doesn't get set by lunrSearch until index.json loads
+      // Note: the search input field doesn't get set by lunrSearch until search.json loads
       var uri = new URI(window.location.search.toString());
       var queryString = uri.search(true);
       if (queryString.hasOwnProperty('q')) {

--- a/_layouts/synapse-default.html
+++ b/_layouts/synapse-default.html
@@ -93,7 +93,7 @@
   <script type="text/javascript">
   $(function() {
     $('#search-query').lunrSearch({
-      indexUrl: '{{ site.baseurl }}/js/index.json',
+      indexUrl: '{{ site.baseurl }}/js/search.json',
       results:  '#search-results',
       template: '#search-results-template',
       titleMsg: '<h3><small>SEARCH RESULTS</small></h3>',
@@ -115,7 +115,7 @@
 
     // If there is a query string that will get picked up by lunrSearch
     //   then hide the page content by default
-    // Note: the search input field doesn't get set by lunrSearch until index.json loads
+    // Note: the search input field doesn't get set by lunrSearch until search.json loads
     var uri = new URI(window.location.search.toString());
     var queryString = uri.search(true);
     if (queryString.hasOwnProperty('q')) {

--- a/_plugins/jekyll-lunr-search.rb
+++ b/_plugins/jekyll-lunr-search.rb
@@ -88,7 +88,7 @@ module Jekyll
         end
 
         FileUtils.mkdir_p(File.join(site.dest, @js_dir))
-        filename = File.join(@js_dir, 'index.json')
+        filename = File.join(@js_dir, 'search.json')
 
         total = {
           "docs" => @docs,
@@ -250,7 +250,7 @@ end
 module Jekyll
   module LunrJsSearch
     class SearchIndexFile < Jekyll::StaticFile
-      # Override write as the index.json index file has already been created
+      # Override write as the search.json index file has already been created
       def write(dest)
         true
       end

--- a/_plugins/jekyll-lunr-search.rb
+++ b/_plugins/jekyll-lunr-search.rb
@@ -76,6 +76,7 @@ module Jekyll
             "categories" => entry.categories,
             "tags" => entry.tags,
             "is_post" => entry.is_post,
+            "is_api_result" => entry.url.start_with?("/api/"),
             "body" => entry.body
           }
 


### PR DESCRIPTION
Resolves [FRONTEND-1888](https://algorithmia.atlassian.net/browse/FRONTEND-1888)

Turns out just about all of the functionality for this one was already done by the current Lunr Jekyll plugin implementation. 🎉 

I flipped the logic on the new boolean so that the API docs items are marked instead of the dev center ones, as it made the logic a tad simpler.

You can see the new JSON by running `npm run build` and looking inside of `sites/public/developers/js/search.json`