### PR TITLE
Prevent side nav toggle on submenu clicks

### DIFF
--- a/_includes/nav-menu.html
+++ b/_includes/nav-menu.html
@@ -34,6 +34,8 @@
           title="{{ section.title }}"
           {% if section.children %}
             @click.prevent.stop="toggle('{{ section.identifier }}')"
+          {% else %}
+            @click.stop
           {% endif %}
           id="{{ section.identifier }}-link">
           <div class="{% if section.icon %}syn-flex align-center{% endif %}

--- a/_layouts/synapse-default.html
+++ b/_layouts/synapse-default.html
@@ -61,7 +61,7 @@
       </div>
       <div class="syn-page-header-nav syn-flex direction-column syn-overflow-hidden" @click="toggleSideMenu">
         <div class="syn-mt-24 syn-ml-16 syn-mb-24 syn-mr-16 flex-item-no-shrink">
-          <a href="/">
+          <a @click.stop href="/">
             {% if site.isLocalDev or site.enterprise %}
             <img
               src="{{ site.baseurl }}/images/algo-purple.svg"

--- a/_plugins/page_toc.rb
+++ b/_plugins/page_toc.rb
@@ -14,7 +14,7 @@ module Jekyll
       doc = Nokogiri::HTML(content)
       doc.css('h2').each do |heading|
         html << "<li class=\"sub-nav-item syn-overflow-hidden allow-wrap\">
-          <a class=\"sub-nav-link flex-item-no-shrink syn-flex justify-space-between align-center syn-text-secondary\" href=\"\##{heading["id"]}\">
+          <a @click.stop class=\"sub-nav-link flex-item-no-shrink syn-flex justify-space-between align-center syn-text-secondary\" href=\"\##{heading["id"]}\">
             <div class=\"sub-nav-text syn-ml-#{context['toc_indent']}\">#{heading.text}</div>
           </a>
         </li>"


### PR DESCRIPTION
Fixes an issue Ryan noticed earlier this morning in the side nav where the toggle state would change when links within submenus were clicked. This also makes an update for the hash menus and the logo as well.