### PR TITLE
Move kafka admin

### DIFF
--- a/_pages/integrations/kafka.md
+++ b/_pages/integrations/kafka.md
@@ -10,63 +10,39 @@ redirect_from:
   - /integrations/message-broker/
   - /integrations/event-flows
 ---
-Create event-driven algorithm workflows to move towards automating your machine learning deployment and monitoring pipelines. We make it easy to ensure connections from your Algorithmia Enterprise cluster to your externally hosted message brokers are secure, provide observability features for easy debugging, and provide an intuitive user interface for data scientists and application developers to create algorithm workflows that respond to events such as new messages written to a queue, or successful algorithm runs. Algorithmia Event Flows allow you to create dynamic data processing and inference pipelines with a few easy steps.
 
-This guide will help Enterprise cluster administrators set up message broker connections, and show members of Enterprise organizations how to activate event-driven workflows for any organization-owned algorithm their cluster administrator has enabled.
+With Algorithmia Event Flows, you can create dynamic, event-driven data processing and inference pipelines in just a few easy steps, helping you toward automating ML deployment and monitoring pipelines.
+
+Event Flows provides an easy way to establish secure connections from your Algorithmia Enterprise cluster to your externally hosted message brokers. We provide observability features for easy debugging, as well as an intuitive user interface (UI) for data scientists and application developers to create algorithm workflows that respond to events such as new messages written to a queue, or successful algorithm runs.
 
 This is only available for Enterprise installations of Algorithmia.
 {: .notice-enterprise}
 
-## Creating and Configuring a Broker Connection in the Algorithmia platform
+## Creating and configuring a broker connection in the Algorithmia platform
 
-Cluster administrators can set up connections to configured message brokers on external clusters that the customer owns.
+In order to use Event Flows, a cluster administrator must first [connect an external message broker](https://training.algorithmia.com/exploring-the-admin-panel/807062) to the cluster.
 
-Open the Algorithmia Web user interface and log in with an admin account.
+Once at least one message broker is connected, members of Enterprise organizations can activate event-driven workflows for any organization-owned algorithm that a cluster administrator has enabled.
 
-Under the Admin menu, click on the "Broker Manager" menu item (under the "System Actions" category) to see a list of configured broker connections.
-
-<img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/message-broker/broker-connection-list.png" alt="A broker connection list">
-
-To create a new broker connection, click on the "Connect Broker" button. This will bring up a form where the admin will fill in the proper configuration options. When filled in, click on the "Connect to Kafka Broker" button to make the connection. When successful, the admin will see the new connection in the list of configured brokers. 
-
-In addition to Kafka, algorithmia supports [Amazon SQS](/developers/integrations/amazon-sqs/) and [Azure SB](/developers/integrations/azure-sb) message brokers.
+Note that in addition to Kafka, algorithmia supports [Amazon SQS](/developers/integrations/amazon-sqs/) and [Azure SB](/developers/integrations/azure-sb) message brokers.
 {: .notice-info}
 
-<img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/message-broker/broker-connection-create.png" alt="Creating a broker connection">
+## Enabling event-driven algorithm workflows
 
-Click on a configured broker connection in the list to view its details and the list of topics set up for this broker connection. This details page is where the cluster administrator will also configure the algorithms that have access to these topics. Also on this page is an action button to delete the broker connection. Clicking it will present a confirmation dialog. After confirming, the broker connection will be removed from the list and unavailable for algorithms to use.
+Once a cluster administrator sets up a broker connection and allows publish or subscribe access to a specific topic for a specific organization-owned algorithm, members of that organization will be able to activate event flows for that algorithm.
 
-There is no mechanism for editing a broker connection once created. It is recommended to create a new one, and delete the one that it is replacing.
-{: .notice-info}
+To get started, log in to the Algorithmia browser UI and click on the ML service catalog menu item to view the list of available algorithms. Select an existing algorithm that's been configured with access to topics via the broker connection configuration (following the admin steps [above](#creating-and-configuring-a-broker-connection-in-the-algorithmia-platform)).
 
-<img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/message-broker/broker-connection-details.png" alt="Broker connection details">
-
-To make topics available to specific algorithms, the admin will select a topic on the broker connection details page. A sidesheet will open on the right that will contain details about the topic, including the list of algorithms with access to the selected topic.
-
-<img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/message-broker/broker-connection-topic-details.png" alt="Broker connection topic details">
-
-To edit the topic details, click on the "Edit" button at the top of the sidesheet. This will open a page where algorithms can be added or removed from the access list. After performing the additions or deletions of algorithms to the topic, the admin must click the "Save changes" button to submit the changes. When the changes are saved successfully, the page will return to the broker connection details.
-
-<img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/message-broker/broker-connection-topic-edit.png" alt="Editing a broker connection topic">
-
-
-## Enable event-driven algorithm workflows
-
-Once a cluster administrator sets up a broker connection and allows access to queues for a specific organization-owned algorithm, members of that organization will be able to enable those queues with a version of the specific algorithm.
-
-Open the Algorithmia Web user interface and log in.
-
-Click on the Algorithms menu item and select an existing algorithm that has been configured with access to topics via the broker connection configuration following the admin steps [above](#creating-and-configuring-a-broker-connection-in-the-algorithmia-platform). Click on the Queues tab to see a list of queues that the algorithm can access. There are action buttons on the right side of each listed queue. Depending on its state, the user will see an "Enable" button if the queue is disabled for the algorithm, and "Disable" and "Edit" buttons if the queue is enabled for the algorithm. 
+Click on the **Events** tab to see a list of broker topics that the algorithm can access. There are action buttons on the right side of each listed broker. Depending on the state of the topic, you'll see an **Enable** button if the topic is disabled for the algorithm, and **Disable** and **Edit** buttons if the topic is enabled for the algorithm.
 
 <img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/message-broker/algorithm-queue-list.png" alt="Algorithm queue list">
 
-Clicking on the "Disable" button will present a confirmation dialog. Once confirmed, the queue will no longer process the algorithm data.
+Clicking the **Disable** button will present a confirmation dialog. Once confirmed, the algorithm data will no longer be sent to the topic.
 
-Clicking on the "Enable" or "Edit button will present a dialog to select the appropriate algorithm version. Once a version is selected, submit it with the "Enable Listener" or "Save Changes" button to allow the queue to process algorithm data. 
+Clicking on the **Enable** or **Edit** button will present a dialog to select the appropriate algorithm version. Once a version is selected, submit it with the **Enable Listener** or **Save Changes** button to allow the topic to receive algorithm data.
 
 <img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/message-broker/algorithm-queue-enable.png" alt="Algorithm queue enable">
 
-Clicking on the "Enable Dead Letter Queue" checkbox 
-will allow you to select a Dead Letter Queue topic for an algorithm. Once a Dead Letter Queue topic name has been selected, click the "Enable Listener" or "Save Changes" button to allow faulty messages to be sent to the selected Dead Letter Queue topic name.
+Clicking on the **Enable Dead Letter Queue** checkbox allows you to select a Dead Letter Queue topic for an algorithm. Once a Dead Letter Queue topic name has been selected, click the **Enable Listener** or **Save Changes** button to allow faulty messages to be sent to the selected Dead Letter Queue topic name.
 
 <img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/message-broker/algorithm-queue-enable-dlq.png" alt="Algorithm queue enable a Dead Letter Queue topic">

--- a/_pages/integrations/kafka.md
+++ b/_pages/integrations/kafka.md
@@ -1,14 +1,14 @@
 ---
-layout: article
-title: "Algorithmia Event Flows"
-excerpt-short: "Set up message broker connections and topics that can be enabled to process algorithm data"
 categories: event-flows
-tags: [integrations, event-flows]
+excerpt-short: "Set up message broker connections and topics that can be enabled to process algorithm data"
+layout: article
 permalink: integrations/kafka
-show_related: true
 redirect_from:
   - /integrations/message-broker/
   - /integrations/event-flows
+show_related: true
+tags: [integrations, event-flows]
+title: "Algorithmia Event Flows"
 ---
 
 With Algorithmia Event Flows, you can create dynamic, event-driven data processing and inference pipelines in just a few easy steps, helping you automate ML deployment and monitoring pipelines.

--- a/_pages/integrations/kafka.md
+++ b/_pages/integrations/kafka.md
@@ -11,18 +11,18 @@ redirect_from:
   - /integrations/event-flows
 ---
 
-With Algorithmia Event Flows, you can create dynamic, event-driven data processing and inference pipelines in just a few easy steps, helping you toward automating ML deployment and monitoring pipelines.
+With Algorithmia Event Flows, you can create dynamic, event-driven data processing and inference pipelines in just a few easy steps, helping you automate ML deployment and monitoring pipelines.
 
 Event Flows provides an easy way to establish secure connections from your Algorithmia Enterprise cluster to your externally hosted message brokers. We provide observability features for easy debugging, as well as an intuitive user interface (UI) for data scientists and application developers to create algorithm workflows that respond to events such as new messages written to a queue, or successful algorithm runs.
 
-This is only available for Enterprise installations of Algorithmia.
+This feature is only available in Enterprise installations of Algorithmia.
 {: .notice-enterprise}
 
 ## Creating and configuring a broker connection in the Algorithmia platform
 
-In order to use Event Flows, a cluster administrator must first [connect an external message broker](https://training.algorithmia.com/exploring-the-admin-panel/807062) to the cluster.
+In order to use Event Flows, a cluster administrator must first [connect an external message broker](https://training.algorithmia.com/exploring-the-admin-panel/807062) to the Algorithmia cluster.
 
-Once at least one message broker is connected, members of Enterprise organizations can activate event-driven workflows for any organization-owned algorithm that a cluster administrator has enabled.
+Once at least one message broker has been connected, members of Algorithmia organizations can activate event-driven workflows for any organization-owned algorithm that a cluster administrator has enabled.
 
 Note that in addition to Kafka, algorithmia supports [Amazon SQS](/developers/integrations/amazon-sqs/) and [Azure SB](/developers/integrations/azure-sb) message brokers.
 {: .notice-info}
@@ -31,7 +31,7 @@ Note that in addition to Kafka, algorithmia supports [Amazon SQS](/developers/in
 
 Once a cluster administrator sets up a broker connection and allows publish or subscribe access to a specific topic for a specific organization-owned algorithm, members of that organization will be able to activate event flows for that algorithm.
 
-To get started, log in to the Algorithmia browser UI and click on the ML service catalog menu item to view the list of available algorithms. Select an existing algorithm that's been configured with access to topics via the broker connection configuration (following the admin steps [above](#creating-and-configuring-a-broker-connection-in-the-algorithmia-platform)).
+To get started, log in to the Algorithmia browser UI and click on the ML service catalog menu item on the left nav bar to view the list of available algorithms. Select an existing algorithm that's been configured with access to topics via the broker connection configuration (following the admin steps [above](#creating-and-configuring-a-broker-connection-in-the-algorithmia-platform)).
 
 Click on the **Events** tab to see a list of broker topics that the algorithm can access. There are action buttons on the right side of each listed broker. Depending on the state of the topic, you'll see an **Enable** button if the topic is disabled for the algorithm, and **Disable** and **Edit** buttons if the topic is enabled for the algorithm.
 
@@ -43,6 +43,6 @@ Clicking on the **Enable** or **Edit** button will present a dialog to select th
 
 <img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/message-broker/algorithm-queue-enable.png" alt="Algorithm queue enable">
 
-Clicking on the **Enable Dead Letter Queue** checkbox allows you to select a Dead Letter Queue topic for an algorithm. Once a Dead Letter Queue topic name has been selected, click the **Enable Listener** or **Save Changes** button to allow faulty messages to be sent to the selected Dead Letter Queue topic name.
+Clicking on the **Enable Dead Letter Queue** checkbox allows you to select a dead letter queue (DLQ) topic for an algorithm. Once a Dead Letter Queue topic name has been selected, click the **Enable Listener** or **Save Changes** button to allow faulty messages to be sent to the selected DLQ topic name.
 
 <img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/message-broker/algorithm-queue-enable-dlq.png" alt="Algorithm queue enable a Dead Letter Queue topic">


### PR DESCRIPTION
[DOCS-151](https://algorithmia.atlassian.net/browse/DOCS-151) - Algorithmia Event Flows/Kafka: split up cluster admin portion and user portion

The admin content has been moved to the [Training Center](https://training.algorithmia.com/exploring-the-admin-panel/807062). Will continue to improve this now that the UI and Event Flow user workflow is in a more stable state.

## Checklist
- [x] My PR title includes a relevant Jira ticket name
- [ ] If no associated Jira ticket, my PR title is informative (individual commit messages are squashed in this repo)
- [x] Unnecessary text (Notes, TODOs, etc.) has been removed
- [x] Screenshots, if present, are full-width and follow the [Screenshot guidelines](https://algorithmia.atlassian.net/wiki/spaces/CUSTOMERS/pages/1634861478/CFD+Style+Guide#Screenshots)
- [x] Grammar, style, tone, punctuation, etc. follow the Algorithmia [manual of style](https://docs.google.com/document/d/1PPVfgMkX7-EVGLPMhN1E485CAXu9QfhSLKM0lZhnZdU/edit?usp=sharing)
- [x] Headers are “Sentence case with Proper Nouns capitalized”
- [x] Placeholder strings are UPPER_SNAKE_CASE and are named as in the [Glossary](https://docs.google.com/document/d/1bYs0j_a4v8LbkbS8r0x2SZ_J6mZ4sIt4w_60dq8iGh4/edit#heading=h.qov2yks2a685) where appropriate
