### PR TITLE
add environments.md to nav

### DIFF
--- a/_pages/model-deployment/environments.md
+++ b/_pages/model-deployment/environments.md
@@ -2,12 +2,14 @@
 layout: article
 title:  "Algorithm Environments"
 excerpt: "Matrix of supported algorithm runtime environments"
-categories: model-guides
+categories: algorithm-development
 tags: [algo-model-guide]
 show_related: true
 permalink: /model-deployment/environments/
 redirect_from:
 - /model-deployment/matrix/
+- /model-deployment/environments
+- /environments
 ---
 
 ## Overview

--- a/_pages/model-deployment/environments.md
+++ b/_pages/model-deployment/environments.md
@@ -5,7 +5,7 @@ excerpt: "Matrix of supported algorithm runtime environments"
 categories: algorithm-development
 tags: [algo-model-guide]
 show_related: true
-permalink: /model-deployment/environments/
+permalink: /algorithm-development/environments/
 redirect_from:
 - /model-deployment/matrix/
 - /model-deployment/environments


### PR DESCRIPTION
Adding the environments matrix to the nav bar under "algorithm-development" instead of with the deployment guides.