### PR TITLE
Update e2e tests after recent merges

### DIFF
--- a/e2e/pages/gettingStarted.js
+++ b/e2e/pages/gettingStarted.js
@@ -26,7 +26,7 @@ class GettingStartedPage extends DeveloperCenterPage {
   }
 
   get notice() {
-    return $('.syn-code-block:nth-of-type(2) + p')
+    return $('.syn-code-block:nth-of-type(4) + div > p')
   }
 
   open() {

--- a/e2e/tests/developers.spec.js
+++ b/e2e/tests/developers.spec.js
@@ -126,8 +126,8 @@ describe("Developer Center", () => {
       page.open()
       page.hamburgerMenu.click()
       browser.refresh()
-      browser.waitUntil(() => page.isSideNavOpen)
-      assert(page.isSideNavOpen)
+      browser.waitUntil(() => !page.isSideNavOpen)
+      assert(!page.isSideNavOpen)
     })
   })
 


### PR DESCRIPTION
After deploying to test, I ran the e2e tests and had two failures due to recent code changes. All tests are passing now for both Windows and Mac.