### PR TITLE
Frontend 1885 - Generate Page TOC from H2s

### DIFF
--- a/_includes/nav-menu.html
+++ b/_includes/nav-menu.html
@@ -53,6 +53,7 @@
           {% assign next_menu_level = include.menu_level | plus:1 %}
           {% include nav-menu.html menu_id=section.identifier menu_level=next_menu_level %}
         {% elsif page.menus[include.menu_id].url == section.url %}
+          {% assign toc_indent = include.menu_level | times:16 %}
           {% pagetoc %}
         {% endif %}
       </li>

--- a/_includes/nav-menu.html
+++ b/_includes/nav-menu.html
@@ -6,7 +6,7 @@
   <ul slot-scope="{ toggle, openSection }"
     class="syn-flex direction-column flex-item-grow
       {% if include.menu_level == 0 %}syn-overflow-hidden
-      {% else %}syn-width-full  syn-overflow-hidden-x syn-scrollable-y{% endif %}">
+      {% else %}syn-width-full syn-overflow-hidden-x syn-scrollable-y{% endif %}">
     {% for section in site.menus[include.menu_id] %}
       {% assign section_active = page.menus[section.identifier] %}
       {% assign checking = section %}
@@ -52,8 +52,11 @@
         {% if section.children %}
           {% assign next_menu_level = include.menu_level | plus:1 %}
           {% include nav-menu.html menu_id=section.identifier menu_level=next_menu_level %}
+        {% elsif page.menus[include.menu_id].url == section.url %}
+          {% pagetoc %}
         {% endif %}
       </li>
     {% endfor %}
   </ul>
 </side-nav-menu>
+

--- a/_plugins/page_toc.rb
+++ b/_plugins/page_toc.rb
@@ -13,8 +13,8 @@ module Jekyll
       doc = Nokogiri::HTML(content)
       doc.css('h2').each do |heading|
         html << "<li class=\"syn-overflow-hidden allow-wrap\">
-          <a class=\"flex-item-no-shrink syn-flex justify-space-between align-center syn-text-secondary syn-caption syn-mb-0\" href=\"\##{heading["id"]}\">
-            #{heading.text}
+          <a class=\"flex-item-no-shrink syn-flex justify-space-between align-center syn-text-secondary\" href=\"\##{heading["id"]}\">
+            <span class=\"syn-caption syn-mb-0\">#{heading.text}</span>
           </a>
         </li>"
       end

--- a/_plugins/page_toc.rb
+++ b/_plugins/page_toc.rb
@@ -14,7 +14,7 @@ module Jekyll
       doc.css('h2').each do |heading|
         html << "<li class=\"syn-overflow-hidden allow-wrap\">
           <a class=\"flex-item-no-shrink syn-flex justify-space-between align-center syn-text-secondary\" href=\"\##{heading["id"]}\">
-            <span class=\"syn-caption syn-mb-0\">#{heading.text}</span>
+            <div class=\"syn-ml-#{context['toc_indent']}\">#{heading.text}</div>
           </a>
         </li>"
       end

--- a/_plugins/page_toc.rb
+++ b/_plugins/page_toc.rb
@@ -1,0 +1,27 @@
+require "nokogiri"
+
+module Jekyll
+  class PageTocTag < Liquid::Tag
+
+    def initialize(tag_name, markdown, options)
+      super
+    end
+
+    def render(context)
+      content = context['page']['content']
+      html = ['<ul class="syn-width-full syn-overflow-hidden-x syn-scrollable-y">']
+      doc = Nokogiri::HTML(content)
+      doc.css('h2').each do |heading|
+        html << "<li class=\"syn-overflow-hidden allow-wrap\">
+          <a class=\"flex-item-no-shrink syn-flex justify-space-between align-center syn-text-secondary syn-caption syn-mb-0\" href=\"\##{heading["id"]}\">
+            #{heading.text}
+          </a>
+        </li>"
+      end
+      html << '</ul>'
+      html.join("\n")
+    end
+  end
+end
+
+Liquid::Template.register_tag('pagetoc', Jekyll::PageTocTag)


### PR DESCRIPTION
Resolves [FRONTEND-1885](https://algorithmia.atlassian.net/browse/FRONTEND-1885) and [FRONTEND-1886](https://algorithmia.atlassian.net/browse/FRONTEND-1886), because it turned out to be much simpler to just render the heading links instead of generating the list somewhere else.