### PR TITLE
clear cache on startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://algorithmia.com/",
   "license": "The MIT License (MIT)",
   "scripts": {
-    "dev": "docker compose up",
+    "dev": "yarn reset:cache && docker compose up",
     "setup": "rm -rf vendor && git submodule init && git submodule update && docker run -v $PWD:/jekyll algorithmiahq/dev-center:local-dev-jekyll-server bundle install",
     "test": "concurrently \"yarn dev\" \"sleep 1m yarn test:run\"",
     "test:run": "cross-env NODE_ENV=production ./node_modules/.bin/mocha ./server/index.spec.js --timeout=10000",


### PR DESCRIPTION
 Quick fix to startup script to clear the Jekyll cache before starting. This helps changes take effect in develop mode.

