### PR TITLE
fix typos in s3.md

### DIFF
--- a/_pages/data/s3.md
+++ b/_pages/data/s3.md
@@ -14,17 +14,17 @@ redirect_from:
   - /application-development/data-sources/s3-guide/
 ---
 
-Learn how to access your S3 account in a few easy steps. This guide will tell you how to configure and connect to your data source and provide details about setting various permissions.
+Learn how to access your S3 account in a few easy steps. This guide will tell you how to configure and connect to your data source, and will provide details about setting various permissions.
 
 ## Data Source Basics
-All data sources have a protocol and a label that you will use to reference your data. For instance S3 is the protocol we'll use in this guide and the label will be automatically assigned to your data connection as a unique identifier, but you may change it later if you wish.
+All data sources have a protocol and a label that you will use to reference your data. For instance, S3 is the protocol we'll use in this guide and the label will be automatically assigned to your data connection as a unique identifier, but you may change it later if you wish.
 
 ## Configure a New Data Connection to S3
-To create a new data connection first navigate to <a href="{{site.baseurl}}/data">Algorithmia's Data Portal</a> where you'll notice there is a drop down that says 'New Data Source' where you'll see the options:
+To create a new data connection, first navigate to <a href="{{site.baseurl}}/data">Algorithmia's Data Portal</a>, where you'll notice there is a drop-down that says "New Data Source" where you'll see several options:
 
 <img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/data_connectors/create_data_connector.png" alt="Create a data connector" class="screenshot img-md">
 
-Select **'Amazon S3'** and a form will open to configure an S3 connection. Here you will need to enter your AWS credentials.
+Select **"Amazon S3"** and a form will open to configure an S3 connection. Here you will need to enter your AWS credentials.
 
 <img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/data_connectors/s3_create_data_connector.png" alt="Create a data connector in modal" class="screenshot img-sm">
 
@@ -35,42 +35,42 @@ Create and download your keys for an [IAM user](https://console.aws.amazon.com/i
 
 **NOTE:** While an algorithm NEVER sees credentials used to access data in S3, it is recommended that you provide an access key that:
 
-- Can only list, get, and put objects to S3 (i.e. cannot perform other operations on your account)
+- Can only list, get, and put objects to S3 (i.e., cannot perform other operations on your account)
 - Can only access the paths in S3 that you want Algorithmia to access
 
 ### Setting Labels For Data Connections
 You will need to provide a unique label for your S3 data connector, editable in the **"Label"** field.
 
-We require these unique labels because you may want to add multiple connections to the same S3 account and they will each need a unique label for later reference in your algorithm. The reason you might want to have multiple connections to the same source is so you can set different access permissions to each connection such as read from one file and write to a different folder.
+We require these unique labels because you may want to add multiple connections to the same S3 account and they will each need a unique label for later reference in your algorithm. The reason you might want to have multiple connections to the same source is so you can set different access permissions to each connection (e.g., read from one file and write to a different folder).
 
 <img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/data_connectors/s3_manage_connector_change_label.png" alt="Change a data connector's label" class="screenshot img-sm">
 
-**NOTE:** The unique label follows the protocol: '+unique_label://restricted_path'
+**NOTE:** The unique label follows the protocol: "+unique_label://restricted_path"
 
 ### Setting Path Restrictions for S3 Folder and File Access
-The default path restrictions are set to allow access to all paths in your S3 account, however you may want to restrict your algorithm's access to specific folders or files:
+The default path restrictions are set to allow access to all paths in your S3 account, but you may want to restrict your algorithm's access to specific folders or files:
 
-- Access to a single file: 'Algorithmia/team.jpg'
-- Access to everything in a specific folder: 'Algorithmia/*'
+- Access to a single file: "Algorithmia/team.jpg"
+- Access to everything in a specific folder: "Algorithmia/*"
 
-**NOTE:** 'Algorithmia*' might match more than you’d like, so if you want to match a directory exactly end with a '/'.
+**NOTE:** "Algorithmia*" might match more than you’d like, so if you want to match a directory exactly, end with a "/".
 
-Here we are setting our path restrictions to everything in the S3 bucket 'Algorithmia':
+Here we are setting our path restrictions to everything in the S3 bucket "Algorithmia":
 
 <img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/data_connectors/s3_restricted_paths.png" alt="Add path restrictions" class="screenshot img-sm">
 
 ### Setting Read and Write Access
-The default access for your data source is set to read only, but you can change this to read *and* write access by checking the **'Write Access'** box.
+The default access for your data source is set to read only, but you can change this to read *and* write access by checking the **"Write Access"** box.
 
-**NOTE:** Write access also means you can ***delete*** anything in the path you've specified in the previous step so be careful that you want read-write-delete access to the path you set in 'Path Restriction'. Also, if your data source has Read/Write privileges, then an algorithm that you call also has Read/Write privileges to your data source.
+**NOTE:** Write access also means you can ***delete*** anything in the path you've specified in the previous step, so be sure that you want read-write-delete access to the path you set in "Path Restriction". Also, if your data source has read/write privileges, it means that an algorithm that you call also has read/write privileges to your data source.
 
 <img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/data_connectors/s3_write_access.png" alt="Manage a data connector" class="screenshot img-sm">
 
-## Accessing your Data
-Accessing your S3 data via the <a href="http://docs.algorithmia.com/#data-api-specification">Algorithmia Data API</a> is easy. Whether you're writing your algorithm in Rust, Ruby, Python, Scala, Java or JavaScript simply import your data with a couple lines of code. With your S3 data connection now configured you can read and write data to and from it via <a href="http://docs.algorithmia.com/#data-api-specification">Algorithmia's Data API</a> by specifying the protocol and label as your path to your data:
+## Accessing Your Data
+Accessing your S3 data via the <a href="http://docs.algorithmia.com/#data-api-specification">Algorithmia Data API</a> is easy. Whether you're writing your algorithm in Rust, Ruby, Python, Scala, Java, or JavaScript, simply import your data with a couple lines of code. With your S3 data connection now configured you can read and write data to and from it via <a href="http://docs.algorithmia.com/#data-api-specification">Algorithmia's Data API</a> by specifying the protocol and label as the path to your data:
 
-- client = Algorithmia.client('YOUR_API_KEY')
-- client.file('S3+unique_label://my_bucket/my_file.csv').getFile().name
+- client = Algorithmia.client("YOUR_API_KEY")
+- client.file("S3+unique_label://my_bucket/my_file.csv").getFile().name
 
 For example, to retrieve and print a file's contents in Python:
 
@@ -78,47 +78,46 @@ For example, to retrieve and print a file's contents in Python:
 import Algorithmia
 import csv
 
-client = Algorithmia.client('your_api_key')
+client = Algorithmia.client("Your_API_KEY")
 
 def s3_data():
     # Get file from S3 data source
-    data_file = client.file('s3+saha://Algorithmia/test_data.csv').get()
+    data_file = client.file("s3+saha://Algorithmia/test_data.csv").get()
     # Pass in file and pass in args required from the algorithm FpGrowth
     input = [data_file, 5, 2]
-    algo = client.algo('paranoia/FpGrowth/0.2.0')
+    algo = client.algo("paranoia/FpGrowth/0.2.0")
     return algo.pipe(input)
 
 s3_data()
 
 {% endhighlight %}
 
-The above examples work when accessing data from a local script or app code. If you're writing an algorithm and accessing a data source from inside the algorithm, create the client without an API Key parameter: `client = Algorithmia.client()`
+The above examples work when accessing data from a local script or application code. If you're writing an algorithm and accessing a data source from inside the algorithm, create the client without an API Key parameter: `client = Algorithmia.client()`
 {: .notice-info}
 
-If you're calling an algorithm that takes a file or directory as input from the Data API, you can also provide it a file or directory from one of your data sources:
+If you're using the Data API to call an algorithm that takes a file or directory as input, you can also provide it a file or directory from one of your data sources:
 
 {% highlight python %}
-algo.pipeJson({'inputFile':'s3+saha://Algorithmia/test_data.csv'})
+algo.pipeJson({"inputFile":"s3+saha://Algorithmia/test_data.csv"})
 {% endhighlight %}
 
-**NOTE:** If you call an algorithm it can only access your own data sources. This means that it is NOT possible for an algorithm to read data from your S3 and write that data to an account controlled by an another algorithm author. Algorithms do NOT have direct access to any credentials associated with your data sources, and can only access data from a data source using the Algorithmia API.
+**NOTE:** An algorithm you call can only access your own data sources. This means that it is NOT possible for an algorithm to read data from your S3 and write that data to an account controlled by another algorithm author (another Algorithmia user). Algorithms do NOT have direct access to any credentials associated with your data sources, and can only access data from a data source using the Algorithmia API.
 
 ## Data Source Routes and Data API Routes
 
-Once a data source connection has been created and configured, all of the Algorithmia client code for interacting with the Data API for file or directory creation, deletion and listing will function identically with a data source route and a data API route except for:
-
-- We do not support generic ACLs for data sources and the only way to update permissions for a data source is through the data portal where you created your data source connection.
+Once a data source connection has been created and configured, all of the Algorithmia client code for interacting with the Data API for file or directory creation, deletion, and listing will function identically with a data source route and a data API route. The one exception to this is that we do not support generic ACLs for data sources, so the only way to update permissions for a data source is through the data portal where you created your data source connection.
 
 If you're implementing a new client or using cURL it is preferred to use the following URL structure:
 
-- '/v1/connector/protocol+label/path':
-    - '/v1/connector/s3+unique_label/my_bucket/foo.txt'
+- "/v1/connector/protocol+label/path":
+    - "/v1/connector/s3+unique_label/my_bucket/foo.txt"
 
 ## Algorithm support
 We have tested to ensure that data source paths function in all of our Algorithmia clients, however:
 
 - Python support was added in version 1.0.4
 - NodeJS support was added in version 0.3.5
+
 This means that algorithms in Python or JavaScript which were last compiled prior to 5/27/2016 might not have the most recent versions of these dependencies, and we can’t guarantee this new functionality will work on algorithms older than that. A simple recompilation of the algorithm will enable support without any code changes needed.
 
 If you have any questions about Algorithmia please <a href="mailto:support@algorithmia.com">get in touch</a>!


### PR DESCRIPTION
- change single quotes to double quotes to be consistent with rest of docs, and especially within Python / JSON code
- R is not mentioned in the list of languages to use the data API (see "Accessing Your Data"). Is this intentional?