### PR TITLE
Updated Github Action links in CI/CD documentation

### DIFF
--- a/_pages/algorithm-development/ci-cd.md
+++ b/_pages/algorithm-development/ci-cd.md
@@ -15,6 +15,13 @@ Continuous Integration & Deployment are standard practice in the world of softwa
 
 Algorithmia supports deployment and redeployment via the [the Algorithmia API]({{site.baseurl}}/algorithm-development/algorithm-management), and this is easily integrated into CI/CD tools such as Jenkins or GitHub Actions. With Algorithmia and your favorite CI/CD tool, your models are deployed as soon as they are ready, and can be instantly redeployed whenever an approved retrained model is available.
 
-<a href="https://github.com/algorithmiaio/model-deployment/tree/master/jenkins_deploy_algorithmia" class="btn btn-default btn-primary"><i class="fa fa-github" aria-hidden="true"></i> TRY IT OUT: Jenkins</a>
+For setting up an automated workflow in your **Algoritm repository**, you can check out the following examples with Jenkins or Github Actions:
 
-<a href="https://github.com/algorithmiaio/model-deployment/tree/master/githubactions_deploy_algorithmia" class="btn btn-default btn-primary"><i class="fa fa-github" aria-hidden="true"></i> TRY IT OUT: GitHub Actions</a>
+<a href="https://github.com/algorithmiaio/githubactions-modeldeployment-deprecated/tree/master/jenkins_deploy_algorithmia" class="btn btn-default btn-primary"><i class="fa fa-github" aria-hidden="true"></i> TRY IT OUT: Jenkins</a>
+
+<a href="https://github.com/algorithmiaio/githubactions-modeldeployment-deprecated/tree/master/githubactions_deploy_algorithmia" class="btn btn-default btn-primary"><i class="fa fa-github" aria-hidden="true"></i> TRY IT OUT: GitHub Actions in Algorithm Repo</a>
+
+
+For setting up an automated workflow in your **machine learning repository at Github**, where you may be using a Jupyter notebook to train/test/export your ML model or checking-in your saved model; you can check out our Github Action that automates your model and algorithm code deployment once you push your changes to your model development repo:
+
+<a href="https://github.com/algorithmiaio/algorithmia-modeldeployment-action" class="btn btn-default btn-primary"><i class="fa fa-github" aria-hidden="true"></i> TRY IT OUT: GitHub Actions in Model Development Repo</a>

--- a/_pages/algorithm-development/ci-cd.md
+++ b/_pages/algorithm-development/ci-cd.md
@@ -15,13 +15,13 @@ Continuous Integration & Deployment are standard practice in the world of softwa
 
 Algorithmia supports deployment and redeployment via the [the Algorithmia API]({{site.baseurl}}/algorithm-development/algorithm-management), and this is easily integrated into CI/CD tools such as Jenkins or GitHub Actions. With Algorithmia and your favorite CI/CD tool, your models are deployed as soon as they are ready, and can be instantly redeployed whenever an approved retrained model is available.
 
-For setting up an automated workflow in your **Algorithm repository**, you can check out the following examples with Jenkins or Github Actions:
+For setting up an automated workflow in your **Algorithm serving repository**, you can check out the following examples with Jenkins or Github Actions:
 
-<a href="https://github.com/algorithmiaio/githubactions-modeldeployment-deprecated/tree/master/jenkins_deploy_algorithmia" class="btn btn-default btn-primary"><i class="fa fa-github" aria-hidden="true"></i> TRY IT OUT: Jenkins</a>
+<a href="https://github.com/algorithmiaio/githubactions-modeldeployment-deprecated/tree/master/jenkins_deploy_algorithmia" class="btn btn-default btn-primary"><i class="fa fa-github" aria-hidden="true"></i> TRY IT OUT: Jenkins for Algorithm Serving Repo</a>
 
-<a href="https://github.com/algorithmiaio/githubactions-modeldeployment-deprecated/tree/master/githubactions_deploy_algorithmia" class="btn btn-default btn-primary"><i class="fa fa-github" aria-hidden="true"></i> TRY IT OUT: GitHub Actions in Algorithm Repo</a>
+<a href="https://github.com/algorithmiaio/githubactions-modeldeployment-deprecated/tree/master/githubactions_deploy_algorithmia" class="btn btn-default btn-primary"><i class="fa fa-github" aria-hidden="true"></i> TRY IT OUT: GitHub Actions for Algorithm Serving Repo</a>
 
 
-For setting up an automated workflow in your **machine learning repository at Github**, where you may be using a Jupyter notebook to train/test/export your ML model or checking-in your saved model; you can check out our Github Action that automates your model and algorithm code deployment once you push your changes to your model development repo:
+For setting up an automated workflow in your **model training repository at Github**, where you may be using a Jupyter notebook to train/test/export your ML model or checking-in your saved model; you can check out our Github Action that automates your model and algorithm code deployment from this repo to Algorithmia:
 
-<a href="https://github.com/algorithmiaio/algorithmia-modeldeployment-action" class="btn btn-default btn-primary"><i class="fa fa-github" aria-hidden="true"></i> TRY IT OUT: GitHub Actions in Model Development Repo</a>
+<a href="https://github.com/algorithmiaio/algorithmia-modeldeployment-action" class="btn btn-default btn-primary"><i class="fa fa-github" aria-hidden="true"></i> TRY IT OUT: GitHub Actions for Model Training Repo</a>

--- a/_pages/algorithm-development/ci-cd.md
+++ b/_pages/algorithm-development/ci-cd.md
@@ -15,7 +15,7 @@ Continuous Integration & Deployment are standard practice in the world of softwa
 
 Algorithmia supports deployment and redeployment via the [the Algorithmia API]({{site.baseurl}}/algorithm-development/algorithm-management), and this is easily integrated into CI/CD tools such as Jenkins or GitHub Actions. With Algorithmia and your favorite CI/CD tool, your models are deployed as soon as they are ready, and can be instantly redeployed whenever an approved retrained model is available.
 
-For setting up an automated workflow in your **Algoritm repository**, you can check out the following examples with Jenkins or Github Actions:
+For setting up an automated workflow in your **Algorithm repository**, you can check out the following examples with Jenkins or Github Actions:
 
 <a href="https://github.com/algorithmiaio/githubactions-modeldeployment-deprecated/tree/master/jenkins_deploy_algorithmia" class="btn btn-default btn-primary"><i class="fa fa-github" aria-hidden="true"></i> TRY IT OUT: Jenkins</a>
 


### PR DESCRIPTION
Updated the links in our Dev-Center after the re-organization of our model-deployment examples repo as per https://algorithmia.atlassian.net/browse/ALGO-854

To merge this as soon as possible and not to have broken links in our Dev-Center, your quick reviews are appreciated :) Thank you!