### PR TITLE
Remove "robots: none" from all docs pages

### DIFF
--- a/_pages/algorithm-development/advanced-algorithm-development/local-development.md
+++ b/_pages/algorithm-development/advanced-algorithm-development/local-development.md
@@ -9,7 +9,6 @@ show_related: true
 author: jon_peck
 image:
     teaser: /post_images/local_development/local_development.png
-robots: none
 ---
 
 <img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/local_development/local_development_wide.png" class="img-fill">

--- a/_pages/algorithm-development/advanced-algorithm-development/multithreading.md
+++ b/_pages/algorithm-development/advanced-algorithm-development/multithreading.md
@@ -10,7 +10,6 @@ show_related: true
 author: jon_peck
 image:
     teaser: /post_images/multithreading/multithreading.png
-robots: none
 ---
 
 <img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/multithreading/multithreading_wide.png" class="img-fill">

--- a/_pages/algorithm-development/algorithm-errors.md
+++ b/_pages/algorithm-development/algorithm-errors.md
@@ -11,7 +11,6 @@ image:
 permalink: /algorithm-development/algorithm-errors/
 redirect_from:
   - /algorithm-development/algorithm-basics/algorithm-errors/
-robots: none
 ---
 
 On Algorithmia you can develop in several different programming languages. Being language agnostic gives you access to libraries and functions in other languages that would not be possible otherwise. For example, you can call a NodeJS library inside of a Python algorithm. All you have to do is to write a wrapper algorithm for that library.

--- a/_pages/algorithm-development/languages/r.md
+++ b/_pages/algorithm-development/languages/r.md
@@ -8,7 +8,6 @@ show_related: true
 author: steph_kim
 image:
     teaser: /language_logos/r.svg
-robots: none
 ---
 
 Before you get started learning about R algorithm development, make sure you go through our <a href="{{site.baseurl}}/algorithm-development/algorithm-basics/your-first-algo">Getting Started Guide</a> to learn how to create your first algorithm, understand permissions available, versioning, using the CLI, and more.

--- a/_pages/algorithm-development/languages/scala.md
+++ b/_pages/algorithm-development/languages/scala.md
@@ -8,7 +8,6 @@ show_related: true
 author: steph_kim
 image:
     teaser: /language_logos/scala.svg
-robots: none
 ---
 
 Before you get started learning about Scala algorithm development, make sure you go through our <a href="{{site.baseurl}}/algorithm-development/algorithm-basics/your-first-algo">Getting Started Guide</a> to learn how to create your first algorithm, understand permissions available, versioning, using the CLI, and more.

--- a/_pages/algorithm-development/markdown-syntax.md
+++ b/_pages/algorithm-development/markdown-syntax.md
@@ -11,7 +11,6 @@ image:
 permalink: /algorithm-development/markdown-syntax/
 redirect_from:
   - /algorithm-development/algorithm-basics/markdown-syntax/
-robots: none
 ---
 
 When you are ready to write the documentation for your algorithm under the "Docs" tab on your algorithm's page, you can use markdown to make your documentation clear.

--- a/_pages/clients/android.md
+++ b/_pages/clients/android.md
@@ -11,7 +11,6 @@ image:
 repository: https://github.com/algorithmiaio/algorithmia-android
 redirect_from:
   - /application-development/client-guides/android/
-robots: none
 ---
 
 This guide provides a walk-through of how to use the official Algorithmia Android Client to call algorithms and manage your data through the Algorithmia platform.

--- a/_pages/clients/cli.md
+++ b/_pages/clients/cli.md
@@ -10,7 +10,6 @@ image:
 redirect_from:
   - /application-development/client-guides/cli/
   - /application-development/guides/cli/
-robots: none
 ---
 
 The Algorithmia CLI is a cross-platform tool for interfacing with algorithms and the Algorithmia Data API.

--- a/_pages/clients/curl.md
+++ b/_pages/clients/curl.md
@@ -11,7 +11,6 @@ redirect_from:
   - /application-development/client-guides/cURL/
   - /application-development/client-guides/curl/
   - /application-development/guides/curl/
-robots: none
 ---
 
 {% include video-responsive.html height="560" width="315" url="https://www.youtube.com/embed/VIxCEFFmpWQ" %}

--- a/_pages/clients/net_c_sharp.md
+++ b/_pages/clients/net_c_sharp.md
@@ -8,7 +8,6 @@ tags: [clients]
 show_related: true
 image:
     teaser: /language_logos/c_sharp_net.svg
-robots: none
 ---
 
 We now have an early version of a native .NET client for calling algorithms and interacting with our Data APIs.  This guide will give you a walkthrough of how to use the new .NET client.  The client is open-sourced and available on [GitHub](https://github.com/algorithmiaio/algorithmia-c-sharp).

--- a/_pages/clients/node.md
+++ b/_pages/clients/node.md
@@ -14,7 +14,6 @@ redirect_from:
   - /application-development/guides/node/
   - /node/
   - /application-development/lang-guides/node/
-robots: none
 ---
 
 This guide provides a walk-through of how to use the official Algorithmia Node.js Client to call algorithms and manage data through the Algorithmia platform.

--- a/_pages/clients/ruby.md
+++ b/_pages/clients/ruby.md
@@ -16,7 +16,6 @@ redirect_from:
   - /application-development/client-guides/ruby/
   - /application-development/guides/ruby/
   - /application-development/lang-guides/ruby/
-robots: none
 ---
 
 This guide provides a walk-through of how to use the official Algorithmia Ruby client to call algorithms and manage your data

--- a/_pages/clients/rust.md
+++ b/_pages/clients/rust.md
@@ -17,7 +17,6 @@ redirect_from:
   - /application-development/guides/rust/
   - /application-development/lang-guides/rust/examples/
   - /application-development/lang-guides/rust/
-robots: none
 ---
 
 This guide provides a walk-through of how to use the official Algorithmia Rust Client to call algorithms and manage your data

--- a/_pages/clients/scala.md
+++ b/_pages/clients/scala.md
@@ -15,7 +15,6 @@ redirect_from:
   - /application-development/client-guides/scala/
   - /application-development/guides/scala/
   - /application-development/lang-guides/scala/
-robots: none
 ---
 
 This guide provides a walk-through of how to use the official Algorithmia Scala Client to call algorithms and manage data through the Algorithmia platform.

--- a/_pages/clients/swift.md
+++ b/_pages/clients/swift.md
@@ -11,7 +11,6 @@ repository: https://github.com/algorithmiaio/algorithmia-swift
 redirect_from:
   - /application-development/client-guides/swift/
   - /lang/swift/
-robots: none
 ---
 
 This guide provides a walk-through of how to use the official Algorithmia Swift Client to call algorithms and manage your data through the Algorithmia platform.

--- a/_pages/data/dynamodb.md
+++ b/_pages/data/dynamodb.md
@@ -9,7 +9,6 @@ show_related: true
 author: steph_kim, jon_peck
 image:
     teaser: /language_logos/dynamo_db_image.png 
-robots: none
 ---
 
 Algorithms can easily access DynamoDB using the [boto3](https://aws.amazon.com/sdk-for-python/) package and securely storing their access credentials in a data collection.

--- a/_pages/data/mssqlserver.md
+++ b/_pages/data/mssqlserver.md
@@ -9,7 +9,6 @@ show_related: true
 author: jon_peck
 image:
     teaser: /language_logos/mssql.png 
-robots: none
 ---
 
 If your algorithm needs to read or write data from a MsSqlServer database, you can do so by either making the database connection directly from within your own code, or by using our helper algorithms.

--- a/_pages/data/snowflake.md
+++ b/_pages/data/snowflake.md
@@ -9,7 +9,6 @@ show_related: true
 author: jon_peck
 image:
     teaser: /language_logos/snowflake_computing.png 
-robots: none
 ---
 
 Algorithms can easily access databases hosted by Snowflake Computing using the [Snowflake Connector for Python](https://pypi.org/project/snowflake-connector-python/) .

--- a/_pages/getting-started.md
+++ b/_pages/getting-started.md
@@ -9,7 +9,6 @@ image:
   teaser: /icons/hexicon_desktop_purple.svg
 redirect_from:
   - /basics/getting-started/
-robots: none
 ---
 
 Welcome to Getting Started with the Algorithmia API. This guide will show you how to call an algorithm via our API in a few lines of code using our supported language clients.

--- a/_pages/integrations/cloudinary.md
+++ b/_pages/integrations/cloudinary.md
@@ -7,7 +7,6 @@ tags: [integrations]
 show_related: true
 image:
     teaser: /language_logos/cloudinary.svg
-robots: none
 ---
 
 Cloudinary automates the process of manipulating and delivering images and videos, optimized for every viewing context, through a programmatic API. Now you can send your Cloudinary images through any of Algorithmia's machine learning models, to transform or extract information from them, then easily re-insert images into Cloudinary.

--- a/_pages/integrations/dataworld.md
+++ b/_pages/integrations/dataworld.md
@@ -7,7 +7,6 @@ tags: [integrations]
 show_related: true
 image:
     teaser: /language_logos/dataworld.svg
-robots: none
 ---
 
 *Data.World* has an amazing marketplace of datasets available. It’s very easy to consume and publish new datasets via Algorithmia. The data.world team has published four helper utility algorithms that you can take advantage of in your own algorithms.  Since you can compose, chain, and pipe output to multiple algorithms together easily, you’ll have so many possibilities for processing datasets available from data.world.

--- a/_pages/integrations/googlesheets.md
+++ b/_pages/integrations/googlesheets.md
@@ -7,7 +7,6 @@ tags: [integrations]
 show_related: true
 image:
     teaser: /language_logos/googlesheets.png
-robots: none
 ---
 
 [Google Sheets](http://sheets.google.com) is a collaborative, extensible online spreadsheet tool (similar to MS Excel).

--- a/_pages/integrations/h2o.md
+++ b/_pages/integrations/h2o.md
@@ -7,7 +7,6 @@ tags: [algo-model-guide, integrations]
 show_related: true
 image:
     teaser: /language_logos/h2o.svg
-robots: none
 ---
 
 Once you've trained your *H2O* models, deploy them to Algorithmia to get all the benefits of elastic, scalable, serverless machine learning hosting! Deploying your models is easy, and you don't need to worry about managing or maintaining servers.

--- a/_pages/integrations/twitter.md
+++ b/_pages/integrations/twitter.md
@@ -12,7 +12,6 @@ author: justin_gage
 repository: https://github.com/algorithmiaio/integrations/tree/master/Twitter/DataAccess
 blog: https://blog.algorithmia.com/how-to-get-all-different-types-of-twitter-data/
 thumbnail: /images/language_logos/twitter.svg
-robots: none
 ---
 
 Twitter isn’t just my favorite way to waste time when my boss isn’t looking -- it’s also a powerful data source for understanding what your customers are saying about you. Getting access to Twitter data for analysis is easy with the Algorithmia platform.

--- a/_pages/model-deployment/allennlp.md
+++ b/_pages/model-deployment/allennlp.md
@@ -11,7 +11,6 @@ redirect_from:
   - /algorithm-development/model-guides/allennlp/
 image:
     teaser: /language_logos/allennlp.png
-robots: none
 ---
 
 Welcome to deploying your <a href="https://allennlp.org/">AllenNLP</a> model on Algorithmia!

--- a/_pages/model-deployment/caffe.md
+++ b/_pages/model-deployment/caffe.md
@@ -11,7 +11,6 @@ redirect_from:
   - /algorithm-development/model-guides/caffe/
 image:
     teaser: /language_logos/caffe.png
-robots: none
 ---
 
 

--- a/_pages/model-deployment/pytorch.md
+++ b/_pages/model-deployment/pytorch.md
@@ -10,7 +10,6 @@ redirect_from:
   - /algorithm-development/model-guides/pytorch/
 image:
     teaser: /language_logos/pytorch.png
-robots: none
 ---
 
 Welcome to deploying your <a href="http://pytorch.org/">PyTorch</a> model on Algorithmia!

--- a/_pages/model-deployment/rusty-machine.md
+++ b/_pages/model-deployment/rusty-machine.md
@@ -11,7 +11,6 @@ redirect_from:
   - /algorithm-development/model-guides/rusty-machine/
 image:
     teaser: /language_logos/algo_icon.svg
-robots: none
 ---
 
 Welcome to deploying your <a href="https://github.com/AtheMathmo/rusty-machine">Rusty Machine</a> model on Algorithmia!

--- a/_pages/model-deployment/xgboost.md
+++ b/_pages/model-deployment/xgboost.md
@@ -11,7 +11,6 @@ redirect_from:
   - /algorithm-development/model-guides/xgboost/
 image:
     teaser: /language_logos/xgboost.png
-robots: none
 ---
 
 Welcome to deploying your <a href="http://xgboost.readthedocs.io/en/latest/">XGBoost</a> model on Algorithmia!

--- a/_pages/platform.md
+++ b/_pages/platform.md
@@ -7,7 +7,6 @@ redirect_from:
  - /basics/
  - /application-development/basic-guides/
  - /basics/algorithm_basics/
-robots: none
 ---
 
 {% assign basics_tags = "basics" | split:"|" %}

--- a/_pages/platform/permissions.md
+++ b/_pages/platform/permissions.md
@@ -11,7 +11,6 @@ image:
 permalink: /platform/permissions/
 redirect_from:
   - /basics/permissions/
-robots: none
 ---
 
 

--- a/_pages/platform/teams.md
+++ b/_pages/platform/teams.md
@@ -12,7 +12,6 @@ permalink: /platform/organizations/
 redirect_from:
   - /teams/
   - /basics/organization_profiles/
-robots: none
 ---
 
 If you are looking to share algorithms privately or publish algorithms on behalf of an organization, such as a university, private company, or open source community, then our teams and organizations feature is what you are looking for. 

--- a/_pages/release_notes.md
+++ b/_pages/release_notes.md
@@ -6,7 +6,6 @@ tags: [alg-dev-getting-started, app-dev-getting-started]
 show_related: true
 image:
     teaser: /icons/algo.svg
-robots: none
 ---
 
 # Q1 2020 Enterprise Release Notes #

--- a/_pages/tutorials.md
+++ b/_pages/tutorials.md
@@ -4,7 +4,6 @@ layout: article_page
 title:  "Tutorials"
 show_related: false
 excerpt: "Tutorials. Sample apps and recipes to help you learn whats going on."
-robots: none
 ---
 
 Here you will find sample apps and recipes (which are a little bit different).


### PR DESCRIPTION
For some reason, a huge number of pages in the docs were marked "robots: none". This results in a robots none meta tag being added to those pages, which prevents indexing by search engines. This can be verified by trying (unsuccessfully) to find those pages using google.

This PR fixes this on all pages. Docs might be the MOST important thing to be google-able.