### PR TITLE
Docs 259 secret store wording updates

### DIFF
--- a/_pages/platform/secret-store.md
+++ b/_pages/platform/secret-store.md
@@ -1,7 +1,7 @@
 ---
 layout: article
 title:  "Secret Store"
-excerpt: ""
+excerpt: "Use Algorithmia's Secret Store to save and access sensitive data"
 categories: basics
 nav_index: 40
 show_related: true
@@ -19,24 +19,24 @@ Algorithmia's Secret Store enables you to decouple sensitive data like passwords
   - Connecting to a password-protected database
   - Calling a secure HTTP webhook to `POST` your algorithm result
 
-Secrets are encrypted at rest, encrypted in transit, and only exposed to the select algorithms that you specify. We never expose sensitive data through the web interface or any user-facing APIs.
+Secrets are encrypted at rest, encrypted in transit, and only exposed to the select algorithms you specify. We never expose sensitive data through the web interface or any user-facing APIs.
 
-Keep in mind that any Algorithmia collaborator who has access to an algorithm's source code can also access an algorithm's secrets by modifying that source code to view the secret value.
+Keep in mind that any Algorithmia collaborator who has access to an algorithm's source code can also access an algorithm's secrets by modifying that source code to expose the secret value.
 
-#### External secret stores 
+#### External secret providers
 
 This feature is available to [Algorithmia Enterprise](/enterprise) users only.
 {: .notice-enterprise}
 
 If your organization uses an external vaulting system to manage secrets, storing these data within Algorithmia might not be suitable. Therefore, Algorithmia Enterprise's Secret Store enables cluster admins to connect Algorithmia to external vaulting systems such as Hashicorp Vault and Azure Key Vault, where secrets are managed and maintained by a DevOps team. This helps Data Science teams access secrets in accordance to an organization's security and compliance standards.
 
-## Managing algorithm secrets
+## Managing Secret Store entries
 
-Algorithm secrets are managed through the **Settings** tab on an algorithm's homepage, where you can create, update, and delete secrets, and view secret metadata.
+Secrets are managed through the **Settings** tab on an algorithm's homepage, where you can create, update, and delete secrets, and view secret metadata.
 
 ![Image of UI settings page for creating secrets](/developers/images/post_images/algorithm_secrets/settings_page.png)
 
-To create a new algorithm secret, click **New secret**.
+To create a new entry in the Secret Store, click **New secret**.
 
 In the modal, select the **secret provider**. This will default to the internal secret provider if an external secret provider hasn't been configured on your cluster.
 
@@ -47,20 +47,20 @@ It can take up to one minute for new secrets to show up inside your algorithm. S
 
 ![Image of UI create secret page](/developers/images/post_images/algorithm_secrets/create_secret_page.png)
 
-After your secret is created, it can be updated or deleted from the same page. Clicking "Update" will open the same modal as shown above, and you'll be able to  change the secret's name, description, and value. Note that through the settings page you can view but not update an existing secret's environment variable name, and you can update but not view an existing secret's value.
+After your secret is created, it can be updated or deleted from the same page. Clicking **Update** will open the same modal as shown above, and you'll be able to change the secret's name, description, and value. Note that through the settings page you can view but not update an existing secret's environment variable name, and you can update but not view an existing secret's value.
 
 ![Image of UI settings page with an existing secret](/developers/images/post_images/algorithm_secrets/settings_page_with_secret.png)
 
-## Accessing algorithm secrets
+## Accessing Secret Store values
 
-Secrets are accessed in your algorithm source code through environment variables. Every language supported by Algorithmia can read environment variables using the language's standard library.
+Secrets are accessed in your algorithm source code through environment variables. Every language supported by Algorithmia can read environment variables using functionality in the language's standard library.
 
-The following demonstrates how you'd access a secret from an environment variable in Python. Note that this code just returns the value, but in practice you wouldn't return the value; rather, you'd use the secret to establish a database connection, etc.
+The following demonstrates how you'd access a Secret Store secret from an environment variable in Python. Note that this code just returns the value, but in practice, we don't recommend returning secret values! Rather, you'd use the secret to establish a database connection, etc., within your algorithm.
 
-Keep your secrets safe! We highly recommend that you never include secrets in your algorithm output. This example demonstrates how algorithms can leak sensitive data if secrets aren't handled correctly.
+Keep your secrets safe! We highly recommend you never include secrets in your algorithm output. The example above demonstrates how algorithms can leak sensitive data if secrets aren't handled correctly.
 {: .notice-warning}
 
-{% highlight python %} 
+{% highlight python %}
 import os
 
 import Algorithmia

--- a/_pages/platform/secret-store.md
+++ b/_pages/platform/secret-store.md
@@ -24,7 +24,7 @@ Keep in mind that any Algorithmia collaborator who has access to an algorithm's 
 
 #### External secret providers
 
-This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+The ability to use external secret providers is available to [Algorithmia Enterprise](/enterprise) users only.
 {: .notice-enterprise}
 
 If your organization uses an external vaulting system to manage secrets, storing these data within Algorithmia might not be suitable. Therefore, Algorithmia Enterprise's Secret Store enables cluster admins to connect Algorithmia to external vaulting systems such as Hashicorp Vault and Azure Key Vault, where secrets are managed and maintained by a DevOps team. This helps Data Science teams access secrets in accordance to an organization's security and compliance standards.

--- a/_pages/platform/secret-store.md
+++ b/_pages/platform/secret-store.md
@@ -1,16 +1,15 @@
 ---
-layout: article
-title:  "Secret Store"
-excerpt: "Use Algorithmia's Secret Store to save and access sensitive data"
 categories: basics
-nav_index: 40
-show_related: true
+excerpt: "Use Algorithmia's Secret Store to save and access sensitive data"
 image:
     teaser: /icons/algo.svg
+layout: article
 permalink: /platform/secret-store/
 redirect_from:
   - /basics/algorithm-secrets/
   - /platform/algorithm-secrets/
+show_related: true
+title:  "Secret Store"
 ---
 
 Algorithmia's Secret Store enables you to decouple sensitive data like passwords, access tokens, and credentials from your algorithm source code. With this feature, you can store your sensitive data securely on Algorithmia and access individual secret values from within your algorithms using environment variables.

--- a/_pages/release-notes.md
+++ b/_pages/release-notes.md
@@ -86,9 +86,9 @@ Our latest release includes a variety of new features that primarily focus on im
 
 We’re proud to share that we’ve expanded our security features to provide even greater protection for your business.
 
-#### Secret store for external resources ####
+#### Secret Store for external resources ####
 
-We’ve created a vault-based secret store, enabling you to create and manage credentials in a central location for access to data sources and web services. This will allow you to provide access to resources without the need to expose credentials or share them amongst the users that require access to sensitive information. Additionally, integrations with third-party vault tools to integrate with your internal vault implementation are being added.
+We’ve created a vault-based Secret Store, enabling you to create and manage credentials in a central location for access to data sources and web services. This will allow you to provide access to resources without the need to expose credentials or share them amongst the users that require access to sensitive information. Additionally, integrations with third-party vault tools to integrate with your internal vault implementation are being added.
 
 #### SSO upgrades ####
 


### PR DESCRIPTION
[DOCS-XXX259](https://algorithmia.atlassian.net/browse/DOCS-259) - Update Dev Center to change naming from Algorithm Secrets to Secret Store

![image](https://user-images.githubusercontent.com/36384768/122306576-8aef2000-cebd-11eb-8341-33d080a83a9c.png)

did not update screenshots yet, made DOCS-260 to do that

## Checklist
- [x] My PR title includes a relevant Jira ticket name
- [ ] If no associated Jira ticket, my PR title is informative (individual commit messages are squashed in this repo)
- [x] Unnecessary text (notes, TODOs, etc.) has been removed
- [x] For YAML "front matter":
  - Properties are alphabetized
  - `permalink` and `redirect_from/to` properties have `/` at beginning and end (e.g., `/path/`)
- [ ] Screenshots, if present, follow the [Screenshot guidelines](https://algorithmia.atlassian.net/wiki/spaces/CUSTOMERS/pages/1634861478/CFD+Style+Guide#Screenshots) which means:
  - Full browser width (browser at 100% zoom and 10-12" width)
  - Max 1000px
- [x] Grammar, style, tone, punctuation, etc. follow the Algorithmia [manual of style](https://docs.google.com/document/d/1PPVfgMkX7-EVGLPMhN1E485CAXu9QfhSLKM0lZhnZdU/edit?usp=sharing)
- [x] Headers are “Sentence case with Proper Nouns capitalized”
- [x] Placeholder strings are `UPPER_SNAKE_CASE` and are named as in the [Glossary](https://docs.google.com/document/d/1bYs0j_a4v8LbkbS8r0x2SZ_J6mZ4sIt4w_60dq8iGh4/edit#heading=h.qov2yks2a685) where appropriate
