### PR TITLE
Remove enterprise conditionals

### DIFF
--- a/_data/toc.yml
+++ b/_data/toc.yml
@@ -49,7 +49,6 @@
 - title: Algorithmia Enterprise
   url: /algorithmia-enterprise/
   nav_category: algorithmia-enterprise
-  enterprise_only: true
 
 - title: VMware
   url: /vmware/

--- a/_pages/algorithm-development/algorithm-management.md
+++ b/_pages/algorithm-development/algorithm-management.md
@@ -38,15 +38,16 @@ If you are using another CI/CD tool, or simply wish to deploy from a simple pure
 
 ### Step-by-step: Creating and Publishing an Algorithm via the API, using the Official Python Client (recommended)
 
-{% if site.enterprise %}
-#### Enterprise Users Only: Specifying an On-Premises or Private Cloud Endpoint
+#### Specifying an On-Premises or Private Cloud Endpoint
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
+
 If you are running [Algorithmia Enterprise](/enterprise), remember to specify your API endpoint when creating the Python Client:
 
 {% highlight python %}
 client = Algorithmia.client("API_KEY", "https://mylocalendpoint")
 {% endhighlight %}
-
-{% endif %}
 
 #### 1. Create your algorithm
 
@@ -107,10 +108,12 @@ Your algorithm is now published and runnable. If you wish, you make also take ad
 
 ### ALTERNATIVE: Creating and Publishing an Algorithm Via the API, Using the OpenAPI Specification and Python Requests
 
-{% if site.enterprise %}
-#### Enterprise Users Only: Specifying an On-Premises or Private Cloud Endpoint
+#### Specifying an On-Premises or Private Cloud Endpoint
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
+
 If you are running [Algorithmia Enterprise](/enterprise), you must specify a different API endpoint when using these APIs. Simply replace "https://api.algorithmia.com" with the base URL of your own installation.
-{% endif %}
 
 #### 1. Create your algorithm
 

--- a/_pages/algorithm-development/source-control-management.md
+++ b/_pages/algorithm-development/source-control-management.md
@@ -19,10 +19,8 @@ When you create an algorithm, a [Git](https://git-scm.com/) repository is initia
 - [Hosting Source Code on Algorithmia](#hosting-source-code-on-algorithmia)
 - [Hosting Source Code on GitHub](#hosting-source-code-on-github)
 
-{% if site.enterprise %}
 **Enterprise Users:** By default, new Algorithmia instances can only store source code internally within the Algorithmia platform. Please consult your instance administrator to have GitHub enabled.
 {: .notice-info}
-{% endif %}
 
 ### Choosing a Repository Host
 
@@ -55,10 +53,8 @@ Replace the `username` and `algoname` values as appropriate. If you're working w
 
 Provide your Algorithmia username and password when asked to authenticate.
 
-{% if site.enterprise %}
-**OIDC Users** If your Algorithmia instance is configured to use OIDC, you will not have a password. To obtain a password, navigate to your user settings page and click "Regenerate Account Password". By following the instructions, you will be provided a password you can use to authenticate with your Algorithmia-hosted Git repositories.
+**Enterprise Users:** If your Algorithmia instance is configured to use OIDC, you will not have a password. To obtain a password, navigate to your user settings page and click "Regenerate Account Password". By following the instructions, you will be provided a password you can use to authenticate with your Algorithmia-hosted Git repositories.
 {: .notice-info}
-{% endif %}
 
 Once you've made changes, commit them to your repository's `master` branch 
 
@@ -160,10 +156,8 @@ If you want to review your GitHub authorization status, you can visit your user 
 
 <img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/source_code_management/scm_user_settings.png" alt="User source code management settings" class="screenshot img-sm">
 
-{% if site.enterprise %}
 **Enterprise Users:** By default, new Algorithmia instances can only store source code internally within the Algorithmia platform. As such, you may not see GitHub listed within the above section until your administrator enables GitHub as a source host.
 {: .notice-info}
-{% endif %}
 
 #### Troubleshooting GitHub-Hosted Algorithms
 

--- a/_pages/algorithmia-enterprise/algorithmia-insights.md
+++ b/_pages/algorithmia-enterprise/algorithmia-insights.md
@@ -8,6 +8,9 @@ image:
   teaser: /icons/algo.svg
 ---
 
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
+
 Algorithmia Insights is an algorithm metrics pipeline providing you access to your algorithm metrics payload for each algorithm session so you can measure, monitor, and manage your algorithms in production.
 
 With Algorithmia Insights you'll be able to opt in to exporting your algorithm's operational metrics to external monitoring and alerting tools. This means you'll be able to monitor your algorithm's execution time as well as capture any model inference metrics you expose from your algorithm's output such as predictions or accuracy. Any metrics you opt to collect will be captured and exported in a payload and, with help from a Platform Administrator, can be connected to your external systems for monitoring and alerting.

--- a/_pages/algorithmia-enterprise/scms.md
+++ b/_pages/algorithmia-enterprise/scms.md
@@ -8,6 +8,10 @@ author: rmiller
 image:
   teaser: /icons/algo.svg
 ---
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
+
 Every algorithm on the Algorithmia platform stores its source code within a [Git](https://git-scm.com/) repository. As an Algorithmia administrator, you can configure where algorithm source code repositories reside. We currently support two repository hosts, which we term source control managers (or SCMs): 
 
 - __Algorithmia__: Users may choose to host their algorithm source within the Algorithmia platform itself. This is the default SCM for all new Algorithmia instances.

--- a/_pages/algorithmia-enterprise/usage-metrics.md
+++ b/_pages/algorithmia-enterprise/usage-metrics.md
@@ -8,6 +8,8 @@ image:
     teaser: /icons/algo.svg
 ---
 
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
 
 ## Platform Usage Metrics
 

--- a/_pages/clients/cli.md
+++ b/_pages/clients/cli.md
@@ -58,10 +58,12 @@ Profile is ready to use. Test with 'algo ls'
 
 See [Using multiple profiles](#using-multiple-profiles) for instructions on how to set authenticate and use more than one profile with the Algorithmia CLI tool.
 
-{% if site.enterprise %}
-#### Enterprise Users Only: Specifying an On-Premises or Private Cloud Endpoint
+#### Specifying an On-Premises or Private Cloud Endpoint
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
+
 If you are running [Algorithmia Enterprise](/enterprise), replace the default API Endpoint (`https://api.algorithmia.com`) with your own API endpoint URL. Note that it must contain the `api` prefix, so if your domain is ` https://algorithmia.companyname.com ` then your API Endpoint should be `https://api.algorithmia.companyname.com`
-{% endif %}
 
 ## Usage
 

--- a/_pages/clients/curl.md
+++ b/_pages/clients/curl.md
@@ -30,10 +30,12 @@ curl -X POST -d '"YOUR_USERNAME"' -H 'Content-Type: application/json' -H 'Author
 
 ## Working with Data via cURL
 
-{% if site.enterprise %}
-#### Enterprise Users Only: Specifying an On-Premises or Private Cloud Endpoint
+#### Specifying an On-Premises or Private Cloud Endpoint
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
+
 If you are running [Algorithmia Enterprise](/enterprise), replace `https://api.algorithmia.com/v1/data/.my` in the codesamples below with your own API endpoint URL.
-{% endif %}
 
 
 #### Create a directory

--- a/_pages/clients/go.md
+++ b/_pages/clients/go.md
@@ -51,15 +51,17 @@ var client = algorithmia.NewClient(apiKey, "")
 
 Now you're ready to start working with Algorithmia in Go.
 
-{% if site.enterprise %}
-#### Enterprise Users Only: Specifying an On-Premises or Private Cloud Endpoint
+#### Specifying an On-Premises or Private Cloud Endpoint
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
+
 If you are running [Algorithmia Enterprise](/enterprise), you can specify the API endpoint when you create the client object:
 
 {% highlight go %}
 var client = algorithmia.NewClient(apiKey, "https://mylocalendpoint");
 {% endhighlight %}
 
-{% endif %}
 
 ## Working with Data Using the Data API
 

--- a/_pages/clients/java.md
+++ b/_pages/clients/java.md
@@ -55,8 +55,11 @@ AlgorithmiaClient client = Algorithmia.client("YOUR_API_KEY");
 
 Now you’re ready to start working with Algorithmia in Java.
 
-{% if site.enterprise %}
-#### Enterprise Users Only: Specifying an On-Premises or Private Cloud Endpoint
+#### Specifying an On-Premises or Private Cloud Endpoint
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
+
 If you are running [Algorithmia Enterprise](/enterprise), you can specify the API endpoint when you create the client object:
 
 {% highlight java %}
@@ -64,7 +67,6 @@ AlgorithmiaClient client = Algorithmia.client("YOUR_API_KEY", "https://mylocalen
 {% endhighlight %}
 
 Alternately, you can ensure that each of your servers interacting with your Algorithmia Enterprise instance have an environment variable named `ALGORITHMIA_API` and the client will use it.  The fallback API endpoint is always the hosted Algorithmia marketplace service at [https://api.algorithmia.com/](https://api.algorithmia.com/)
-{% endif %}
 
 ## Working with Data Using the Data API
 
@@ -261,8 +263,10 @@ This guide used the the first chapter of [Jack London's Burning Daylight](https:
 
 If you are interested in learning more about working with unstructured text data check out our guide [Introduction to Natural Language Processing](https://algorithmia.com/blog/introduction-natural-language-processing-nlp).
 
-{% if site.enterprise %}
 ## Publishing Algorithmia Insights
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
 
 Inference-related metrics (a feature of [Algorithmia Insights](../algorithmia-enterprise/algorithmia-insights)) can be reported via using the `reportInsights` method of the Algorithmia client.
 
@@ -273,8 +277,6 @@ client.reportInsights(new HashMap<String,Object>() { {
     put("dogs_in_image", true);
 } });
 {% endhighlight %}
-
-{% endif %}
 
 ## Limits
 

--- a/_pages/clients/javascript.md
+++ b/_pages/clients/javascript.md
@@ -55,20 +55,22 @@ Here is an example of how to authenticate and call an algorithm in JavaScript:
 {% highlight javascript %}
 var input = 41;
 var client = Algorithmia.client("YOUR_API_KEY");
-client.algo("docs/JavaAddOne").pipe(input).then(function(output) {
+client.algo("docs/JavaAddOne/0.1.1").pipe(input).then(function(output) {
   if(output.error) return console.error("error: " + output.error);
   console.log(output.result);
 });
 {% endhighlight %}
 
-{% if site.enterprise %}
-#### Enterprise Users Only: Specifying an On-Premises or Private Cloud Endpoint
+#### Specifying an On-Premises or Private Cloud Endpoint
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
+
 If you are running [Algorithmia Enterprise](/enterprise), you can specify the API endpoint when you create the client object:
 
 {% highlight javascript %}
 var client = Algorithmia.client("YOUR_API_KEY", "https://mylocalendpoint/v1/web/algo");
 {% endhighlight %}
-{% endif %}
 
 ### Limits
 

--- a/_pages/clients/net_c_sharp.md
+++ b/_pages/clients/net_c_sharp.md
@@ -183,8 +183,11 @@ Now you've seen how to upload a local data file, check if a file exists in a dat
 
 For more methods on how to get a file using the Data API from a data collection go to the [API Specification](http://docs.algorithmia.com/#getting-a-file).
 
-{% if site.enterprise %}
 #### Specifying an On-Premises Algorithmia Enterprise Endpoint
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
+
 This .NET Client also works for customers running [Algorithmia Enterprise](/enterprise).  You can specify the API endpoint when you create the client object.
 
 {% highlight csharp %}
@@ -192,7 +195,6 @@ var client = new Client("YOUR_API_KEY", "https://mylocalendpoint");
 {% endhighlight %}
 
 Alternately, you can ensure that each of your servers interacting with your Algorithmia Enterprise instance have an environment variable named `ALGORITHMIA_API` and the client will use it.  The fallback API endpoint is always the hosted Algorithmia marketplace service at [https://api.algorithmia.com/](https://api.algorithmia.com/)
-{% endif %}
 
 
 #### Additional information

--- a/_pages/clients/node.md
+++ b/_pages/clients/node.md
@@ -44,14 +44,16 @@ var client = algorithmia("YOUR_API_KEY");
 
 Now you’re ready to start working with Algorithmia in Node.
 
-{% if site.enterprise %}
-#### Enterprise Users Only: Specifying an On-Premises or Private Cloud Endpoint
+#### Specifying an On-Premises or Private Cloud Endpoint
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
+
 If you are running [Algorithmia Enterprise](/enterprise), you can specify the API endpoint when you create the client object:
 
 {% highlight js %}
 var client = algorithmia("YOUR_API_KEY", "https://mylocalendpoint");
 {% endhighlight %}
-{% endif %}
 
 ## Working with Data Using the Data API
 

--- a/_pages/clients/python.md
+++ b/_pages/clients/python.md
@@ -48,8 +48,11 @@ apiKey = "YOUR_API_KEY"
 client = Algorithmia.client(apiKey)
 {% endhighlight %}
 
-{% if site.enterprise %}
-#### Enterprise Users Only: Specifying an On-Premises or Private Cloud Endpoint
+#### Specifying an On-Premises or Private Cloud Endpoint
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
+
 If you are running [Algorithmia Enterprise](/enterprise), you can specify the API endpoint when you create the client object:
 
 {% highlight python %}
@@ -57,7 +60,6 @@ client = Algorithmia.client("YOUR_API_KEY", "https://mylocalendpoint")
 {% endhighlight %}
 
 Alternately, you can ensure that each of your servers interacting with your Algorithmia Enterprise instance have an environment variable named `ALGORITHMIA_API` and the client will use it.  The fallback API endpoint is always the hosted Algorithmia marketplace service at [https://api.algorithmia.com/](https://api.algorithmia.com/)
-{% endif %}
 
 ## Calling an Algorithm
 
@@ -241,7 +243,9 @@ This will get the image as binary data, saving it to the variable `image_data`, 
 If the file was text (an image, etc.), you could instead use the function `.getString()` to retrieve the file's content as a string. For more methods on how to get a file from a data collection using the Data API go to the [API Specification](/developers/api/#get-a-file-or-directory).
 
 ## Publishing Algorithmia Insights
-**This feature is available to Enterprise users only:**
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
 
 Inference-related metrics (a feature of [Algorithmia Insights](../algorithmia-enterprise/algorithmia-insights)) can be reported via using the `report_insights` method of the Algorithmia client.
 {% highlight python %}

--- a/_pages/clients/r.md
+++ b/_pages/clients/r.md
@@ -46,8 +46,11 @@ apiKey <- "YOUR_API_KEY"
 client <- getAlgorithmiaClient(apiKey)
 {% endhighlight %}
 
-{% if site.enterprise %}
-#### Enterprise Users Only: Specifying an On-Premises or Private Cloud Endpoint
+#### Specifying an On-Premises or Private Cloud Endpoint
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
+
 If you are running [Algorithmia Enterprise](/enterprise), you can specify the API endpoint when you create the client object:
 
 {% highlight r %}
@@ -55,7 +58,6 @@ client <- getAlgorithmiaClient("YOUR_API_KEY", "https://mylocalendpoint");
 {% endhighlight %}
 
 Alternately, you can ensure that each of your servers interacting with your Algorithmia Enterprise instance have an environment variable named `ALGORITHMIA_API` and the client will use it.  The fallback API endpoint is always the hosted Algorithmia marketplace service at [https://api.algorithmia.com/](https://api.algorithmia.com/)
-{% endif %}
 
 ## Calling an Algorithm
 
@@ -251,8 +253,10 @@ This will get the file as a JSON object, saving it to the variable `processed_te
 
 If the file was an image or some other binary data type, you could instead use the function `.getRaw()` to retrieve the file's content as raw bytes. For more methods on how to get a file using the Data API from a data collection refer to the [API Specification](/developers/api/#get-a-file-or-directory).
 
-{% if site.enterprise %}
 ## Publishing Algorithmia Insights
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
 
 Inference-related metrics (a feature of [Algorithmia Insights](../algorithmia-enterprise/algorithmia-insights)) can be reported via using the `report_insights` method of the Algorithmia client.
 
@@ -260,8 +264,6 @@ Inference-related metrics (a feature of [Algorithmia Insights](../algorithmia-en
 # Report Algorithmia Insights
 client$report_insights(list(faces_in_image=4)})
 {% endhighlight %}
-
-{% endif %}
 
 ## Additional Functionality
 

--- a/_pages/clients/ruby.md
+++ b/_pages/clients/ruby.md
@@ -53,14 +53,16 @@ client = Algorithmia.client(apiKey)
 
 Now you’re ready to start working with Algorithmia in Ruby.
 
-{% if site.enterprise %}
-#### Enterprise Users Only: Specifying an On-Premises or Private Cloud Endpoint
+#### Specifying an On-Premises or Private Cloud Endpoint
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
+
 If you are running [Algorithmia Enterprise](/enterprise), you can specify the API endpoint when you create the client object:
 
 {% highlight ruby %}
 client = Algorithmia.client(apiKey, "https://mylocalendpoint");
 {% endhighlight %}
-{% endif %}
 
 ## Working with Data Using the Data API
 

--- a/_pages/clients/rust.md
+++ b/_pages/clients/rust.md
@@ -52,14 +52,16 @@ let client = Algorithmia::client("YOUR_API_KEY");
 
 Now you’re ready to start working with Algorithmia in Rust.
 
-{% if site.enterprise %}
-#### Enterprise Users Only: Specifying an On-Premises or Private Cloud Endpoint
+#### Specifying an On-Premises or Private Cloud Endpoint
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
+
 If you are running [Algorithmia Enterprise](/enterprise), you can specify the API endpoint when you create the client object:
 
 {% highlight rust %}
 let client = Algorithmia::client("YOUR_API_KEY", "https://mylocalendpoint");
 {% endhighlight %}
-{% endif %}
 
 ## Working with Data Using the Data API
 

--- a/_pages/clients/scala.md
+++ b/_pages/clients/scala.md
@@ -49,8 +49,12 @@ val client = Algorithmia.client("YOUR_API_KEY")
 
 Now you’re ready to start working with Algorithmia in Scala.
 
-{% if site.enterprise %}
-#### Enterprise Users Only: Specifying an On-Premises or Private Cloud Endpoint
+
+#### Specifying an On-Premises or Private Cloud Endpoint
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
+
 If you are running [Algorithmia Enterprise](/enterprise), you can specify the API endpoint when you create the client object:
 
 {% highlight scala %}
@@ -58,7 +62,6 @@ val client = Algorithmia.client("YOUR_API_KEY", "https://mylocalendpoint")
 {% endhighlight %}
 
 Alternately, you can ensure that each of your servers interacting with your Algorithmia Enterprise instance have an environment variable named `ALGORITHMIA_API` and the client will use it.  The fallback API endpoint is always the hosted Algorithmia marketplace service at [https://api.algorithmia.com/](https://api.algorithmia.com/)
-{% endif %}
 
 ## Working with Data Using the Data API
 

--- a/_pages/integrations/wolfram.md
+++ b/_pages/integrations/wolfram.md
@@ -18,9 +18,8 @@ You can run this code sample by downloading the free [Wolfram Engine](http://www
 
 First, we specify the URL of the algorithm we want to run. You can get this from the Algorithm's page (such as [https://algorithmia.com/algorithms/nlp/SentimentAnalysis](https://algorithmia.com/algorithms/nlp/SentimentAnalysis)) under the "Install and Use"> cURL sample -- but in most cases it is just "https://api.algorithmia.com/v1/algo/" followed by the algorithm and version you want to use.
 
-{% if site.enterprise %}
-Enterprise users: your URL will be custom for your domain, e.g. "https://mydomainendpoint.com/v1/algo/" followed by the algorithm.
-{% endif %}
+**Enterprise users:** your URL will be custom for your domain, e.g. "https://mydomainendpoint.com/v1/algo/" followed by the algorithm.
+{: .notice-info}
 
 Next, we specify the input we want to send to the Algorithm.
 

--- a/css/devcenter.css
+++ b/css/devcenter.css
@@ -45,4 +45,22 @@ body,
   color: rgba(0, 0, 0, .54)
 }
 
+/* For Enterprise-only notice */
+#content .notice-enterprise {
+  position: relative;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  line-height: 2;
+  background-color: #fafafa;
+  border: .0625rem solid #b0b0b0;
+}
 
+#content .notice-enterprise:before {
+  content: "Enterprise";
+  margin-right: .5rem;
+  background-color: #e56967;
+  color: #ffffff;
+  padding: .5rem;
+  text-transform: uppercase;
+  font-size: 80%;
+}


### PR DESCRIPTION
Removed most, but not all, enterprise conditionals.

- For conditionals that included a section header, I added the a banner notice which says "This feature is available to users only.", links to `/enterprise`, and includes a CSS badge that says "Enterprise" in all caps. Screenshot below.
- This same banner was added to Enterprise-specific pages, and they are now included in all builds.
- For conditionals that were info notices, I removed the conditional and left the text "Enterprise users:"
- Two conditionals that included alternate content, on the Learning Center and Your First Algo pages, were left unchanged, as was a conditional in the release notes.

I added custom CSS to `devcenter.css`; let me know if there's a better way.

Banner notice screenshot:

<img width="846" alt="Screen Shot 2021-01-13 at 2 00 25 PM" src="https://user-images.githubusercontent.com/626257/104498161-517e5580-55a9-11eb-9848-beb3465ed9f7.png">