### PR TITLE
update nav item name in toc.yml

### DIFF
--- a/_data/toc.yml
+++ b/_data/toc.yml
@@ -41,7 +41,7 @@
 - title: API Documentation
   url: http://docs.algorithmia.com
 
-- title: Learning & Training Center
+- title: Training Center
   url:  /learningcenter/
 
 - title: Teams


### PR DESCRIPTION
"Learning Center" no longer exists. Will make PR for updating page title as well, when I finish re-writing that page.