### PR TITLE
add link to admin config for user-facing errors

### DIFF
--- a/_pages/platform/account-profile.md
+++ b/_pages/platform/account-profile.md
@@ -43,7 +43,7 @@ This tab lists any organizations of which you're a member. To learn about how to
 This tab displays the API keys you own. Each key can be edited or deleted through the action menu at the right of the corresponding row in the table. For information about how to use API keys, see [API Keys]({{site.baseurl}}//platform/customizing-api-keys).
 
 ### Errors
-Beginning in Algorithmia version 20.5.52, this tab displays runtime errors from algorithms that you've called. Specifically, it lists the 200 most recent algorithm runtime errors over the past seven days that've been called using any of your API keys.
+Beginning in Algorithmia version 20.5.52, this tab displays runtime errors from algorithms that you've called. Specifically, it lists the 200 most recent algorithm runtime errors over the past seven days that've been called using any of your API keys. Note that this feature is disabled by default and can only be [enabled by a cluster administrator](https://training.algorithmia.com/managing-advanced-workflows/829681).
 
 For each error, the algorithm endpoint is listed along with the exact date and time that the error occurred. If the error is a [custom Algorithmia error type]({{site.baseurl}}/algorithm-development/algorithm-errors), that information is displayed as well. The error message is displayed in red below these details.
 


### PR DESCRIPTION
no Jira ticket, just adding a missing link to admin content for user-facing errors
