### PR TITLE
Fix lightbox

### DIFF
--- a/jest/__snapshots__/ImagePopout.spec.js.snap
+++ b/jest/__snapshots__/ImagePopout.spec.js.snap
@@ -7,7 +7,7 @@ exports[`ImagePopout should close modal when modal image is clicked 1`] = `
     <!---->
   </div>
   <div class="syn-modal" align-center="">
-    <div class="syn-modal-card no-padding large card-view-sm">
+    <div class="syn-modal-card no-padding large card-view-sm fit-content">
       <!---->
       <div><img></div>
     </div>
@@ -24,7 +24,7 @@ exports[`ImagePopout should display caption if provided 1`] = `
     </div>
   </div>
   <div class="syn-modal" align-center="">
-    <div class="syn-modal-card no-padding large card-view-sm">
+    <div class="syn-modal-card no-padding large card-view-sm fit-content">
       <!---->
       <div><img></div>
     </div>
@@ -39,7 +39,7 @@ exports[`ImagePopout should fill slot in container and modal with image provided
     <!---->
   </div>
   <div class="syn-modal" align-center="">
-    <div class="syn-modal-card no-padding large card-view-sm">
+    <div class="syn-modal-card no-padding large card-view-sm fit-content">
       <!---->
       <div><img></div>
     </div>
@@ -54,7 +54,7 @@ exports[`ImagePopout should open modal when image is clicked 1`] = `
     <!---->
   </div>
   <div class="syn-modal open" align-center="">
-    <div class="syn-modal-card no-padding large card-view-sm">
+    <div class="syn-modal-card no-padding large card-view-sm fit-content">
       <!---->
       <div><img></div>
     </div>

--- a/src/components/ImagePopout.vue
+++ b/src/components/ImagePopout.vue
@@ -8,7 +8,7 @@
         {{caption}}
       </div>
     </div>
-    <modal v-model="modalOpen" no-padding hide-close-btn large align-center card-view-sm>
+    <modal v-model="modalOpen" no-padding hide-close-btn large align-center card-view-sm fit-content>
       <div @click="modalOpen = false">
         <slot></slot>
       </div>


### PR DESCRIPTION
Noticed that our lightbox/img popout had formatting issues with narrow images. This ensures that there's no extra whitespace in the popout modal.

* Be sure to rebuild vue/synapse!
* Relies on changes in https://github.com/algorithmiaio/synapse/pull/197