### PR TITLE
Update api docs build stage to use Ruby base image of 2.7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN npm run build
 #
 # Stage 2: build API docs
 #
-FROM ruby:2.3 AS docs-builder
+FROM ruby:2.7.2 AS docs-builder
 
 RUN apt-get update && apt-get install -y nodejs \
   && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I'll update the SHA used for api-docs to whatever the master commit is after that PR is merged.

Docker output after running `docker build ...` locally:
```
Successfully built 84f3165869ed
Successfully tagged algorithmiahq/dev-center:api-test
```