### PR TITLE
Speed up local dev and make it more apparent that stuff is happening

### DIFF
--- a/_config-dev.yml
+++ b/_config-dev.yml
@@ -8,3 +8,9 @@ cdnurl: http://localhost:4000
 isLocalDev: true
 
 plugins_dir: _plugins-dev
+
+# This is a subset of the plugins configured in _config.yml
+# Removing some plugins speeds up local dev
+plugins:
+  - jekyll-redirect-from
+  - jekyll-last-modified-at

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "4567:4567"
   jekyll:
     image: algorithmiahq/dev-center:local-dev-jekyll-server
-    command: bundle exec jekyll serve --config _config.yml,_config-dev.yml --port 4001 --host 0.0.0.0
+    command: bundle exec jekyll serve --config _config.yml,_config-dev.yml --port 4001 --host 0.0.0.0 --incremental --verbose
     volumes:
       - .:/jekyll
     ports:

--- a/local.jekyll.Dockerfile
+++ b/local.jekyll.Dockerfile
@@ -24,4 +24,4 @@ VOLUME  /jekyll
 
 EXPOSE 4001
 
-CMD ["bundle", "exec jekyll serve --config _config.yml,_config-dev.yml --port 4001 --host 0.0.0.0"]
+CMD ["bundle", "exec jekyll serve --config _config.yml,_config-dev.yml --port 4001 --host 0.0.0.0 --incremental --verbose"]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://algorithmia.com/",
   "license": "The MIT License (MIT)",
   "scripts": {
-    "dev": "docker-compose up",
+    "dev": "docker compose up",
     "setup": "rm -rf vendor && git submodule init && git submodule update && docker run -v $PWD:/jekyll algorithmiahq/dev-center:local-dev-jekyll-server bundle install",
     "test": "concurrently \"yarn dev\" \"sleep 1m yarn test:run\"",
     "test:run": "cross-env NODE_ENV=production ./node_modules/.bin/mocha ./server/index.spec.js --timeout=10000"


### PR DESCRIPTION
This improves local dev in a few ways:

- Adds `--verbose` flag to make it more apparent that stuff is happening when Jekyll starts up
- Adds the `--incremental` flag to leverage caching on subsequent Jekyll builds so that Jekyll only targets changed files
- Updates the docker compose command to work with the newest version of Docker
- Removes the sitemap plugin when working locally since it was a bottleneck