### PR TITLE
Update Rust client guide

### DIFF
--- a/_pages/clients/rust.md
+++ b/_pages/clients/rust.md
@@ -257,4 +257,4 @@ In addition to the functionality covered in this guide, the Rust Client Library 
 
 ## Next Steps
 
-If you're a data scientist or developer who will be building and deploying new algorithms, you can move on to the [Algorithm Development > Getting Started](/developers/algorithm-development/your-first-algo/) guide.
+If you're a data scientist or developer who will be building and deploying new algorithms, you can move on to the [Algorithm Development > Getting Started](/developers/algorithm-development/your-first-algo) guide.

--- a/_pages/clients/rust.md
+++ b/_pages/clients/rust.md
@@ -154,10 +154,10 @@ The documentation for "Face Detection" says that it takes a URL or a Data URI of
 
 {% highlight rust %}
 let img_directory = client.dir("data://YOUR_USERNAME/img_directory");
-if img_directory.exists().unwrap() == false {
-    img_directory.create(DataAcl::from(ReadAcl::Public)).unwrap();
-} else {
+if img_directory.exists().unwrap() {
     println!("img_directory exists");
+} else {
+    img_directory.create(DataAcl::from(ReadAcl::Public)).unwrap();
 }
 {% endhighlight %}
 
@@ -183,10 +183,10 @@ let img_file = "data://.my/img_directory/friends.jpg";
 Then upload your local file to the data collection using the `put_file` method:
 
 {% highlight rust %}
-if client.file(img_file).exists().unwrap() == false {
-    img_directory.put_file("../data/friends.jpg").unwrap();
-} else {
+if client.file(img_file).exists().unwrap() {
     println!{"file exists"};
+} else {
+    img_directory.put_file("../data/friends.jpg").unwrap();
 }
 {% endhighlight %}
 

--- a/_pages/clients/rust.md
+++ b/_pages/clients/rust.md
@@ -19,18 +19,17 @@ redirect_from:
   - /application-development/lang-guides/rust/
 ---
 
-This guide provides a walk-through of how to use the official Algorithmia Rust Client to call algorithms and manage your data
-through the Algorithmia platform.
+The Algorithmia Rust client provides a native Rust interface to the Algorithmia API, letting developers manage and call algorithms, work with data in object stores using Algorithmia Data Sources, and access other features of the Algorithmia platform.
 
-Here you will learn how to install the Algorithmia Rust Client, work with the Data API by uploading and downloading files, create and update directories and permission types and last, you'll learn how to call an algorithm that summarizes text files.
+This guide will cover setting up the client, calling an algorithm using direct user input, calling an algorithm that accesses data through Algorithmia Data Sources, and using Algorithmia's Hosted Data service. For complete details about the Algorithmia API, please refer to the [API Docs](/developers/api/).
 
-To follow along you can create a new project with `cargo new <PROJECT>`
+Create a new Rust project to follow along.
 
-## Getting Started with Algorithmia
+## Set Up the Client
 
-The official Algorithmia Rust Client is published to [crates.io](https://crates.io/crates/algorithmia) and additional reference documentation can be found in the cargo-generated [Algorithmia Client Documentation](http://algorithmiaio.github.io/algorithmia-rust/algorithmia/) and the [Algorithmia API docs](http://docs.algorithmia.com/?rust#).
+The official Algorithmia Rust Client is published to [crates.io](https://crates.io/crates/algorithmia) and additional reference documentation can be found in the cargo-generated [Algorithmia Rust Client Documentation](http://algorithmiaio.github.io/algorithmia-rust/algorithmia/) and the [Algorithmia API docs](http://docs.algorithmia.com/).
 
-To get started, first install the Algorithmia Rust Client by adding `algorithmia = "2.0.0"` to the dependencies in your `Cargo.toml`.
+To get started, first install the Algorithmia Rust Client by adding `algorithmia = "2.1.3"` to the dependencies in your `Cargo.toml`.
 
 Then build the cargo file to download and install the client:
 
@@ -38,19 +37,18 @@ Then build the cargo file to download and install the client:
 cargo build
 {% endhighlight %}
 
-## Authentication
+To use the client you'll need an API key, which Algorithmia uses for fine-grained authentication across the platform. For this example, we'll use the `default-key` that was created along with your account, which has a broad set of permissions. Log in to Algorithmia and navigate to Home > [API Keys](/user#credentials) to find your key, or read the [API keys](/developers/platform/customizing-api-keys) documentation for more information.
 
-Next, login to [Algorithmia](/) to get your [API key](/user#credentials):
-
-Now import the Algorithmia library and create the Algorithmia client:
+Once the client is installed, you can import it into your code and instantiate the client object:
 
 {% highlight rust %}
-use algorithmia::*;
-// Instantiate an Algorithmia client using your API key
-let client = Algorithmia::client("YOUR_API_KEY");
-{% endhighlight %}
+use algorithmia::Algorithmia;
 
-Now you’re ready to start working with Algorithmia in Rust.
+// Authenticate with your API key
+let api_key = "YOUR_API_KEY"
+// Create the Algorithmia client object
+let client = Algorithmia::client("api_key").unwrap();
+{% endhighlight %}
 
 #### Specifying an On-Premises or Private Cloud Endpoint
 
@@ -63,200 +61,200 @@ If you are running [Algorithmia Enterprise](/enterprise), you can specify the AP
 let client = Algorithmia::client("YOUR_API_KEY", "https://mylocalendpoint");
 {% endhighlight %}
 
-## Working with Data Using the Data API
+Alternately, you can ensure that each of your servers interacting with your Algorithmia Enterprise instance have an environment variable named `ALGORITHMIA_API` and the client will use it.  The fallback API endpoint is always the hosted Algorithmia marketplace service at [https://api.algorithmia.com/](https://api.algorithmia.com/)
 
-For application developers, [Algorithmia's Data Portal](/data) offers three different ways to store your data, all available via the [Data API](http://docs.algorithmia.com/#data-api-specification).
+## Calling an Algorithm
 
-This guide will show you how to work with the [Hosted Data]({{site.baseurl}}/data/hosted) option on the Algorithmia platform which is available to both algorithm and application developers.
+Algorithms take three basic types of input whether they are invoked directly through the API or by using a client library: strings, JSON, and binary data. In addition, individual algorithms might have their own I/O requirements, such as using different data types for input and output, or accepting multiple types of input, so consult the input and output sections of an algorithm's documentation for specifics.
 
-### Prerequisites
-If you wish to follow along working through the example yourself, create a text file that contains any unstructured text such as a chapter from a public domain book or article. We used a chapter from [Burning Daylight, by Jack London](https://en.wikisource.org/wiki/Burning_Daylight) which you can copy and paste into a text file. Or copy and paste it from here: <a href="{{site.baseurl}}/data_assets/burning_daylight.txt">Chapter One Burning Daylight, by Jack London</a>. This will be used throughout the guide.
+The first algorithm we'll call is a demo version of the algorithm used in the Algorithm Development [Getting Started](/developers/algorithm-development/your-first-algo) guide, which is available at [demo/Hello](/algorithms/demo/Hello). Looking at the [algorithm's documentation](/algorithms/demo/Hello/docs), it takes a string as input and returns a string.
 
-### Create a Data Collection
-
-This section will show how to create a data collection which is essentially a folder of data files hosted on Algorithmia for free.
-
-To begin working with data directories in Rust, first add these imports:
+In order to call an Algorithm from Rust, we need to first create an algorithm object. With the client already instantiated, we can run the following code to create an object:
 
 {% highlight rust %}
-use algorithmia::data::*;
-use std::io::Read;
+let algo = client.algo("demo/Hello");
 {% endhighlight %}
 
-Now create a data collection called nlp_directory:
+Then, we can use the `pipe` method to call the algorithm. We'll provide our input as the argument to the function, and store the result in the `response` variable. We can then print the output using the `as_string` method:
 
 {% highlight rust %}
-// Instantiate a DataDirectory object, set your data URI and call create
-let nlp_directory = client.dir("data://YOUR_USERNAME/nlp_directory");
+let response = algo.pipe("HAL 9000").unwrap();
+println!("{}", response.as_string().unwrap());
+{% endhighlight %}
 
-if nlp_directory.exists().unwrap() == false{
-    nlp_directory.create(DataAcl::default());
+Which should print the phrase, `Hello HAL 9000`.
+
+### JSON and Rust
+
+The Rust client integrates with the `serde` framework and allows you to call an algorithm with JSON input by calling `pipe` with a reference to a type that implements `serde::Serialize`. If the algorithm output is JSON, you can call decode to deserialize the resonse into a type that implements `serde::Deserialize`.
+
+Additionally, with `serde_json`, you can use the `json!` macro or implement custom serialization/deserialization. See [serde.rs](https://serde.rs/) for more details on using serde.
+
+Let's look at an example using JSON and the [nlp/LDA](https://algorithmia.com/algorithms/nlp/LDA) algorithm. The [algorithm docs](https://algorithmia.com/algorithms/nlp/LDA/docs) tell us that the algorithm takes a list of documents and returns a number of topics that are relevant to those documents. The documents can be a list of strings, a Data API file path, or a URL. We'll construct our input using `serde_json` following the format in the algorithm documentation:
+
+{% highlight rust %}
+let algo_json = client.algo("nlp/LDA/1.0.0");
+let input = json!({
+    "docsList": [
+        "The apples are ready for picking",
+        "It's apple picking season"
+    ]
+});
+let response_json = algo_json.pipe(input);
+let output = response_json.unwrap();
+println!("{}", output.to_json().unwrap());
+{% endhighlight %}
+
+The output will be `[{'picking': 2}, {'apple': 1}, {'apples': 1, 'ready': 1}, {'season': 1}]`, which is the list of relevant words and the number of occurrences.
+
+You might have noticed that in this example we included a version number when instantiating the algorithm. Pinning your code to a specific version of the algorithm can be especially important in a production environment where the underlying implementation might change from version to version.
+
+### Request Options
+
+The client exposes options that can configure algorithm requests via a builder pattern. This includes support for changing the timeout or indicating that the API should include stdout in the response. In the following example, we set the timeout to 60 seconds and disable `stdout` in the response:
+
+{% highlight rust %}
+let mut algo = client.algo("demo/Hello");
+let algo = algo.timeout(10).stdout(false);
+let response = algo.pipe("HAL 9001").unwrap();
+println!("{}", response.as_string().unwrap());
+{% endhighlight %}
+
+You can find more details in [API Docs](/developers/api/) > [Invoke an Algorithm](/developers/api/#invoke-an-algorithm).
+
+### Error Handling
+
+To be able to better develop across languages, Algorithmia has created a set of standardized errors that can be returned by either the platform or by the algorithm being run. True to the nature of explicit error handling in rust, the pipe and response parsing methods all return Result-wrapped types:
+
+{% highlight rust %}
+let algo = client.algo("util/WhoopsWrongAlgo");
+match algo.pipe("Hello, world!") {
+    Ok(_response) => { /* success */ },
+    Err(err) => println!("error calling algorithm: {}", err),
 }
 {% endhighlight %}
 
-A Data URI uniquely identifies files and directories and contains a protocol "data://" and path "YOUR_USERNAME/data_collection". For more information on the Data URI see the [Data API Specification](http://docs.algorithmia.com/#data-api-specification).
-
-Instead of your username you can also use '.my' when calling algorithms. For more information about the '.my' pseudonym check out the [Hosted Data Guide]({{site.baseurl}}/data/hosted).
-{: .notice-info}
-
-### Work with Directory Permissions
-
-When we created the data collection in the previous code snippet, we set it to the default setting "MyAlgorithms" via `DataAcl::default()`, which is a permission type that allows other users on the platform to interact with your data through the algorithms you create if you decide to contribute to algorithm development. This means users can call your algorithm to perform an operation on your data stored in this collection, otherwise the algorithm you created would only work for you.
-
-In order to change your data collection permissions you can go to [Hosted Data](/data/hosted) and click on the collection you just created called **"nlp_directory"** and select from the dropdown at the top of the screen that will show three different types of permissions:
-
--   My Algorithms (called by any user)
--   Private (accessed only by me)
--   Public (available to anyone)
-
-For more information about data collection permissions go to the [Hosted Data Guide]({{site.baseurl}}/data/hosted).
-
-### Upload Data to your Data Collection
-
-So far you've created your data collection and checked and updated directory permissions. Now you're ready to upload the text file that you created at the beginning of the guide to your data collection using the Data API.
-
-First create a variable that holds the path to your data collection and the text file you will be uploading:
-
-{% highlight rust %}
-let text_file = "data://YOUR_USERNAME/nlp_directory/jack_london.txt";
-{% endhighlight %}
-
-Next upload your local file to the data collection using the .put_file() method:
-
-{% highlight rust %}
-// Check if file exists
-if client.file(text_file).exists().unwrap() == false{
-	// Upload local file
-	nlp_directory.put_file("/your_local_path_to_file/jack_london.txt");
-}
-{% endhighlight %}
-
-This endpoint will replace a file if it already exists. If you wish to avoid replacing a file, check if the file exists before using this endpoint.
-{: .notice-warning}
-
-You can confirm that the file was created by navigating to Algorithmia's [Hosted Data Source](/data/hosted) and finding your data collection and file.
-
-You can also upload your data through the UI on Algorithmia's [Hosted Data Source](/data/hosted). For instructions on how to do this go to the [Hosted Data Guide]({{site.baseurl}}/data/hosted).
-
-### Downloading Data from a Data Collection
-
-Next check if the file that you just uploaded to data collections exists, and try downloading it to a (new) local file:
-
-{% highlight rust %}
-// Download the file
-if client.file(text_file).exists().unwrap() {
-	let mut file_reader = client.file(text_file).get().unwrap();
-	let mut localfile = File::create("/path/to/save/localfile.png").unwrap();
-	std::io::copy(&mut file_reader, &mut localfile);
-}
-{% endhighlight %}
-
-This copies the file from your data collection and saves it as a file on your local machine, storing the filename in the variable `localfile`.
-
-Alternately, if you just need the text content of the file to be stored in a variable, you can retrieve the remote file's content without saving the actual file:
-
-{% highlight rust %}
-// Download contents of file as a string
-if client.file(text_file).exists().unwrap() {
-	let mut text_reader = client.file(text_file).get().unwrap();
-	let mut jack_london_text = String::new();
-	let _ = text_reader.read_to_string(&mut jack_london_text);
-}
-{% endhighlight %}
-
-This will get your file as a string, saving it to the variable `input`.  If the file was binary (an image, etc), you could instead use the function `.getBytes()` to retrieve the file's content as a byte array.
-
-Now you've seen how to upload a local data file, check if a file exists in a data collection, and download the file contents.
-
-For more methods on how to get a file using the Data API from a data collection go to the [API Specification](http://docs.algorithmia.com/#getting-a-file).
-
-## Call an Algorithm
-
-Finally we are ready to call an algorithm. In this guide we'll use the natural language processing algorithm called [Summarizer](https://algorithmia.com/algorithms/nlp/Summarizer). This algorithm results in a string that is the summary of the text content you pass in as the algorithm's input.
-
-A single algorithm may have different input and output types, or accept multiple types of input, so consult the algorithm’s description for usage examples specific to that algorithm.
-{: .notice-info}
-
-This example shows the summary of the text file which we downloaded from our data collection and set as the variable called "input" in the previous code sample.
-
-Create the algorithm object and pass in the variable "input" into algo.pipe:
-
-{% highlight rust %}
-// Download contents of file as a string
-if client.file(text_file).exists().unwrap() {
-	let mut text_reader = client.file(text_file).get().unwrap();
-	let mut jack_london_text = String::new();
-	let _ = text_reader.read_to_string(&mut jack_london_text);
-
-	// Call Summarizer algorithm.
-	let algo = client.algo("nlp/Summarizer/0.1.3");
-	match algo.pipe(& jack_london_text) {
-	    Ok(response) => {
-	    	response.as_string().unwrap();
-	    },
-	    Err(err) => println!("error calling Summarizer algo: {}", err),
-	};
-}
-{% endhighlight %}
-
-This guide used the the first chapter of [Jack London's Burning Daylight](https://en.wikisource.org/wiki/Burning_Daylight) and the Summarizer algorithm outputs:
-
-"It was a quiet night in the Shovel. The miners were in from Moseyed Creek and the other diggings to the west, the summer washing had been good, and the men's pouches were heavy with dust and nuggets. MacDonald grinned and nodded, and opened his mouth to speak, when the front door swung wide and a man appeared in the light."
-
-If you are interested in learning more about working with unstructured text data check out our guide [Introduction to Natural Language Processing](https://algorithmia.com/blog/introduction-natural-language-processing-nlp).
+You can read more about [Error Handling](/developers/algorithm-development/algorithm-errors) in the [Algorithm Development](/developers/algorithm-development) section of the dev center.
 
 ### Limits
 
 Your account can make up to {{site.data.stats.platform.max_num_algo_requests}} Algorithmia requests at the same time (this limit <a onclick="Intercom('show')">can be raised</a> if needed).
 
-## Conclusion
+## Working with Algorithmia Data Sources
 
-This guide covered installing the Algorithmia Rust Client, uploading and downloading data to and from a user created data collection, checking if a file exists using the Data API, calling an algorithm, and handling errors.
+For some algorithms, passing input to the algorithm at request time is sufficient, while others might have larger data requirements or need to preserve state between calls. Application developers can use Algorithmia's [Hosted Data](/developers/data/hosted) to store data as text, JSON, or binary, and access it via the Algorithmia [Data API](/developers/api/#data).
 
-For more information on the methods available using the Data API in Rust check out the [Data API](http://docs.algorithmia.com/?rust#data-api-specification) documentation, the [Rust Client Docs](https://github.com/algorithmiaio/algorithmia-rust) and the [Rust Language Docs] (https://crates.io/crates/algorithmia)
+The Data API defines [connectors](/developers/api/#connectors) to a variety of storage providers, including Algorithmia [Hosted Data](/developers/data/hosted), Amazon S3, Google Cloud Storage, Azure Storage Blobs, and Dropbox. After creating a connection in Data Sources, you can use the API to create, update, and delete directories and files and manage permissions across providers by making use of [Data URIs](/developers/api/#data-uris) in your code.
 
-For convenience, here is the whole code snippet available to run:
+In this example, we'll upload an image to Algorithmia's [Hosted Data](/developers/data/hosted) storage provider, and use the [dlib/FaceDetection](https://algorithmia.com/algorithms/dlib/FaceDetection) algorithm to detect any faces in the image. The algorithm will create a new copy of the image with bounding boxes drawn around the detected faces, and then return a JSON object with details about the dimensions of the bounding boxes and a URI where you can download the resulting image.
+
+### Create a Data Collection
+
+The documentation for "Face Detection" says that it takes a URL or a Data URI of the image to be processed, and a Data URI where the algorithm can store the result. We'll create a directory to host the input image and set its [permissions](/developers/api/#update-collection-acl) to make it publicly accessible by creating a DataAcl with `DataAcl::from(ReadAcl::Public)` and passing it to the `create` method.
 
 {% highlight rust %}
-extern crate algorithmia;
-use algorithmia::*;
-use algorithmia::data::*;
-
-use std::io::Read;
-
-fn main() {
-	// Instantiate an Algorithmia client using your API key
-	let client = Algorithmia::client("YOUR_API_KEY");
-
-	// Instantiate a DataDirectory object, set your data URI and call create
-	let nlp_directory = client.dir("data://YOUR_USERNAME/nlp_directory");
-
-	if nlp_directory.exists().unwrap() == false{
-	    nlp_directory.create(DataAcl::default());
-	}
-
-	let text_file = "data://YOUR_USERNAME/nlp_directory/jack_london.txt";
-
-	// Check if file exists
-	if client.file(text_file).exists().unwrap() == false{
-		// Upload local file
-		nlp_directory.put_file("/your_local_path_to_file/jack_london.txt");
-	}
-
-	// Download contents of file as a string
-	if client.file(text_file).exists().unwrap() {
-		let mut text_reader = client.file(text_file).get().unwrap();
-		let mut jack_london_text = String::new();
-		let _ = text_reader.read_to_string(&mut jack_london_text);
-
-		// Call Summarizer algorithm.
-		let algo = client.algo("nlp/Summarizer/0.1.3");
-		match algo.pipe(& jack_london_text) {
-		    Ok(response) => {
-		    	response.as_string().unwrap();
-		    },
-		    Err(err) => println!("error calling Summarizer algo: {}", err),
-		};
-	}
+let img_directory = client.dir("data://YOUR_USERNAME/img_directory");
+if img_directory.exists().unwrap() == false {
+    img_directory.create(DataAcl::from(ReadAcl::Public)).unwrap();
+} else {
+    println!("img_directory exists");
 }
 {% endhighlight %}
+
+Instead of your username you can also use '.my' when calling algorithms. For more information about the '.my' pseudonym check out the [Hosted Data Guide]({{site.baseurl}}/data/hosted).
+{: .notice-info}
+
+If you need to update an existing directory's permissions so that it's publicly accessible, you can go to [Hosted Data](/data/hosted) and click on the collection you just created called **"img_directory"** and select from the dropdown at the top of the screen that shows three different types of permissions:
+
+-   My Algorithms (called by any user)
+-   Private (accessed only by me)
+-   Public (available to anyone)
+
+### Upload Data to your Data Collection
+
+Now we're ready to upload an image file for processing. For this example, we'll use [this photo of a group of friends](https://unsplash.com/photos/Q_Sei-TqSlc). Download the image and save it locally as `friends.jpg`. 
+
+Next, create a variable that holds the location where you would like to upload the image as a URI:
+
+{% highlight rust %}
+let img_file = "data://.my/img_directory/friends.jpg";
+{% endhighlight %}
+
+Then upload your local file to the data collection using the `put_file` method:
+
+{% highlight rust %}
+if client.file(img_file).exists().unwrap() == false {
+    img_directory.put_file("../data/friends.jpg").unwrap();
+} else {
+    println!{"file exists"};
+}
+{% endhighlight %}
+
+This method call will replace a file if it already exists at the specified location. If you wish to avoid replacing a file, check if the file exists before using this method.
+{: .notice-warning}
+
+Confirm that the file was created by navigating to Algorithmia's [Hosted Data Source](/data/hosted) and finding your data collection and file.
+
+You can also upload your data through the UI on Algorithmia's [Hosted Data Source](/data/hosted). For instructions on how to do this go to the [Hosted Data Guide]({{site.baseurl}}/data/hosted).
+
+### Call the Algorithm
+
+Once the file has been uploaded, you are ready to call the algorithm. Create the algorithm object, then pass the required inputs—an image URI (which is stored in `img_file` in the code above) and a URI for the image output—to `pipe`:
+
+{% highlight rust %}
+let algo_cv = client.algo("dlib/FaceDetection/0.2.1");
+let input_cv = json!({
+    "images": [
+        {
+            "url": "data://.my/img_directory/friends.jpg",
+            "output": "data://.algo/temp/detected_faces.png"
+        }
+    ]
+});
+
+match algo_cv.pipe(input_cv) {
+    Ok(response) => println!("{}", response.to_json().unwrap()),
+    Err(err) => println!("error calling FaceDetection algo: {}", err)
+};
+{% endhighlight %}
+
+Once the algorithm has completed, `response` will contain the dimensions of the bounding boxes for any detected faces and the URI for the resulting file, which you can then download (or provide as input to another algorithm in a pipeline).
+
+Algorithms can create and store data in folders named with the algorithm name in the Algorithm Data collection. To access this folder from within an executing algorithm, the `.algo` shortcut can be used, as in the input example above. When accessing data from a client context, the algorithm author and name can be used along with the `.algo` shortcut to download data, in the format `data://.algo/author/algoName/folder/fileName`.
+{: .notice-info}
+
+### Download the resulting file
+
+The URI included in the algorithm output uses the `.algo` shortcut, so we'll need to modify it slighly to download the file by adding the algorithm name and author:
+
+{% highlight rust %}
+let download_uri = "data://.algo/dlib/FaceDetection/temp/detected_faces.png";
+{% endhighlight %}
+
+Verify that the file that you want to download exists, and try downloading it to a new local file location. The Rust client allows you to download files by calling `get` on a `DataFile` object, which returns a `Result`-wrapped `DataResponse` that implements `Read`. You can then write the file locally using `std::fs:File` and `std::io:copy`:
+
+{% highlight rust %}
+if client.file(download_uri).exists().unwrap() {
+    let mut png_reader = client.file(download_uri).get().unwrap();
+    let mut png = std::fs::File::create("../data/detected_faces.png").unwrap();
+    std::io::copy(&mut png_reader, &mut png).unwrap();
+};
+{% endhighlight %}
+
+Alternately, if you just need the binary content of the file to be stored in a variable, you could store the results in a byte array:
+
+{% highlight rust %}
+let mut png_reader = client.file(download_uri).get().unwrap();;
+let mut png = Vec::new();
+png_reader.read_to_end(&mut t800_bytes);
+{% endhighlight %}
+
+If the file was text (an image, etc.), you can use `read_to_string` on the response. The [API Specification](/developers/api/#get-a-file-or-directory) has more details on how to get files from a data collection using the Data API.
+
+## Additional Functionality
+
+In addition to the functionality covered in this guide, the Rust Client Library provides a complete interface to the Algorithmia platform, including [managing algorithms](/developers/algorithm-development/algorithm-management), administering [organizations](/developers/platform/organizations), and working with [source control](/developers/algorithm-development/source-code-management). You can also visit the [API Docs](/developers/api) to view the complete API specification.
+
+## Next Steps
+
+If you're a data scientist or developer who will be building and deploying new algorithms, you can move on to the [Algorithm Development > Getting Started](/developers/algorithm-development/your-first-algo/) guide.


### PR DESCRIPTION
Updated Rust client guide.

I'm not sure that I've dealt with error handling in the examples in the most Rust-like way. From what I could find, `unwrap` is often used in examples to skip error handling, so that's what I went with, but would appreciate a sanity check from someone who writes Rust.

Also, I ended up using 3.0.0-beta.3 instead of 2.1.3, which has dependencies that don't work with current versions of OpenSSL.
