### PR TITLE
Feature/frontend 1985 - Language Preference

### DIFF
--- a/src/components/CodeSample.vue
+++ b/src/components/CodeSample.vue
@@ -88,7 +88,7 @@ export default {
       setCookieValue(
         Cookie.preferredLanguage,
         newLanguage,
-        { daysUntilExpire: 365 }
+        { path: '/', daysUntilExpire: 365 }
       )
     },
     setLanguage(newLanguage) {

--- a/src/components/CodeSample.vue
+++ b/src/components/CodeSample.vue
@@ -3,7 +3,12 @@
     <div class="syn-code-block-header syn-flex justify-space-between align-center">
       <span class="syn-overline syn-text-light-primary syn-mb-0 syn-ml-16 syn-mr-8">{{title}}</span>
       <div class="syn-ma-8 syn-flex align-center">
-        <select class="syn-code-language-selector syn-mr-8" v-if="languages.length > 1" v-model="selectedLanguage">
+        <select
+          class="syn-code-language-selector syn-mr-8"
+          v-if="languages.length > 1"
+          :value="selectedLanguage"
+          @change="onSelectChange($event.target.value)"
+        >
           <option v-for="language in languages" :key="language" :value="language">
             {{ language }}
           </option>
@@ -23,7 +28,10 @@
 </template>
 
 <script>
+import { mapActions, mapGetters } from 'vuex'
 import { copyToClipboard } from '../utilities/clipboard'
+import { setCookieValue } from '../utilities/cookie'
+import { Cookie } from '../enums/Cookie'
 
 export default {
   name: 'CodeSample',
@@ -39,6 +47,7 @@ export default {
       selectedLanguage: ''
     }
   },
+  computed: mapGetters(['preferredLanguage']),
   methods: {
     copySample() {
       const copyText = this.$refs.codeContent.querySelector(`figure.${this.selectedLanguage}`).innerText
@@ -72,16 +81,44 @@ export default {
           sample.hidden = true
         }
       })
-    }
+    },
+    onSelectChange(newLanguage) {
+      this.setLanguage(newLanguage)
+      this.setPreferredLanguage(newLanguage)
+      setCookieValue(
+        Cookie.preferredLanguage,
+        newLanguage,
+        { daysUntilExpire: 365 }
+      )
+    },
+    setLanguage(newLanguage) {
+      this.selectedLanguage = newLanguage
+    },
+    hasLanguage(language) {
+      return this.languages.includes(language)
+    },
+    ...mapActions(['setPreferredLanguage'])
   },
   mounted() {
     // Wait to check for languages till mounted
     this.languages = this.processLanguages()
-    if (this.languages.length) this.selectedLanguage = this.languages[0]
+
+    if (!this.languages.length) return
+
+    this.setLanguage(
+      this.hasLanguage(this.preferredLanguage)
+        ? this.preferredLanguage
+        : this.languages[0]
+    )
   },
   watch: {
     selectedLanguage(newVal, oldVal) {
       if (newVal !== oldVal) this.showSelectedLanguage()
+    },
+    preferredLanguage(newVal, oldVal) {
+      if (this.hasLanguage(newVal)) {
+        this.setLanguage(newVal)
+      }
     }
   }
 }

--- a/src/enums/Cookie.js
+++ b/src/enums/Cookie.js
@@ -1,0 +1,3 @@
+export const Cookie = {
+  preferredLanguage: 'user-preferred-language'
+}

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,9 @@ import SearchInput from './components/SearchInput'
 import { getCurrentUser } from './api/user'
 import { setupPage } from './utilities/setupPage'
 import store from './store/index'
+import { readCookie } from './utilities/cookie'
+import { Cookie } from './enums/Cookie'
+import { mapActions } from 'vuex'
 
 Vue.component('codeSample', CodeSample)
 Vue.component('sideNavMenu', SideNavMenu)
@@ -23,13 +26,24 @@ const app = new Vue({
   data: {
     user: null
   },
-  async mounted() {
-    try {
-      this.user = await getCurrentUser()
-    } catch (err) {
-      console.error(err.message)
+  methods: {
+    ...mapActions(['setPreferredLanguage']),
+    async loadUser() {
+      try {
+        this.user = await getCurrentUser()
+      } catch (err) {
+        console.error(err.message)
+      }
+    },
+    initStateFromCookies() {
+      this.setPreferredLanguage(
+        readCookie(Cookie.preferredLanguage) || ''
+      )
     }
-
+  },
+  mounted() {
+    this.loadUser()
+    this.initStateFromCookies()
     setupPage(this.user)
   }
 })

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ import { setupPage } from './utilities/setupPage'
 import store from './store/index'
 import { readCookie } from './utilities/cookie'
 import { Cookie } from './enums/Cookie'
-import { mapActions } from 'vuex'
+import { mapActions, mapGetters } from 'vuex'
 
 Vue.component('codeSample', CodeSample)
 Vue.component('sideNavMenu', SideNavMenu)
@@ -25,6 +25,9 @@ const app = new Vue({
   store,
   data: {
     user: null
+  },
+  computed: {
+    ...mapGetters(['showSearchResults'])
   },
   methods: {
     ...mapActions(['setPreferredLanguage']),

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,11 +1,13 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
 import { search } from './search'
+import { user } from './user'
 
 Vue.use(Vuex)
 
 export default new Vuex.Store({
   modules: {
     search,
+    user,
   },
 })

--- a/src/store/user.js
+++ b/src/store/user.js
@@ -1,0 +1,22 @@
+import Vue from 'vue'
+
+export const user = {
+  state: {
+    preferences: {
+      language: ''
+    }
+  },
+  mutations: {
+    SET_PREFERRED_LANGUAGE: (state, payload) => {
+      Vue.set(state.preferences, 'language', payload.language)
+    },
+  },
+  actions: {
+    setPreferredLanguage({ commit }, language) {
+      commit('SET_PREFERRED_LANGUAGE', { language })
+    },
+  },
+  getters: {
+    preferredLanguage: state => state.preferences.language,
+  }
+}

--- a/src/utilities/cookie.js
+++ b/src/utilities/cookie.js
@@ -1,0 +1,38 @@
+import { isClient } from './env'
+
+export const getCookieValueFrom = (cookie) => (name) => {
+  const value = cookie.match(`(^|;)\\s*${name}\\s*=\\s*([^;]+)`)
+  if (value) {
+    return value.pop() || ''
+  }
+  return ''
+}
+
+export const readCookie = isClient()
+  ? getCookieValueFrom(document.cookie)
+  : _ => undefined
+
+export const setCookieValue = (name, value, opts) => {
+  if (!isClient()) return
+
+  let extra = ''
+  if (opts.daysUntilExpire) {
+    const date = new Date()
+    date.setTime(date.getTime() + opts.daysUntilExpire * 24 * 60 * 60 * 1000)
+    extra += `; expires=${date.toUTCString()}`
+  }
+  if (opts.path) {
+    extra += `; path=${opts.path}`
+  }
+  return (document.cookie = `${name}=${value}${extra}`)
+}
+
+export const deleteCookie = (name, path) => {
+  if (!isClient()) return
+
+  let extra = ''
+  if (path) {
+    extra += `; path=${path}`
+  }
+  return (document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:01 GMT${extra}`)
+}

--- a/src/utilities/env.js
+++ b/src/utilities/env.js
@@ -1,0 +1,7 @@
+export const isClient = () => {
+  try {
+    return window !== undefined && document !== undefined
+  } catch {
+    return false
+  }
+}

--- a/test/user.spec.ts
+++ b/test/user.spec.ts
@@ -1,0 +1,70 @@
+import Vue from 'vue'
+import * as Vuex from 'vuex'
+import { expect } from 'chai'
+import 'mocha'
+import { user } from '../src/store/user'
+import nock from 'nock'
+import sinon from 'sinon'
+
+Vue.use(Vuex)
+
+const index = {
+  docs: {},
+  index: {
+    version: '2.3.8',
+    fields: [],
+    fieldVectors: [],
+    invertedIndex: [],
+    pipeline: []
+  }
+}
+
+nock(/.+/)
+  .get('/developers/js/search.json')
+  .reply(200, index)
+
+const store: any = new Vuex.Store({
+  modules: { user },
+})
+
+describe('Vuex: Search Store', () => {
+
+  describe('mutations', () => {
+    it('should set the correct state for SET_PREFERRED_LANGUAGE', () => {
+      store.state.user.preferences.language = 'spanish'
+      store.commit('SET_PREFERRED_LANGUAGE', { language: 'german' })
+      expect(store.state.user.preferences.language).to.equal('german')
+    })
+  })
+
+  describe('actions', () => {
+    const commitSpy = sinon.spy()
+    const dispatchSpy = sinon.spy()
+    const rootState = { stage: {} }
+    const context: any = {
+      commit: commitSpy,
+      dispatch: dispatchSpy,
+      rootState,
+      getters: store.getters
+    }
+
+    afterEach(() => {
+      commitSpy.resetHistory()
+      dispatchSpy.resetHistory()
+    })
+
+    it('should commit correct mutations for setPreferredLanguage', () => {
+      user.actions.setPreferredLanguage(context, 'italian')
+      expect(commitSpy.args).to.deep.equal([
+        ['SET_PREFERRED_LANGUAGE', { language: 'italian' }],
+      ])
+    })
+  })
+
+  describe('getters', () => {
+    it('should return the correct state for preferredLanguage', () => {
+      store.state.user.preferences.language = 'portuguese'
+      expect(store.getters.preferredLanguage).to.equal('portuguese')
+    })
+  })
+})


### PR DESCRIPTION
Resolves [FRONTEND-1985](https://algorithmia.atlassian.net/browse/FRONTEND-1985).

This is best evaluated on [/developers/api/data-api-specification/](http://localhost:4000/developers/api/data-api-specification/), as there are a ton of code snippets on that page and not all of them support the same languages.

Whenever you update a language, the selected language in all other code snippets is only updated if those code snippets also have that language, otherwise they're left alone. You can see this by selecting `Node` as the language since some of the snippets don't have Node as an option.

