### PR TITLE
Move Insights info from client guides to language guides

### DIFF
--- a/_pages/algorithm-development/languages/java.md
+++ b/_pages/algorithm-development/languages/java.md
@@ -1,29 +1,29 @@
 ---
-layout: article
-title:  "Java"
-excerpt: "Build your algorithm in Java"
-categories: languages
-tags: [algo-guide-lang]
-show_related: true
 author: steph_kim
+categories: languages
+excerpt: "Build your algorithm in Java"
 image:
     teaser: /language_logos/java.svg
+layout: article
+show_related: true
+tags: [algo-guide-lang]
+title:  "Java"
 ---
 
 Before you get started learning about Java algorithm development, make sure you go through our <a href="{{site.baseurl}}/algorithm-development/algorithm-basics/your-first-algo">Getting Started Guide</a> to learn how to create your first algorithm, understand permissions available, versioning, using the CLI, and more.
 
-Table of Contents
+Table of contents
 
-* [Available Libraries](#available-libraries)
-* [Write your First Algorithm](#write-your-first-algorithm)
-* [Managing Dependencies](#managing-dependencies)
-* [I/O for your Algorithms](#io-for-your-algorithms)
-* [Error Handling](#error-handling)
-* [Algorithm Checklist](#algorithm-checklist)
-* [Publish Algorithm](#publish-algorithm)
-* [Conclusion and Resources](#conclusion-and-resources)
+* [Available libraries](#available-libraries)
+* [Write your first algorithm](#write-your-first-algorithm)
+* [Managing dependencies](#managing-dependencies)
+* [I/O for your algorithms](#io-for-your-algorithms)
+* [Error handling](#error-handling)
+* [Algorithm checklist](#algorithm-checklist)
+* [Publish algorithm](#publish-algorithm)
+* [Conclusion and resources](#conclusion-and-resources)
 
-## Available Libraries
+## Available libraries
 
 Algorithmia makes a number of libraries available to make algorithm development easier.
 
@@ -32,7 +32,7 @@ is available for you to use in your algorithms.
 
 Furthermore, algorithms can call other algorithms and manage data on the Algorithmia platform via the <a href="{{site.baseurl}}/clients/java">Algorithmia Java Client</a>.
 
-## Write your First Algorithm
+## Write your first algorithm
 
 If you've followed the <a href="{{site.baseurl}}/algorithm-development/algorithm-basics/your-first-algo">Getting Started Guide</a>, you'll notice in your algorithm editor, there is boilerplate code that returns "Hello" and whatever you input to the console.
 
@@ -45,7 +45,7 @@ Go ahead and remove the boilerplate code below that's inside the apply() functio
 
 <img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/algo_dev_lang/algorithm_console_java.png" alt="Algorithm console Java" class="screenshot">
 
-## Managing Dependencies
+## Managing dependencies
 
 Algorithmia supports adding 3rd party dependencies via Maven packages. Specifically, any packages from
 <a href="https://search.maven.org/artifact/com.algorithmia/algorithmia-client/">Maven Central</a> can be added to algorithms.
@@ -73,7 +73,7 @@ The Algorithmia dependency is already installed for your convenience. For more i
 
 This guide won't depend on any external dependencies so you can close the dependencies window.
 
-## I/O for your Algorithms
+## I/O for your algorithms
 
 Now let's get started on the hands-on portion of the guide:
 
@@ -83,7 +83,7 @@ It will output a JSON formatted object which the user will consume with an API c
 
 This path is based on your Algorithmia user name and the name of your algorithm, so if you are “AdaDeveloper” and your algorithm is “TokenizeText”, then the path for version 0.1.1 of your algorithm will be AdaDeveloper/TokenizeText/0.1.1
 
-### Working with Basic Data Structures
+### Working with basic data structures
 
 Below is a code sample showing how to create an algorithm working with basic user input.
 
@@ -125,7 +125,7 @@ You should see the value from the key returned in the console:
 "some/path/somefile.txt"
 {% endhighlight %}
 
-### Working with Data Stored on Algorithmia
+### Working with data stored on Algorithmia
 
 This next code snippet shows how to create an algorithm working with a data file that a user has stored using Algorithmia's [Hosted Data Source]({{site.baseurl}}/data/hosted).
 
@@ -276,7 +276,7 @@ save_some_output_to(tempfile);
 client.file(file_uri).put(tempfile);
 {% endhighlight %}
 
-### Calling Other Algorithms and Managing Data
+### Calling other algorithms and managing data
 
 To call other algorithms or manage data from your algorithm, use the <a href="{{site.baseurl}}/clients/java">Algorithmia Java Client</a> which is automatically available to any algorithm you create on the Algorithmia platform. For more detailed information on how to work with data see the [Data API docs](http://docs.algorithmia.com/) and learn about Algorithmia's [Hosted Data Source]({{site.baseurl}}/data).
 
@@ -348,7 +348,7 @@ For an example that takes and processes image data check out the [Places 365 Cla
 Some older algorithms use our deprecated Java client. If it has an import from the <code>algorithmia</code> package instead of the <code>com.algorithmia</code> package, that means it is using the deprecated client.
 {: .notice-warning}
 
-## Error Handling
+## Error handling
 
 {% highlight java %}
 throw new AlgorithmException("Invalid graph structure");
@@ -358,13 +358,13 @@ Algorithms can throw any exception, and they will be returned as an error via th
 
 For more information on error handling see the <a href="{{site.baseurl}}/algorithm-development/algorithm-basics/algorithm-errors">Better Error Handling Guide</a>.
 
-## Algorithm Checklist
+## Algorithm checklist
 
 Before you are ready to publish your algorithm it's important to go through this [Algorithm Checklist]({{site.baseurl}}/algorithm-development/algorithm-checklist) and check out this blog post for <a href="https://algorithmia.com/blog/advanced-algorithm-design">Advanced Algorithm Development <i class="fa fa-external-link"></i></a>.
 
 Both links will go over important best practices such as how to create a good algorithm description, add links to external documentation and other important information.
 
-## Publish Algorithm
+## Publish algorithm
 
 Once you've developed your algorithm, you can publish it and make it available for others to use.
 
@@ -386,7 +386,7 @@ Under Semantic Versioning you can choose which kind of release your change shoul
 
 If you are satisfied with your algorithm and settings, go ahead and hit publish. Congratulations, you’re an algorithm developer!
 
-## Conclusion and Resources
+## Conclusion and resources
 
 In this guide we covered how to create an algorithm, work with different types of data and learned how to publish an algorithm.
 

--- a/_pages/algorithm-development/languages/java.md
+++ b/_pages/algorithm-development/languages/java.md
@@ -19,6 +19,7 @@ Table of contents
 * [Managing dependencies](#managing-dependencies)
 * [I/O for your algorithms](#io-for-your-algorithms)
 * [Error handling](#error-handling)
+* [Publishing Algorithmia Insights](#publishing-algorithmia-insights)
 * [Algorithm checklist](#algorithm-checklist)
 * [Publish algorithm](#publish-algorithm)
 * [Conclusion and resources](#conclusion-and-resources)
@@ -357,6 +358,33 @@ throw new AlgorithmException("Invalid graph structure");
 Algorithms can throw any exception, and they will be returned as an error via the Algorithmia API. If you want to throw a generic exception message, use an `AlgorithmException`.
 
 For more information on error handling see the <a href="{{site.baseurl}}/algorithm-development/algorithm-basics/algorithm-errors">Better Error Handling Guide</a>.
+
+## Publishing Algorithmia Insights
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
+
+Inference-related metrics (a feature of [Algorithmia Insights](../algorithmia-enterprise/algorithmia-insights)) can be reported via using the `report_insights` method of the Algorithmia client.
+
+Depending on your algorithm, you might want to report on the algorithm payload for each API call (such as the features or number of features), the output of the algorithm to monitor data distributions of predictions, or probability of each inference.
+
+In the case of an example credit scoring model, shown in this [demo for Algorithmia Insights](https://www.youtube.com/watch?v=pdKwtp-_n2M), reported metrics include the algorithm predictions:
+
+{% highlight java %}
+// Report Algorithmia Insights
+client.reportInsights(new HashMap<String,Object>() { {
+    put("risk_score", risk_score);
+    put("approved", approved);
+} });
+{% endhighlight %}
+
+{% highlight json %}
+// Sample model output that is pushed to Insights
+{
+  "approved": 1,
+  "risk_score": 0.08
+}
+{% endhighlight %}
 
 ## Algorithm checklist
 

--- a/_pages/algorithm-development/languages/python.md
+++ b/_pages/algorithm-development/languages/python.md
@@ -304,6 +304,30 @@ from .secondary_file import auxillary_func, some_other_func
 from .sub_module.special_stuff import special_stuff
 ```
 
+## Publishing Algorithmia Insights
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
+
+Inference-related metrics (a feature of [Algorithmia Insights](../algorithmia-enterprise/algorithmia-insights)) can be reported via using the `report_insights` method of the Algorithmia client.
+
+Depending on your algorithm, you might want to report on the algorithm payload for each API call (such as the features or number of features), the output of the algorithm to monitor data distributions of predictions, or probability of each inference.
+
+In the case of an example credit scoring model, shown in this <a href="https://www.youtube.com/watch?v=pdKwtp-_n2M">demo for Algorithmia Insights</a>, reported metrics include the algorithm predictions:
+
+{% highlight python %}
+# Report Algorithmia Insights
+client.report_insights({"risk_score": risk_score, "approved": approved})
+{% endhighlight %}
+
+{% highlight python %}
+# Sample model output that is pushed to Insights
+{
+  "approved": 1,
+  "risk_score": 0.08
+}
+{% endhighlight %}
+
 ## Algorithm checklist
 
 Before you are ready to publish your algorithm it's important to go through this [Algorithm Checklist]({{site.baseurl}}/algorithm-development/algorithm-checklist) and check out this blog post for <a href="https://algorithmia.com/blog/advanced-algorithm-design">Advanced Algorithm Development <i class="fa fa-external-link"></i></a>.

--- a/_pages/algorithm-development/languages/python.md
+++ b/_pages/algorithm-development/languages/python.md
@@ -24,6 +24,7 @@ Table of Contents
 * [Calling other algorithms](#calling-other-algorithms)
 * [Error handling](#error-handling)
 * [Algorithms with multiple files](#algorithms-with-multiple-files)
+* [Publishing Algorithmia Insights](#publishing-algorithmia-insights)
 * [Algorithm checklist](#algorithm-checklist)
 * [Publish algorithm](#publish-algorithm)
 * [Conclusion and resources](#conclusion-and-resources)

--- a/_pages/algorithm-development/languages/python.md
+++ b/_pages/algorithm-development/languages/python.md
@@ -1,13 +1,13 @@
 ---
-layout: article
-title:  "Python"
-excerpt: "Build your algorithm in Python"
-categories: languages
-tags: [algo-guide-lang]
-show_related: true
 author: steph_kim
+categories: languages
+excerpt: "Develop your algorithm in Python"
+layout: article
 image:
     teaser: /language_logos/python.svg
+show_related: true
+tags: [algo-guide-lang]
+title:  "Python"
 ---
 
 Before you get started learning about Python algorithm development, make sure you go through our <a href="{{site.baseurl}}/algorithm-development/algorithm-basics/your-first-algo">Getting Started Guide</a> to learn how to create your first algorithm, understand permissions available, versioning, using the CLI, and more. In this guide we'll cover algorithm development for Python in more depth, including making use of Algorithmia's [Algorithm Development Kit for Python](https://github.com/algorithmiaio/algorithmia-adk-python).
@@ -15,24 +15,24 @@ Before you get started learning about Python algorithm development, make sure yo
 Table of Contents
 
 * [What is an Algorithm Development Kit (ADK)?](#what-is-an-algorithm-development-kit-adk)
-* [Algorithm Project Structure](#adk-project-structure)
-* [Hello World](#hello-world)
-* [Loaded State](#loaded-state)
-* [Available Libraries](#available-libraries)
-* [Managing Dependencies](#managing-dependencies)
-* [I/O for your Algorithms](#io-for-your-algorithms)
-* [Calling Other Algorithms](#calling-other-algorithms)
-* [Error Handling](#error-handling)
-* [Algorithms with Multiple Files](#algorithms-with-multiple-files)
-* [Algorithm Checklist](#algorithm-checklist)
-* [Publish Algorithm](#publish-algorithm)
-* [Conclusion and Resources](#conclusion-and-resources)
+* [Algorithm project structure](#adk-project-structure)
+* [Hello world](#hello-world)
+* [Loaded state](#loaded-state)
+* [Available libraries](#available-libraries)
+* [Managing dependencies](#managing-dependencies)
+* [I/O for your algorithms](#io-for-your-algorithms)
+* [Calling other algorithms](#calling-other-algorithms)
+* [Error handling](#error-handling)
+* [Algorithms with multiple files](#algorithms-with-multiple-files)
+* [Algorithm checklist](#algorithm-checklist)
+* [Publish algorithm](#publish-algorithm)
+* [Conclusion and resources](#conclusion-and-resources)
 
 ## What is an Algorithm Development Kit (ADK)?
 
 An Algorithm Development Kit is a package that contains all of the necessary components to convert a regular application into one that can be executed and run on Algorithmia. To do that, an ADK must be able to communicate with Algorithmia's [langserver](https://github.com/algorithmiaio/langpacks/blob/develop/langpack_guide.md) service. To simplify development, an ADK exposes some optional functions, along with an `apply()` function that acts as the explicit entry point into your algorithm. Along with those basics, an ADK also exposes the ability to execute your algorithm locally, without `langserver`, which enables better debuggability.
 
-## Algorithm Project Structure
+## Algorithm project structure
 
 Algorithm development begins with your project's `src/Algorithm.py` file, where you'll import the Algorithmia ADK and implement the required functions. Each algorithm must contain an `apply()` function, which defines the input point of the algorithm. We use the `apply()` function in order to make different algorithms standardized. This makes them easily chained and helps authors think about designing their algorithms in a way that makes them easy to leverage and predictable for end users. When an algorithm is invoked via an API request, the body of the request is passed as `input` to our `apply()` function.
 
@@ -45,7 +45,7 @@ If youre a PyCharm user, you can refer to [this guide](https://algorithmia.com/d
 
 Let's look at an example to clarify some of these concepts.
 
-## Hello World
+## Hello world
 
 Below you'll find a `src/Algorithm.py` file which prints "hello" plus an input when it is invoked. We start by importing the Algorithmia ADK, and then defining our `apply()` function, followed by our call to the handler function `ADK()`, and finally calling `init()` to start the function.
 
@@ -61,7 +61,7 @@ algorithm.init("Algorithmia")
 
 When executed on the Algorithmia platform and providing the string "HAL 9000" as an input, this algorithm will output "hello HAL 9000". If executed locally, such as during development or debugging, the algorithm will print `hello Algorithmia` to `stdout` instead.
 
-## Loaded State
+## Loaded state
 
 When an algorithm is called, our platform checks whether there's already a running instance that's ready to handle the request, or whether a new one needs to be created. Spinning up a new algorithm instance involves overhead, and this can be substantial for algorithms with extensive code dependencies, or algorithms that need to load a significant amount of data into memory. Developing with an ADK allows you to make use of an optional `load()` function for preparing an algorithm for runtime operations, rather than performing these operations each time the algorithm is invoked.
 
@@ -88,7 +88,7 @@ In our load function we've created a `globals` object and added a key called `pa
 
 If a failure occurs while executing the `load()` function, the platform will raise a `loadingError`.
 
-## Available Libraries
+## Available libraries
 
 In addition to your own code in `src/Algorithm.py`, Algorithmia makes a number of libraries available to make algorithm development easier. We support multiple versions of Python and a variety of frameworks, and we continue to add new variants and broaden GPU support. A complete list of predefined environments can be found on the [Environment Matrix](/developers/algorithm-development/environments/) page, and are available through the "Environment" drop-down when creating a new algorithm.
 
@@ -98,7 +98,7 @@ In addition to the libraries and ML frameworks that we make available in our pre
 
 Also, algorithms can call other algorithms and manage data on the Algorithmia platform. You can learn more about calling algorithms in the <a href="{{site.baseurl}}/clients/python">Algorithmia Python Client Guide</a>.
 
-## Managing Dependencies
+## Managing dependencies
 
 Algorithmia supports adding third-party dependencies via the <a href="https://pypi.python.org/pypi">Python Package Index (PyPI)</a> using a requirements.txt file, where you can add the names of any dependencies you have. If you do add dependencies, you will still need to import those packages via the import statement to your algorithm file as you would do for any Python script.
 
@@ -116,11 +116,11 @@ If you're using Python 3, the syntax has changed for imports. You'll need to use
 `from .somefile import *` instead of in Python 2 where it's `from file import *`.
 {: .notice-warning}
 
-## I/O for your Algorithms
+## I/O for your algorithms
 
 Algorithm input is standardized across the Algorithmia platform. Algorithms take three basic types of input: strings, JSON, and binary data. You will need to parse the algorithm's `input` as part of your `apply()` or `load()` functions.
 
-### Working with Basic Data Structures
+### Working with basic data structures
 
 Below is a code sample showing how to work with basic user input in the `apply()` function. You'll also see some error handling, which we'll cover in more detail in the [Error Handling](#error-handling) section of this guide. Our input to this function is as follows:
 
@@ -156,7 +156,7 @@ If we were to run this code as part of our algorithm, we should see the minimum 
 {"max_num":6, "min_num":1}
 {% endhighlight %}
 
-### Working with Data Stored on Algorithmia
+### Working with data stored on Algorithmia
 
 This next code snippet shows how to create an algorithm that works with a data file stored in a [Hosted Data Collection]({{site.baseurl}}/data/hosted) on Algorithmia.
 
@@ -220,13 +220,13 @@ save_some_output_to(tempfile)
 client.file(file_uri).putFile(tempfile)
 {% endhighlight %}
 
-## Calling Other Algorithms
+## Calling other algorithms
 
 To call other algorithms from your algorithm you can use the <a href="{{site.baseurl}}/clients/python">Algorithmia Python Client</a>, which is automatically available to any algorithm you create on the Algorithmia platform. For more information on calling algorithms, you can refer to the [Python Client Guide](https://algorithmia.com/developers/clients/python#calling-an-algorithm).
 
 You may call up to {{site.data.stats.platform.max_num_parallel_algo_requests}} other algorithms, either in parallel or recursively.
 
-## Error Handling
+## Error handling
 
 In the above code examples we made use of an AlgorithmError class which you should use for handling errors within your algorithm. This way the user can tell the difference between a standard Python library error and an error thrown by your algorithm:
 
@@ -304,19 +304,19 @@ from .secondary_file import auxillary_func, some_other_func
 from .sub_module.special_stuff import special_stuff
 ```
 
-## Algorithm Checklist
+## Algorithm checklist
 
 Before you are ready to publish your algorithm it's important to go through this [Algorithm Checklist]({{site.baseurl}}/algorithm-development/algorithm-checklist) and check out this blog post for <a href="https://algorithmia.com/blog/advanced-algorithm-design">Advanced Algorithm Development <i class="fa fa-external-link"></i></a>.
 
 These resources provide important information on best practices, including how to write a good algorithm description and how to add links to external documentation.
 
-## Publish Algorithm
+## Publish algorithm
 
 Once you've developed your algorithm, you can publish it, which makes it available for others to use.
 
 To learn how to publish your algorithm you can refer to the Algorithm Development [Getting Started Guide]({{site.baseurl}}/algorithm-development/your-first-algo#publishing-your-algorithm).
 
-## Conclusion and Resources
+## Conclusion and resources
 
 In this guide we covered the basics of the ADK, how to create an algorithm and work with different types of data, and learned how to publish an algorithm. You can find [complete examples](https://github.com/algorithmiaio/algorithmia-adk-python#example-workflows) in the Algorithmia Python ADK repository on GitHub, inlcuding a [Pytorch based image classification example](https://github.com/algorithmiaio/algorithmia-adk-python#pytorch-based-image-classification).
 

--- a/_pages/algorithm-development/languages/r.md
+++ b/_pages/algorithm-development/languages/r.md
@@ -20,6 +20,7 @@ Table of contents
 * [Managing dependencies](#managing-dependencies)
 * [I/O for your algorithms](#io-for-your-algorithms)
 * [Error handling](#error-handling)
+* [Publishing Algorithmia Insights](#publishing-algorithmia-insights)
 * [Algorithm checklist](#algorithm-checklist)
 * [Publish algorithm](#publish-algorithm)
 * [Conclusion and resources](#conclusion-and-resources)
@@ -392,6 +393,18 @@ algo$pipe(list())$error$message
 
 For more information on error handling see the <a href="{{site.baseurl}}/algorithm-development/algorithm-basics/algorithm-errors">Better Error Handling Guide</a>.
 
+## Publishing Algorithmia Insights
+
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
+{: .notice-enterprise}
+
+Inference-related metrics (a feature of [Algorithmia Insights](../algorithmia-enterprise/algorithmia-insights)) can be reported via the `report_insights` method of the Algorithmia client. For example, to report a list:
+
+{% highlight r %}
+# Report Algorithmia Insights
+client$report_insights(list(faces_in_image=4)})
+{% endhighlight %}
+
 ## Algorithm checklist
 
 Before you are ready to publish your algorithm it's important to go through this [Algorithm Checklist]({{site.baseurl}}/algorithm-development/algorithm-checklist) and check out this blog post for <a href="https://algorithmia.com/blog/advanced-algorithm-design">Advanced Algorithm Development <i class="fa fa-external-link"></i></a>.
@@ -428,5 +441,5 @@ In this guide we covered how to create an algorithm, work with different types o
 
 * [Algorithmia CRAN package documentation](https://cran.r-project.org/web/packages/algorithmia/vignettes/introduction-to-algorithmia.html)
 * [Algorithmia R client documentation]({{site.baseurl}}/clients/r)
-* [Hosted Data Source]({{site.baseurl}}/data)
-* [Algorithmia API Docs](http://docs.algorithmia.com/?r)
+* [Hosted data documentation]({{site.baseurl}}/data)
+* [Algorithmia API documentation](http://docs.algorithmia.com/?r)

--- a/_pages/algorithm-development/languages/r.md
+++ b/_pages/algorithm-development/languages/r.md
@@ -1,30 +1,30 @@
 ---
-layout: article
-title:  "R"
-excerpt: "Build your algorithm in R"
-categories: languages
-tags: [algo-guide-lang]
-show_related: true
 author: steph_kim
+categories: languages
+excerpt: "Develop your algorithm in R"
 image:
     teaser: /language_logos/r.svg
+layout: article
+show_related: true
+tags: [algo-guide-lang]
+title:  "R"
 ---
 
 Before you get started learning about R algorithm development, make sure you go through our <a href="{{site.baseurl}}/algorithm-development/algorithm-basics/your-first-algo">Getting Started Guide</a> to learn how to create your first algorithm, understand permissions available, versioning, using the CLI, and more.
 
-Table of Contents
+Table of contents
 
-* [Available Libraries](#available-libraries)
-* [Write your First Algorithm](#write-your-first-algorithm)
-* [Saving and Loading R Models](#saving-and-loading-r-models)
-* [Managing Dependencies](#managing-dependencies)
-* [I/O for your Algorithms](#io-for-your-algorithms)
-* [Error Handling](#error-handling)
-* [Algorithm Checklist](#algorithm-checklist)
-* [Publish Algorithm](#publish-algorithm)
-* [Conclusion and Resources](#conclusion-and-resources)
+* [Available libraries](#available-libraries)
+* [Write your first algorithm](#write-your-first-algorithm)
+* [Saving and loading R models](#saving-and-loading-r-models)
+* [Managing dependencies](#managing-dependencies)
+* [I/O for your algorithms](#io-for-your-algorithms)
+* [Error handling](#error-handling)
+* [Algorithm checklist](#algorithm-checklist)
+* [Publish algorithm](#publish-algorithm)
+* [Conclusion and resources](#conclusion-and-resources)
 
-## Available Libraries
+## Available libraries
 
 Algorithmia makes a number of libraries available to make algorithm development easier.
 
@@ -34,7 +34,7 @@ The full <a href="https://www.r-project.org/about.html" rel="noopener noreferrer
 
 Furthermore, algorithms can call other algorithms and manage data on the Algorithmia platform via the <a href="{{site.baseurl}}/clients/r">Algorithmia R language Client</a>.
 
-## Write your First Algorithm
+## Write your first algorithm
 
 If you've followed the <a href="{{site.baseurl}}/algorithm-development/algorithm-basics/your-first-algo">Getting Started Guide</a>, you'll notice in your algorithm editor, there is boilerplate code that returns "Hello" and whatever you input to the console.
 
@@ -47,7 +47,8 @@ Go ahead and remove the boilerplate code below that's inside the algorithm() fun
 
 <img src="{{site.cdnurl}}{{site.baseurl}}/images/post_images/algo_dev_lang/algorithm_console_r.png" alt="Algorithm console R" class="screenshot">
 
-## Saving and Loading R Models
+## Saving and loading R models
+
 When you have an R model that has been serialized as an .rds file, you can deploy it easily on Algorithmia. All you need to do is save your model:
 
 {% highlight r %}
@@ -61,7 +62,7 @@ Here are a couple of demos to show you how to load your hosted .rds file inside 
 * [Arima Time Series Forecasting Model](https://algorithmia.com/algorithms/demo/rdemo)
 * [Naive Bayes Iris Classication Model](https://algorithmia.com/algorithms/demo/irisrdemo)
 
-## Managing Dependencies
+## Managing dependencies
 
 Now that you have created your algorithm, you can add dependencies.
 
@@ -122,7 +123,7 @@ The Algorithmia dependency is already installed for your convenience and relies 
 
 This guide won't depend on any external dependencies so you can close the dependencies window.
 
-Note: if you see an error similar to: 
+Note: if you see an error similar to:
 {% highlight bash %}
 Error: Failed to start algorithm - Loading required package: methods
 Error: package or namespace load failed...
@@ -163,7 +164,7 @@ caret
 -t https://cran.r-project.org/src/contrib/nnet_7.3-12.tar.gz
 {% endhighlight %}
 
-## I/O for your Algorithms
+## I/O for your algorithms
 
 Now let's get started on the hands-on portion of the guide:
 
@@ -176,7 +177,7 @@ This path is based on your Algorithmia user name and the name of your algorithm,
 Note that Algorithmia uses `rjson` to automatically (de)serialize input and output for you. If you are used to using `jsonlite` or another JSON package, certain datastructures (especially matrices and dataframes) will be structured differently in the I/O. We recommend reviewing [this excellent guide](https://rstudio-pubs-static.s3.amazonaws.com/31702_9c22e3d1a0c44968a4a1f9656f1800ab.html) which explains the differences.
 {: .notice-warning}
 
-### Working with Basic Data Structures
+### Working with basic data structures
 
 Below is a code sample showing how to create an algorithm working with basic user input.
 
@@ -226,7 +227,7 @@ You should see the minimum and maximum of the numbers in the list returned in th
 {"max_num":6, "min_num":1}
 {% endhighlight %}
 
-### Working with Data Stored on Algorithmia
+### Working with data stored on Algorithmia
 
 This next code snippet shows how to create an algorithm working with a data file that a user has stored using Algorithmia's [Hosted Data Source]({{site.baseurl}}/data/hosted).
 
@@ -285,7 +286,7 @@ This guide uses a chapter from the public domain book [Burning Daylight, by Jack
 When you are creating an algorithm be mindful of the data types you require from the user and the output you return to them. Our advice is to create algorithms that allow for a few different input types such as a file, a sequence or a URL.
 {: .notice-info}
 
-#### Working with JSON Data
+#### Working with JSON data
 
 Note that we use the rjson package to parse JSON within your algorithm.
 
@@ -307,7 +308,7 @@ save_some_output_to(tempfile)
 client$file(file_uri)$putFile(tempfile)
 {% endhighlight %}
 
-### Calling Other Algorithms and Managing Data
+### Calling other algorithms and managing data
 
 To call other algorithms or manage data from your algorithm, use the <a href="{{site.baseurl}}/clients/r">Algorithmia R Client</a> which is automatically available to any algorithm you create on the Algorithmia platform. For more detailed information on how to work with data see the [Data API docs](http://docs.algorithmia.com/).
 
@@ -361,7 +362,7 @@ As you can see from these examples, fields that are passed into your algorithm b
 
 For an example that takes and processes image data check out the [Places 365 Classifier's source code](https://algorithmia.com/algorithms/deeplearning/Places365Classifier).
 
-## Error Handling
+## Error handling
 
 In the above code examples we showed how to create an AlgorithmError function which you should use for handling errors within your algorithm. This way the user can tell the difference between a standard R library error and an error thrown by your algorithm:
 
@@ -391,13 +392,13 @@ algo$pipe(list())$error$message
 
 For more information on error handling see the <a href="{{site.baseurl}}/algorithm-development/algorithm-basics/algorithm-errors">Better Error Handling Guide</a>.
 
-## Algorithm Checklist
+## Algorithm checklist
 
 Before you are ready to publish your algorithm it's important to go through this [Algorithm Checklist]({{site.baseurl}}/algorithm-development/algorithm-checklist) and check out this blog post for <a href="https://algorithmia.com/blog/advanced-algorithm-design">Advanced Algorithm Development <i class="fa fa-external-link"></i></a>.
 
 Both links will go over important best practices such as how to create a good algorithm description, add links to external documentation and other important information.
 
-## Publish Algorithm
+## Publish algorithm
 
 Once you've developed your algorithm, you can publish it and make it available for others to use.
 
@@ -419,12 +420,11 @@ Under Semantic Versioning you can choose which kind of release your change shoul
 
 If you are satisfied with your algorithm and settings, go ahead and hit publish. Congratulations, you’re an algorithm developer!
 
-## Conclusion and Resources
+## Conclusion and resources
 
 In this guide we covered how to create an algorithm, work with different types of data and learned how to publish an algorithm.
 
-
-## Additional Resources
+## Additional resources
 
 * [Algorithmia CRAN package documentation](https://cran.r-project.org/web/packages/algorithmia/vignettes/introduction-to-algorithmia.html)
 * [Algorithmia R client documentation]({{site.baseurl}}/clients/r)

--- a/_pages/clients/java.md
+++ b/_pages/clients/java.md
@@ -273,33 +273,6 @@ This will get the image as binary data, saving it to the variable `image_data`, 
 
 If the file was text (an image, etc.), you could instead use the function `.getString()` to retrieve the file's content as a string. For more methods on how to get a file from a data collection using the Data API go to the [API Specification](/developers/api/#get-a-file-or-directory).
 
-## Publishing Algorithmia Insights
-
-This feature is available to [Algorithmia Enterprise](/enterprise) users only.
-{: .notice-enterprise}
-
-Inference-related metrics (a feature of [Algorithmia Insights](../algorithmia-enterprise/algorithmia-insights)) can be reported via using the `report_insights` method of the Algorithmia client.
-
-Depending on your algorithm, you might want to report on the algorithm payload for each API call (such as the features or number of features), the output of the algorithm to monitor data distributions of predictions, or probability of each inference.
-
-In the case of an example credit scoring model, shown in this demo for [Algorithmia Insights](https://www.youtube.com/watch?v=pdKwtp-_n2M), reported metrics include the algorithm predictions:
-
-{% highlight java %}
-// Report Algorithmia Insights
-client.reportInsights(new HashMap<String,Object>() { {
-    put("risk_score", risk_score);
-    put("approved", approved);
-} });
-{% endhighlight %}
-
-{% highlight json %}
-// Sample model output that is pushed to Insights
-{
-  "approved": 1,
-  "risk_score": 0.08
-}
-{% endhighlight %}
-
 ## Additional Functionality
 
 In addition to the functionality covered in this guide, the Java Client Library provides a complete interface to the Algorithmia platform, including [managing algorithms](/developers/algorithm-development/algorithm-management), administering [organizations](/developers/platform/organizations), and working with [source control](/developers/algorithm-development/source-code-management). You can also visit the [API Docs](/developers/api) to view the complete API specification.

--- a/_pages/clients/java.md
+++ b/_pages/clients/java.md
@@ -1,12 +1,9 @@
 ---
-layout: article
-title: "Java"
-excerpt: "Working in Java? Check out this Algorithmia Java client."
 categories: clients
-tags: [clients]
-show_related: true
+excerpt: "Working in Java? Check out this Algorithmia Java client."
 image:
     teaser: /language_logos/java.svg
+layout: article
 repository: https://github.com/algorithmiaio/algorithmia-java
 redirect_from:
   - /algorithm-development/client-guides/java/
@@ -15,6 +12,9 @@ redirect_from:
   - /application-development/client-guides/java/
   - /application-development/guides/java/
   - /application-development/lang-guides/java/
+show_related: true
+tags: [clients]
+title: "Java"
 ---
 
 The Algorithmia Java client provides a native Java interface to the Algorithmia API, letting developers manage and call algorithms, work with data in object stores using Algorithmia Data Sources, and access other features of the Algorithmia platform.
@@ -23,7 +23,7 @@ This guide will cover setting up the client, calling an algorithm using direct u
 
 To follow along you can create a new Java file in the IDE of your choice.
 
-## Set Up the Client
+## Set up the client
 
 The Algorithmia Java Client is published to Maven central. To get started, the Algorithmia Java Client can be added as a library through Maven using your IDE of choice or you can [download the JAR file](https://mvnrepository.com/artifact/com.algorithmia/algorithmia-client) and add it as a dependency in your POM file:
 
@@ -47,7 +47,7 @@ import com.algorithmia.*;
 AlgorithmiaClient client = Algorithmia.client("YOUR_API_KEY");
 {% endhighlight %}
 
-#### Specifying an On-Premises or Private Cloud Endpoint
+#### Specifying an on-premises or private cloud endpoint
 
 This feature is available to [Algorithmia Enterprise](/enterprise) users only.
 {: .notice-enterprise}
@@ -60,7 +60,7 @@ AlgorithmiaClient client = Algorithmia.client("YOUR_API_KEY", "https://mylocalen
 
 Alternately, you can ensure that each of your servers interacting with your Algorithmia Enterprise instance have an environment variable named `ALGORITHMIA_API` and the client will use it.  The fallback API endpoint is always the hosted Algorithmia marketplace service at [https://api.algorithmia.com/](https://api.algorithmia.com/)
 
-## Calling an Algorithm
+## Calling an algorithm
 
 Algorithms take three basic types of input whether they are invoked directly through the API or by using a client library: strings, JSON, and binary data. In addition, individual algorithms might have their own I/O requirements, such as using different data types for input and output, or accepting multiple types of input, so consult the input and output sections of an algorithm's documentation for specifics.
 
@@ -114,7 +114,7 @@ Alternatively, you may work with raw JSON input by calling `pipeJson()`, and raw
 
 You might have noticed that in this example we included a version number when instantiating the algorithm. Pinning your code to a specific version of the algorithm can be especially important in a production environment where the underlying implementation might change from version to version.
 
-### Request Options
+### Request options
 
 The client exposes options that can configure algorithm requests. This includes support for changing the timeout or indicating that the API should include stdout in the response. In the following example, we set the timeout to 60 seconds and disable `stdout` in the response:
 
@@ -125,7 +125,7 @@ algo.setStdout(false);
 
 You can find more details in [API Docs](/developers/api/) > [Invoke an Algorithm](/developers/api/#invoke-an-algorithm).
 
-### Error Handling
+### Error handling
 
 To be able to better develop across languages, Algorithmia has created a set of standardized errors that can be returned by either the platform or by the algorithm being run. In Java, API errors and Algorithm exceptions will result in calls to `pipe` throwing `APIException`:
 
@@ -150,7 +150,7 @@ Your account can make up to {{site.data.stats.platform.max_num_algo_requests}} A
 
 Algorithm requests have a payload size limit of 10MB for input and 15MB for output. If you need to work with larger amounts of data, you can make use of the Algorithmia [Data API](/developers/api/#data).
 
-## Working with Algorithmia Data Sources
+## Working with Algorithmia data sources
 
 For some algorithms, passing input to the algorithm at request time is sufficient, while others might have larger data requirements or need to preserve state between calls. Application developers can use Algorithmia's [Hosted Data](/developers/data/hosted) to store data as text, JSON, or binary, and access it via the Algorithmia [Data API](/developers/api/#data).
 
@@ -158,7 +158,7 @@ The Data API defines [connectors](/developers/api/#connectors) to a variety of s
 
 In this example, we'll upload an image to Algorithmia's [Hosted Data](/developers/data/hosted) storage provider, and use the [dlib/FaceDetection](https://algorithmia.com/algorithms/dlib/FaceDetection) algorithm to detect any faces in the image. The algorithm will create a new copy of the image with bounding boxes drawn around the detected faces, and then return a JSON object with details about the dimensions of the bounding boxes and a URI where you can download the resulting image.
 
-### Create a Data Collection
+### Create a data collection
 
 The documentation for "Face Detection" says that it takes a URL or a Data URI of the image to be processed, and a Data URI where the algorithm can store the result. We'll create a directory to host the input image, then update its [permissions](/developers/api/#update-collection-acl) so that its publicly accessible:
 
@@ -177,9 +177,9 @@ try {
 Instead of your username you can also use '.my' when calling algorithms. For more information about the '.my' pseudonym check out the [Hosted Data Guide]({{site.baseurl}}/data/hosted).
 {: .notice-info}
 
-### Upload Data to your Data Collection
+### Upload data to your data collection
 
-Now we're ready to upload an image file for processing. For this example, we'll use [this photo of a group of friends](https://unsplash.com/photos/Q_Sei-TqSlc). Download the image and save it locally as `friends.jpg`. 
+Now we're ready to upload an image file for processing. For this example, we'll use [this photo of a group of friends](https://unsplash.com/photos/Q_Sei-TqSlc). Download the image and save it locally as `friends.jpg`.
 
 Next, create a variable that holds the location where you would like to upload the image as a URI:
 
@@ -208,7 +208,7 @@ Confirm that the file was created by navigating to Algorithmia's [Hosted Data So
 
 You can also upload your data through the UI on Algorithmia's [Hosted Data Source](/data/hosted). For instructions on how to do this go to the [Hosted Data Guide]({{site.baseurl}}/data/hosted).
 
-### Call the Algorithm
+### Call the algorithm
 
 Once the file has been uploaded, you are ready to call the algorithm. Create the algorithm object, then pass the required inputs—a JSON object, encoded as a string, with the image URI (which is stored in `img_file` in the code above) and a URI for the image output—to `.pipeJson()`.
 

--- a/_pages/clients/javascript.md
+++ b/_pages/clients/javascript.md
@@ -1,12 +1,9 @@
 ---
-layout: article
-title:  "Javascript"
-excerpt: "Add machine learning to your Javascript app with Algorithmia"
 categories: clients
-tags: [clients]
-show_related: true
+excerpt: "Add machine learning to your Javascript app with Algorithmia"
 image:
     teaser: /language_logos/js.svg
+layout: article
 redirect_from:
   - /algorithm-development/client-guides/javascript/
   - /algorithm-development/guides/javascript/
@@ -14,17 +11,20 @@ redirect_from:
   - /application-development/client-guides/javascript/
   - /application-development/guides/javascript/
   - /application-development/lang-guides/javascript/
+show_related: true
+tags: [clients]
+title:  "Javascript"
 ---
 
 {% include video-responsive.html height="560" width="315" url="https://www.youtube.com/embed/HF04Ge-3XdE" %}
 
-The Algorithmia JavaScript client provides a native interface for calling algorithms using the Algorithmia API. 
+The Algorithmia JavaScript client provides a native interface for calling algorithms using the Algorithmia API.
 
 This guide will cover setting up the client, calling an algorithm using direct user input, and calling an algorithm that uses JSON as input. For complete details about the Algorithmia API, please refer to the [API Docs](/developers/api/).
 
 The code in this guide can be run from the JavaScript console in your browser or used in your own scripts.
 
-## Set Up the Client
+## Set up the client
 
 The JavaScript client can be downloaded from [https://algorithmia.com/v1/clients/js/algorithmia-0.2.1.js](https://algorithmia.com/v1/clients/js/algorithmia-0.2.1.js) and the JavaScript file can be included as a script tag:
 
@@ -40,7 +40,7 @@ Once the client is included, you can instantiate the client object:
 var client = Algorithmia.client("YOUR_API_KEY");
 {% endhighlight %}
 
-#### Specifying an On-Premises or Private Cloud Endpoint
+#### Specifying an on-premises or private cloud endpoint
 
 This feature is available to [Algorithmia Enterprise](/enterprise) users only.
 {: .notice-enterprise}
@@ -51,7 +51,7 @@ If you are running [Algorithmia Enterprise](/enterprise), you can specify the AP
 var client = Algorithmia.client("YOUR_API_KEY", "https://mylocalendpoint/v1/web/algo");
 {% endhighlight %}
 
-## Calling an Algorithm
+## Calling an algorithm
 
 Algorithms take three basic types of input whether they are invoked directly through the API or by using a client library: strings, JSON, and binary data. In addition, individual algorithms might have their own I/O requirements, such as using different data types for input and output, or accepting multiple types of input, so consult the input and output sections of an algorithm's documentation for specifics.
 
@@ -75,13 +75,13 @@ algo.pipe("HAL 9000").then(function (output)
 
 Which should print the phrase `Hello HAL 9000` to the console.
 
-### JSON Inputs
+### JSON inputs
 
 Let's look at an example using JSON and the [nlp/LDA](https://algorithmia.com/algorithms/nlp/LDA) algorithm. The [algorithm docs](https://algorithmia.com/algorithms/nlp/LDA/docs) tell us that the algorithm takes a list of documents and returns a number of topics that are relevant to those documents. The documents can be a list of strings, a Data API file path, or a URL. We'll call this algorithm using a JSON object as our input, following the format in the algorithm documentation:
 
 {% highlight javascript %}
 input = {
-    "docsList": 
+    "docsList":
         [
             "It's apple picking season",
             "The apples are ready for picking"
@@ -110,7 +110,7 @@ The output will be a JSON object which includes an array of topics which include
 
 You might have noticed that in this example we included a version number when instantiating the algorithm. Pinning your code to a specific version of the algorithm can be especially important in a production environment where the underlying implementation might change from version to version.
 
-### Error Handling
+### Error handling
 
 To be able to better develop across languages, Algorithmia has created a set of standardized errors that can be returned by either the platform or by the algorithm being run. In JavaScript, API errors and Algorithm exceptions will result in calls to `.pipe()` returning an error object in their output.
 
@@ -132,7 +132,7 @@ Your account can make up to {{site.data.stats.platform.max_num_algo_requests}} A
 
 Algorithm requests have a payload size limit of 10MB for input and 15MB for output. If you need to work with larger amounts of data, you can make use of the Algorithmia [Data API](/developers/api/#data).
 
-### Note: Working with Files
+### Working with files
 
 Because of security concerns, the JavaScript client does not implement the [Data API](http://docs.algorithmia.com/#data-api-specification) which other clients use to move files into and out of [Data Sources]({{site.baseurl}}/data). This can be a problem if you call an algorithm which writes its output to a file (instead of returning it directly).  However, there are workarounds:
 

--- a/_pages/clients/python.md
+++ b/_pages/clients/python.md
@@ -70,7 +70,7 @@ The first algorithm we'll call is a demo version of the algorithm used in the Al
 In order to call an Algorithm from Python, we need to first create an algorithm object. With the client already instantiated, we can run the following code to create an object:
 
 {% highlight python %}
-algo = client.algo('demo/Hello') 
+algo = client.algo("demo/Hello")
 {% endhighlight %}
 
 Then, we can use the `.pipe()` method to call the algorithm. We'll provide our input as the argument to the function, and then print the output using the `result` attribute:
@@ -159,7 +159,7 @@ Instead of your username you can also use '.my' when calling algorithms. For mor
 
 ### Upload data to a data collection
 
-Now we're ready to upload an image file for processing. For this example, we'll use [this photo of a group of friends](https://unsplash.com/photos/Q_Sei-TqSlc). Download the image and save it locally as `friends.jpg`. 
+Now we're ready to upload an image file for processing. For this example, we'll use [this photo of a group of friends](https://unsplash.com/photos/Q_Sei-TqSlc). Download the image and save it locally as `friends.jpg`.
 
 Next, create a variable that holds the location where you would like to upload the image as a URI:
 
@@ -245,10 +245,10 @@ If the file was text (an image, etc.), you could instead use the function `.getS
 
 ## Publishing Algorithmia Insights
 
-This feature is available to [Algorithmia Enterprise](/enterprise) users only. 
+This feature is available to [Algorithmia Enterprise](/enterprise) users only.
 {: .notice-enterprise}
 
-Inference-related metrics (a feature of [Algorithmia Insights](../algorithmia-enterprise/algorithmia-insights)) can be reported via using the `report_insights` method of the Algorithmia client. 
+Inference-related metrics (a feature of [Algorithmia Insights](../algorithmia-enterprise/algorithmia-insights)) can be reported via using the `report_insights` method of the Algorithmia client.
 
 Depending on your algorithm, you might want to report on the algorithm payload for each API call (such as the features or number of features), the output of the algorithm to monitor data distributions of predictions, or probability of each inference.
 

--- a/_pages/clients/python.md
+++ b/_pages/clients/python.md
@@ -1,20 +1,20 @@
 ---
-layout: article
-title: "Python"
-excerpt: "Add machine learning to your Python app with Algorithmia"
 categories: clients
-tags: [clients]
+excerpt: "Add machine learning to your Python app with Algorithmia"
 ignore_sections: [install-from-source, upgrading-from-0-9-x, running-tests]
-show_related: true
 image:
     teaser: /language_logos/python.svg
-repository: https://github.com/algorithmiaio/algorithmia-python
+layout: article
 redirect_from:
   - /algorithm-development/client-guides/python/
   - /algorithm-development/guides/python/
   - /algorithm-development/guides/python-guide/
   - /application-development/client-guides/python/
   - /application-development/guides/python/
+repository: https://github.com/algorithmiaio/algorithmia-python
+show_related: true
+tags: [clients]
+title: "Python"
 ---
 
 {% include video-responsive.html height="560" width="315" url="https://www.youtube.com/embed/bZB2vu0v6A0" %}
@@ -25,10 +25,9 @@ This guide will cover setting up the client, calling an algorithm using direct u
 
 The code in this guide can be run directly in a Python interpreter or used in your own scripts.
 
-## Set Up the Client
+## Set up the client
 
 The official client is available on [PyPI](https://pypi.python.org/pypi/algorithmia/) and can be installed with pip:
-
 
 {% highlight bash %}
 $ pip3 install algorithmia
@@ -49,7 +48,7 @@ apiKey = "YOUR_API_KEY"
 client = Algorithmia.client(apiKey)
 {% endhighlight %}
 
-#### Specifying an On-Premises or Private Cloud Endpoint
+#### Specifying an on-premises or private cloud endpoint
 
 This feature is available to [Algorithmia Enterprise](/enterprise) users only.
 {: .notice-enterprise}
@@ -62,7 +61,7 @@ client = Algorithmia.client("YOUR_API_KEY", "https://mylocalendpoint")
 
 Alternately, you can ensure that each of your servers interacting with your Algorithmia Enterprise instance have an environment variable named `ALGORITHMIA_API` and the client will use it.  The fallback API endpoint is always the hosted Algorithmia marketplace service at [https://api.algorithmia.com/](https://api.algorithmia.com/)
 
-## Calling an Algorithm
+## Calling an algorithm
 
 Algorithms take three basic types of input whether they are invoked directly through the API or by using a client library: strings, JSON, and binary data. In addition, individual algorithms might have their own I/O requirements, such as using different data types for input and output, or accepting multiple types of input, so consult the input and output sections of an algorithm's documentation for specifics.
 
@@ -105,7 +104,7 @@ The output will be `[{'picking': 2}, {'apple': 1}, {'apples': 1, 'ready': 1}, {'
 
 You might have noticed that in this example we included a version number when instantiating the algorithm. Pinning your code to a specific version of the algorithm can be especially important in a production environment where the underlying implementation might change from version to version.
 
-### Request Options
+### Request options
 
 The client exposes options that can configure algorithm requests. This includes support for changing the timeout or indicating that the API should include stdout in the response. In the following example, we set the timeout to 60 seconds and disable `stdout` in the response:
 
@@ -115,7 +114,7 @@ algo.set_options(timeout=60, stdout=False)
 
 You can find more details in [API Docs](/developers/api/?python) > [Invoke an Algorithm](/developers/api/?python#invoke-an-algorithm).
 
-### Error Handling
+### Error handling
 
 To be able to better develop across languages, Algorithmia has created a set of standardized errors that can be returned by either the platform or by the algorithm being run. In Python, API errors and Algorithm exceptions will result in calls to `.pipe()` throwing an `AlgoException`:
 
@@ -132,7 +131,7 @@ Your account can make up to {{site.data.stats.platform.max_num_algo_requests}} A
 
 Algorithm requests have a payload size limit of 10MB for input and 15MB for output. If you need to work with larger amounts of data, you can make use of the Algorithmia [Data API](/developers/api/?python#data).
 
-## Working with Algorithmia Data Sources
+## Working with Algorithmia data sources
 
 For some algorithms, passing input to the algorithm at request time is sufficient, while others might have larger data requirements or need to preserve state between calls. Application developers can use Algorithmia's [Hosted Data](/developers/data/hosted) to store data as text, JSON, or binary, and access it via the Algorithmia [Data API](/developers/api/?python#data).
 
@@ -140,7 +139,7 @@ The Data API defines [connectors](/developers/api/?python#connectors) to a varie
 
 In this example, we'll upload an image to Algorithmia's [Hosted Data](/developers/data/hosted) storage provider, and use the [dlib/FaceDetection](https://algorithmia.com/algorithms/dlib/FaceDetection) algorithm to detect any faces in the image. The algorithm will create a new copy of the image with bounding boxes drawn around the detected faces, and then return a JSON object with details about the dimensions of the bounding boxes and a URI where you can download the resulting image.
 
-### Create a Data Collection
+### Create a data collection
 
 The documentation for "Face Detection" says that it takes a URL or a Data URI of the image to be processed, and a Data URI where the algorithm can store the result. We'll create a directory to host the input image, then update its [permissions](/developers/api/#update-collection-acl) so that it's publicly accessible:
 
@@ -158,7 +157,7 @@ img_directory.update_permissions(ReadAcl.public)
 Instead of your username you can also use '.my' when calling algorithms. For more information about the '.my' pseudonym check out the [Hosted Data Guide]({{site.baseurl}}/data/hosted).
 {: .notice-info}
 
-### Upload Data to your Data Collection
+### Upload data to a data collection
 
 Now we're ready to upload an image file for processing. For this example, we'll use [this photo of a group of friends](https://unsplash.com/photos/Q_Sei-TqSlc). Download the image and save it locally as `friends.jpg`. 
 
@@ -183,7 +182,7 @@ Confirm that the file was created by navigating to Algorithmia's [Hosted Data So
 
 You can also upload your data through the UI on Algorithmia's [Hosted Data Source](/data/hosted). For instructions on how to do this go to the [Hosted Data Guide]({{site.baseurl}}/data/hosted).
 
-### Call the Algorithm
+### Call the algorithm
 
 Once the file has been uploaded, you are ready to call the algorithm. Create the algorithm object, then pass the required inputs—an image URI (which is stored in `img_file` in the code above) and a URI for the image output—to `algo.pipe()`:
 
@@ -268,10 +267,10 @@ client.report_insights({"risk_score": risk_score, "approved": approved})
 }
 {% endhighlight %}
 
-## Additional Functionality
+## Additional functionality
 
 In addition to the functionality covered in this guide, the Python Client Library provides a complete interface to the Algorithmia platform, including [managing algorithms](/developers/algorithm-development/algorithm-management), administering [organizations](/developers/platform/organizations), and working with [source control](/developers/algorithm-development/source-code-management). You can also visit the [API Docs](/developers/api) to view the complete API specification.
 
-## Next Steps
+## Next steps
 
 If you're a data scientist or developer who will be building and deploying new algorithms, you can move on to the [Algorithm Development > Getting Started](/developers/algorithm-development/your-first-algo/) guide.

--- a/_pages/clients/python.md
+++ b/_pages/clients/python.md
@@ -243,30 +243,6 @@ This will get the image as binary data, saving it to the variable `image_data`, 
 
 If the file was text (an image, etc.), you could instead use the function `.getString()` to retrieve the file's content as a string. For more methods on how to get a file from a data collection using the Data API go to the [API Specification](/developers/api/#get-a-file-or-directory).
 
-## Publishing Algorithmia Insights
-
-This feature is available to [Algorithmia Enterprise](/enterprise) users only.
-{: .notice-enterprise}
-
-Inference-related metrics (a feature of [Algorithmia Insights](../algorithmia-enterprise/algorithmia-insights)) can be reported via using the `report_insights` method of the Algorithmia client.
-
-Depending on your algorithm, you might want to report on the algorithm payload for each API call (such as the features or number of features), the output of the algorithm to monitor data distributions of predictions, or probability of each inference.
-
-In the case of an example credit scoring model, shown in this demo for <a href="https://www.youtube.com/watch?v=pdKwtp-_n2M">Algorithmia Insights</a>, reported metrics include the algorithm predictions:
-
-{% highlight python %}
-# Report Algorithmia Insights
-client.report_insights({"risk_score": risk_score, "approved": approved})
-{% endhighlight %}
-
-{% highlight python %}
-# Sample model output that is pushed to Insights
-{
-  "approved": 1,
-  "risk_score": 0.08
-}
-{% endhighlight %}
-
 ## Additional functionality
 
 In addition to the functionality covered in this guide, the Python Client Library provides a complete interface to the Algorithmia platform, including [managing algorithms](/developers/algorithm-development/algorithm-management), administering [organizations](/developers/platform/organizations), and working with [source control](/developers/algorithm-development/source-code-management). You can also visit the [API Docs](/developers/api) to view the complete API specification.

--- a/_pages/clients/r.md
+++ b/_pages/clients/r.md
@@ -1,19 +1,18 @@
 ---
-layout: article
-title: "R"
-excerpt: "Add machine learning to your R scripts with Algorithmia"
-categories: clients
-tags: [clients]
-show_related: true
 author: steph_kim
+categories: clients
+excerpt: "Add machine learning to your R scripts with Algorithmia"
 image:
     teaser: /language_logos/r.svg
-repository: https://github.com/algorithmiaio/algorithmia-r
+layout: article
 redirect_from:
   - /algorithm-development/client-guides/r/
   - /application-development/client-guides/r/
+repository: https://github.com/algorithmiaio/algorithmia-r
+show_related: true
+tags: [clients]
+title: "R"
 ---
-
 
 The Algorithmia R client provides a native R interface to the Algorithmia API, letting developers manage and call algorithms, work with data in object stores using Algorithmia Data Sources, and access other features of the Algorithmia platform.
 
@@ -21,7 +20,7 @@ This guide will cover setting up the client, calling an algorithm using direct u
 
 The code in this guide can be run directly in an R interpreter or used in your own scripts.
 
-## Set Up the Client
+## Set up the client
 
 The official Algorithmia R client is available on CRAN and includes links to vignettes and the reference manual at: <a href="https://cran.r-project.org/web/packages/algorithmia/index.html">Algorithmia on CRAN</a>
 
@@ -42,11 +41,11 @@ library(algorithmia)
 
 # Authenticate with your API key
 apiKey <- "YOUR_API_KEY"
-# Create the Algorithmia Client object
+# Create the Algorithmia client object
 client <- getAlgorithmiaClient(apiKey)
 {% endhighlight %}
 
-#### Specifying an On-Premises or Private Cloud Endpoint
+#### Specifying an on-premises or private cloud endpoint
 
 This feature is available to [Algorithmia Enterprise](/enterprise) users only.
 {: .notice-enterprise}
@@ -59,7 +58,7 @@ client <- getAlgorithmiaClient("YOUR_API_KEY", "https://mylocalendpoint");
 
 Alternately, you can ensure that each of your servers interacting with your Algorithmia Enterprise instance have an environment variable named `ALGORITHMIA_API` and the client will use it.  The fallback API endpoint is always the hosted Algorithmia marketplace service at [https://api.algorithmia.com/](https://api.algorithmia.com/)
 
-## Calling an Algorithm
+## Calling an algorithm
 
 Algorithms take three basic types of input whether they are invoked directly through the API or by using a client library: strings, JSON, and binary data. In addition, individual algorithms might have their own I/O requirements, such as using different data types for input and output, or accepting multiple types of input, so consult the input and output sections of an algorithm's documentation for specifics.
 
@@ -68,7 +67,7 @@ The first algorithm we'll call is a demo version of the algorithm used in the Al
 In order to call an Algorithm from R, we need to first create an algorithm object. With the client already instantiated, we can run the following code to create an object:
 
 {% highlight r %}
-algo <- client$algo('demo/Hello') 
+algo <- client$algo('demo/Hello')
 {% endhighlight %}
 
 Then, we can use the `$pipe()` method to call the algorithm. We'll provide our input as the argument to the function, and then print the output using the `result` attribute:
@@ -126,7 +125,7 @@ The output will be a list with named elements for each relevant word, and the nu
 
 You might have noticed that in this example we included a version number when instantiating the algorithm. Pinning your code to a specific version of the algorithm can be especially important in a production environment where the underlying implementation might change from version to version.
 
-### Request Options
+### Request options
 
 The client exposes options that can configure algorithm requests. This includes support for changing the timeout or indicating that the API should include `stdout` in the response. In the following example, we set the timeout to 60 seconds and disabling `stdout` in the response:
 
@@ -136,7 +135,7 @@ algo$setOptions(timeout=60, stdout=FALSE)
 
 You can find more details in [API Docs](/developers/api/) > [Invoke an Algorithm](/developers/api/#invoke-an-algorithm).
 
-### Error Handling
+### Error handling
 
 To be able to better develop across languages, Algorithmia has created a set of standardized errors that can be returned by either the platform or by the algorithm being run. We can then catch these errors as follows:
 
@@ -148,7 +147,7 @@ tryCatch({
     stop(e))
 })
 
-Error in getResponse(client$postJsonHelper(algoUrl, input, queryParameters)) : 
+Error in getResponse(client$postJsonHelper(algoUrl, input, queryParameters)) :
   Algorithm error: algorithm algo://util/whoopsWrongAlgo/ not found
 {% endhighlight %}
 
@@ -160,7 +159,7 @@ Your account can make up to {{site.data.stats.platform.max_num_algo_requests}} A
 
 Algorithm requests have a payload size limit of 10MB for input and 15MB for output. If you need to work with larger amounts of data, you can make use of the Algorithmia [Data API](/developers/api/#data).
 
-## Working with Algorithmia Data Sources
+## Working with Algorithmia data sources
 
 For some algorithms, passing input to the algorithm at request time is sufficient, while others might have larger data requirements or need to preserve state between calls. Application developers can use Algorithmia's [Hosted Data](/developers/data/hosted) to store data as text, JSON, or binary, and access it via the Algorithmia [Data API](/developers/api/#data).
 
@@ -168,7 +167,7 @@ The Data API defines [connectors](/developers/api/#connectors) to a variety of s
 
 In this example, we'll upload a text document to Algorithmia's [Hosted Data](/developers/data/hosted) storage provider, and use the [nlp/CleanDocuments](https://algorithmia.com/algorithms/nlp/CleanDocuments/) algorithm to pre-process the document for use in other algorithms. "Clean Documents" will remove HTML tags, emojis and other utf-8 encodings, along with all non-punctuation symbols and symoblics, then return a JSON object with a URI where you can download the resulting document.
 
-### Create a Data Collection
+### Create a data collection
 
 The [documentation for nlp/CleanDocuments](https://algorithmia.com/algorithms/nlp/CleanDocuments/docs) says that it takes a URL or a Data URI of the documents to be processed, and returns a Data URI where the result can be downloaded. We'll create a directory to host the input documents, then update its [permissions](/developers/api/#update-collection-acl) so that it's publicly accessible:
 
@@ -186,7 +185,7 @@ nlp_directory$update_permissions(ReadAcl.PUBLIC)
 Instead of your username you can also use '.my' when calling algorithms. For more information about the '.my' pseudonym check out the [Hosted Data Guide]({{site.baseurl}}/data/hosted).
 {: .notice-info}
 
-### Upload Data to your Data Collection
+### Upload data to your data collection
 
 Now we're ready to upload an text document for processing. For this example, we'll use the first chapter of Jack London's [Burning Daylight](https://en.wikisource.org/wiki/Burning_Daylight). Since the "Clean Documents" algorithm can process multiple documents in the same text file, it requires each document to be separated by the delimiter `"""`. The algorithm will throw an error if the delimiter isn't present. You can download the first chapter with the delimiter already added here: [Chapter One Burning Daylight, by Jack London](/data_assets/burning_daylight_delimiter.txt).
 
@@ -212,7 +211,7 @@ Confirm that the file was created by navigating to Algorithmia's [Hosted Data So
 
 You can also upload your data through the UI on Algorithmia's "Hosted Data Source". For instructions on how to do this go to the [Hosted Data Guide]({{site.baseurl}}/data/hosted).
 
-### Call the Algorithm
+### Call the algorithm
 
 Once the file has been uploaded, you are ready to call the algorithm. Instantiate the algorithm, then pass the URI for the file you want to process as the input:
 
@@ -248,7 +247,7 @@ Alternately, if you just need the JSON content of the processed file to be store
 if client$file(response$result)$exists()) {
     processed_text <- client$file(download_uri).getJson()
 }
-    
+
 {% endhighlight %}
 
 This will get the file as a JSON object, saving it to the variable `processed_text`, which might be useful when writing algorithms that are part of a text processing pipeline.
@@ -267,10 +266,10 @@ Inference-related metrics (a feature of [Algorithmia Insights](../algorithmia-en
 client$report_insights(list(faces_in_image=4)})
 {% endhighlight %}
 
-## Additional Functionality
+## Additional functionality
 
 In addition to the functionality covered in this guide, the R Client Library provides a complete interface to the Algorithmia platform, including [managing algorithms](/developers/algorithm-development/algorithm-management), administering [organizations](/developers/platform/organizations), and working with [source control](/developers/algorithm-development/source-code-management). You can also visit the [API Docs](/developers/api) to view the complete API specification.
 
-## Next Steps
+## Next steps
 
 If you're a data scientist or developer who will be building and deploying new algorithms, you can move on to the [Algorithm Development > Getting Started](/developers/algorithm-development/your-first-algo/) guide.

--- a/_pages/clients/r.md
+++ b/_pages/clients/r.md
@@ -254,18 +254,6 @@ This will get the file as a JSON object, saving it to the variable `processed_te
 
 If the file was an image or some other binary data type, you could instead use the function `.getRaw()` to retrieve the file's content as raw bytes. For more methods on how to get a file using the Data API from a data collection refer to the [API Specification](/developers/api/#get-a-file-or-directory).
 
-## Publishing Algorithmia Insights
-
-This feature is available to [Algorithmia Enterprise](/enterprise) users only.
-{: .notice-enterprise}
-
-Inference-related metrics (a feature of [Algorithmia Insights](../algorithmia-enterprise/algorithmia-insights)) can be reported via using the `report_insights` method of the Algorithmia client.
-
-{% highlight r %}
-# Report Algorithmia Insights
-client$report_insights(list(faces_in_image=4)})
-{% endhighlight %}
-
 ## Additional functionality
 
 In addition to the functionality covered in this guide, the R Client Library provides a complete interface to the Algorithmia platform, including [managing algorithms](/developers/algorithm-development/algorithm-management), administering [organizations](/developers/platform/organizations), and working with [source control](/developers/algorithm-development/source-code-management). You can also visit the [API Docs](/developers/api) to view the complete API specification.


### PR DESCRIPTION
[DOCS-275](https://algorithmia.atlassian.net/browse/DOCS-275) - move Insights info from client guides to language guides

Additional context/notes if appropriate (e.g., specifics about what's changing, links to epic or other PRs, etc.)

* no screenshots changed/updated
* text content not reviewed/changed except headers and some content related to Insights
* placeholder strings not reviewed/replaced

## Checklist
- [x] My PR title includes a relevant Jira ticket name
- [ ] If no associated Jira ticket, my PR title is informative (individual commit messages are squashed in this repo)
- [x] Unnecessary text (notes, TODOs, etc.) has been removed
- [x] For YAML "front matter":
  - Properties are alphabetized
  - `permalink` and `redirect_from/to` properties have `/` at beginning and end (e.g., `/path/`)
- [ ] Screenshots, if present, follow the [Screenshot guidelines](https://algorithmia.atlassian.net/wiki/spaces/CUSTOMERS/pages/1634861478/CFD+Style+Guide#Screenshots) which means:
  - Full browser width (browser at 100% zoom and 10-12" width)
  - Max 1000px
- [x] Grammar, style, tone, punctuation, etc. follow the Algorithmia [manual of style](https://docs.google.com/document/d/1PPVfgMkX7-EVGLPMhN1E485CAXu9QfhSLKM0lZhnZdU/edit?usp=sharing)
- [x] Headers are “Sentence case with Proper Nouns capitalized”
- [ ] Placeholder strings are `UPPER_SNAKE_CASE` and are named as in the [Glossary](https://docs.google.com/document/d/1bYs0j_a4v8LbkbS8r0x2SZ_J6mZ4sIt4w_60dq8iGh4/edit#heading=h.qov2yks2a685) where appropriate
