### PR TITLE
Docs 238 create glossary page

### DIFF
--- a/_data/toc.yml
+++ b/_data/toc.yml
@@ -14,7 +14,10 @@
   nav_category: basics
 
 - title: API Documentation
-  url: /api
+  url: /api/
+
+- title: Glossary
+  url: /glossary/
 
 - title: Client Guides
   url: /clients/
@@ -29,7 +32,7 @@
   # nav_category: model-deployment
 
 - title: Native Data Integrations
-  url: /data
+  url: /data/
   nav_category: data-api
 
 - title: SQL Database Patterns

--- a/_pages/glossary.html
+++ b/_pages/glossary.html
@@ -26,6 +26,19 @@
       color: inherit;
       border-bottom: 1px dotted;
     }
+
+    /* indent example terms*/
+    #glossary-usage dl {
+      margin-left: 3ch;
+    }
+
+    #glossary-usage dd {
+      margin-left: 3ch;
+    }
+
+    #glossary-definitions dd {
+      margin-left: 3ch;
+    }
   </style>
   <div id="glossary-usage">
     <p>This page provides brief definitions for many of the terms used across Algorithmia's platform and documentation.
@@ -37,39 +50,40 @@
         uppercase strings in our UI, and in code samples across our documentation, to denote generic values that must be
         replaced with custom values in your code. Placeholders <code
           class="placeholder">{/beginning/with-a-slash}</code> are <a class="glossary-hoverable" href="#api-endpoint"
-          title="" parentId="dd-api-endpoint">endpoints</a> from the <code>https://algorithmia.com</code> <a
-          class="glossary-hoverable" href="#base-url" title="" parentId="dd-base-url">base URL</a> (or from
+          title="" parentId="dd-api-endpoint">endpoints</a> from the <a class="glossary-hoverable" href="#base-url"
+          title="" parentId="dd-base-url">base URL</a>, i.e.,
         <code>https://<a class="glossary-hoverable" href="#cluster-domain" title="" parentId="dd-cluster-domain">CLUSTER_DOMAIN</a></code>
-        for enterprise clusters; see below).
+        (or <code>https://algorithmia.com</code> for non-Enterprise clusters).
       </li>
-      <dl>
-        <ul>
-          <dt id="example-term-with-placeholder">example term with placeholder <code
-              class="placeholder">{PLACEHOLDER_STRING}</code>
-          </dt>
-          <dd id="dd-example-term-with-placeholder">
-            Definition of first term.
-          </dd>
-          <dt id="example-term-with-endpoint">example term with endpoint placeholder <code
-              class="placeholder">{/endpoint}</code>
-          </dt>
-          <dd id="dd-example-term-with-endpoint">
-            Definition of second term.
-          </dd>
-        </ul>
+      <dl class="indented-example">
+
+        <dt id="example-term-with-placeholder">example term with placeholder <code
+            class="placeholder">{PLACEHOLDER_STRING}</code>
+        </dt>
+        <dd id="dd-example-term-with-placeholder">
+          Definition of first term.
+        </dd>
+
+        <dt id="example-term-with-endpoint">example term with endpoint placeholder <code
+            class="placeholder">{/path/to/endpoint}</code>
+        </dt>
+        <dd id="dd-example-term-with-endpoint">
+          Definition of second term.
+        </dd>
+
       </dl>
       <li>
         Some definitions reference other glossary terms. Links are hoverable and clickable; on hover, they'll display
         the linked definition for quick reference, e.g.:
       </li>
-      <dl>
-        <ul>
-          <dt id="example-term-with-link">example term with link</dt>
-          <dd id="dd-example-term-with-link">
-            This term has a hoverable link to the <a class="glossary-hoverable" href="#example-term-with-placeholder"
-              title="" parentId="dd-example-term-with-placeholder">example term</a> from above.
-          </dd>
-        </ul>
+      <dl class="indented-example">
+
+        <dt id="example-term-with-link">example term with link</dt>
+        <dd id="dd-example-term-with-link">
+          This term has a hoverable link to the <a class="glossary-hoverable" href="#example-term-with-placeholder"
+            title="" parentId="dd-example-term-with-placeholder">example term</a> from above.
+        </dd>
+
       </dl>
     </ul>
   </div>
@@ -82,6 +96,7 @@
       float: left;
       width: 50%;
       padding: 10px;
+      column-gap: 0ch;
     }
 
     /* Clear floats after the columns */
@@ -399,7 +414,7 @@
         and revision.
       </dd>
 
-      <dt id="algorithm-template">algorithm template <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-template">algorithm template</dt>
       <dd id="dd-algorithm-template">
         Source code file or collection of files with boilerplate code that serves as a unified starting point for new
         <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">algorithms</a>
@@ -413,7 +428,7 @@
         <code>1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d</code>.
       </dd>
 
-      <dt id="algorithm-vanity-url">algorithm vanity URL <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-vanity-url">algorithm vanity URL</dt>
       <dd id="dd-algorithm-vanity-url">
         Minimal URL for specific <a class="glossary-hoverable" href="#algorithm-endpoint" title=""
           parentId="dd-algorithm-endpoint">algorithm endpoint</a> in a <a class="glossary-hoverable"
@@ -515,7 +530,7 @@
           parentId="dd-authentication-factor">authentication factors</a>.
       </dd>
 
-      <dt id="authentication">authentication <code class="placeholder">{}</code></dt>
+      <dt id="authentication">authentication</dt>
       <dd id="dd-authentication">
         The act of signing on to the Algorithmia platform in order to gain access to an <a class="glossary-hoverable"
           href="#authentication-token" title="" parentId="dd-authentication-token">authentication
@@ -523,7 +538,7 @@
           title="" parentId="dd-authenticated-resource-request">authenticated resource requests</a>.
       </dd>
 
-      <dt id="authentication-factor">authentication factor <code class="placeholder">{}</code></dt>
+      <dt id="authentication-factor">authentication factor</dt>
       <dd id="dd-authentication-factor">
         Property used to authenticate into an <a class="glossary-hoverable" href="#account" title=""
           parentId="dd-account">account</a> to access <a class="glossary-hoverable" href="#resource" title=""
@@ -540,7 +555,7 @@
           class="glossary-hoverable" href="#resource" title="" parentId="dd-resource">resources</a>.
       </dd>
 
-      <dt id="authorization">authorization <code class="placeholder">{}</code></dt>
+      <dt id="authorization">authorization</dt>
       <dd id="dd-authorization">
         The act of granting an identity access to specific <a class="glossary-hoverable" href="#resource" title=""
           parentId="dd-resource">resources</a>.
@@ -622,13 +637,13 @@
           class="glossary-hoverable" href="#base-url" title="" parentId="dd-base-url">base URL</a>.
       </dd>
 
-      <dt id="cluster-operator">cluster operator <code class="placeholder">{}</code></dt>
+      <dt id="cluster-operator">cluster operator</dt>
       <dd id="dd-cluster-operator">
-        The DevOps customer persona that works with Algorithmia I&O to deploy, upgrade, and maintain Algorithmia’s
+        DevOps customer persona that works with Algorithmia I&O to deploy, upgrade, and maintain Algorithmia’s
         infrastructure in their Enterprise environment.
       </dd>
 
-      <dt id="cold-algorithm">cold algorithm <code class="placeholder">{}</code></dt>
+      <dt id="cold-algorithm">cold algorithm</dt>
       <dd id="dd-cold-algorithm">
         <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">Algorithm</a> for which no
         <a class="glossary-hoverable" href="#algorithm-instance" title="" parentId="dd-algorithm-instance">instances</a>
@@ -651,7 +666,7 @@
         where they need to and in the environment that works best for them.
       </dd>
 
-      <dt id="consumer">consumer <code class="placeholder">{}</code></dt>
+      <dt id="consumer">consumer</dt>
       <dd id="dd-consumer">
         Not used. See <a class="glossary-hoverable" href="#subscriber" title="" parentId="dd-subscriber">subscriber</a>.
       </dd>
@@ -741,7 +756,7 @@
 
       <dt id="file">file <code class="placeholder">{FILE_NAME}</code></dt>
       <dd id="dd-file">
-        A file of any type (text, JSON, binary, etc.) in local, <a class="glossary-hoverable"
+        Generic term for file of any type (text, JSON, binary, etc.) in local, <a class="glossary-hoverable"
           href="#hosted-data-collection" title="" parentId="dd-hosted-data-collection">hosted</a>, cloud, or other
         storage.
       </dd>
@@ -985,7 +1000,7 @@
           parentId="dd-org-organization">org</a>.
       </dd>
 
-      <dt id="parent-algorithm">parent algorithm <code class="placeholder">{}</code></dt>
+      <dt id="parent-algorithm">parent algorithm</dt>
       <dd id="dd-parent-algorithm">
         <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">Algorithm</a> that receives an
         API request directly from a caller and calls other algorithms internally in a
@@ -996,7 +1011,7 @@
           algorithm</a>.
       </dd>
 
-      <dt id="password">password <code class="placeholder">{}</code></dt>
+      <dt id="password">password</dt>
       <dd id="dd-password">
         <a class="glossary-hoverable" href="#authentication-factor" title=""
           parentId="dd-authentication-factor">Authentication factor</a> used to <a class="glossary-hoverable"
@@ -1265,7 +1280,8 @@
       <dt id="web-ide">Web IDE</dt>
       <dd id="dd-web-ide">
         Algorithmia’s built-in source code editor and test console, accessible through the “Source” tab from an
-        algorithm’s profile page.
+        algorithm’s <a class="glossary-hoverable" href="#algorithm-profile" title=""
+          parentId="dd-algorithm-profile">profile</a>.
       </dd>
 
       <dt id="worker-node">worker node</dt>

--- a/_pages/glossary.html
+++ b/_pages/glossary.html
@@ -13,7 +13,7 @@
     }
 
     dd {
-      margin-bottom: 15px;
+      margin-bottom: 25px;
     }
 
     .placeholder {
@@ -76,13 +76,11 @@
   <hr />
 
   <style>
-    /* Create two equal columns that floats next to each other */
+    /* Create two equal columns that float next to each other */
     .column {
       float: left;
       width: 50%;
       padding: 10px;
-      /* height: 1200px; */
-      /* Should be removed. Only for demonstration */
     }
 
     /* Clear floats after the columns */
@@ -92,7 +90,7 @@
       clear: both;
     }
 
-    /* Responsive layout - when the screen is less than 950px wide, make the
+    /* Responsive layout - when the screen is less than 1000px wide, make the
      two columns stack on top of each other instead of next to each other */
     @media screen and (max-width: 1000px) {
       .column {
@@ -178,6 +176,7 @@
         <li><a href="#identity">identity</a></li>
         <li><a href="#kibana">Kibana</a></li>
         <li><a href="#machine-learning">machine learning (ML)</a></li>
+        <li><a href="#machine-learning-operations">machine learning operations (MLOps)</a></li>
         <li><a href="#master-node">master node</a></li>
         <li><a href="#message-broker">message broker</a></li>
         <li><a href="#message-broker-connection">message broker connection</a></li>
@@ -242,15 +241,9 @@
   <div id="glossary-definitions">
     <dl>
 
-      <dt id="uniqueId">item name <code class="placeholder">{PLACEHOLDER}</code></dt>
-      <dd id="dd-uniqueId">
-        Definition
-      </dd>
-
       <dt id="account">account <code class="placeholder">{ACCOUNT_NAME}</code></dt>
       <dd id="dd-account">
-        <a class="glossary-hoverable" href="#identity" title="" parentId="dd-identity">Identity</a> on the
-        Algorithmia
+        <a class="glossary-hoverable" href="#identity" title="" parentId="dd-identity">Identity</a> on the Algorithmia
         platform that may own and/or be used to access a resource (e.g., an <a class="glossary-hoverable"
           href="#algorithm" title="" parentId="dd-algorithm">algorithm</a>).
       </dd>
@@ -281,317 +274,423 @@
 
       <dt id="algo-cli">algo CLI</dt>
       <dd id="dd-algo-cli">
-        Algorithmia’s command-line interface tool, called with algo [COMMAND [OPTIONS]].
+        Algorithmia’s command-line interface tool, called with <code>algo [COMMAND [OPTIONS]]</code>.
       </dd>
 
       <dt id="algorithm">algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm">
-        Definition
+        Microservice on Algorithmia that accepts an input, may return an output, and may have side effects. An algorithm
+        can only accept a JSON type as input, and if it returns an output, can only return a JSON type. Algorithms can
+        be pipelined together with other algorithms. The primary use case for algorithms on Algorithmia’s platform is to
+        provide functionality for loading and calling ML models for inference, but the scope of tasks that algorithms
+        can perform is not constrained to this. For example, algorithms can perform conventional deterministic
+        algorithmic routines (e.g., binary search), can read and write data, can be used to query or send data to an
+        external data source such as a database, can perform utility tasks such as downloading images and pre-processing
+        structured or unstructured data, and can be configured to orchestrate all of the above.
       </dd>
 
       <dt id="algorithm-build">algorithm build <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-build">
-        Definition
+        Specific compiled version of an algorithm, described by an algorithm build hash.
       </dd>
 
       <dt id="algorithm-build-hash">algorithm build hash <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-build-hash">
-        Definition
+        Unique value describing an algorithm version created from a specific Git commit when an algorithm builds
+        (compiles) successfully. Synonymous with algorithm version hash.
       </dd>
 
       <dt id="algorithm-build-uuid">algorithm build UUID <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-build-uuid">
-        Definition
+        Globally unique identifier for a specific algorithm build, in the format <code>1234-1234-1234-1234</code>.
       </dd>
 
       <dt id="algorithm-environment">algorithm environment <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-environment">
-        Definition
+        Predefined, optimized runtime configuration for an algorithm. Environments usually contain specific ML framework
+        dependencies optimized for Algorithmia’s architecture, and serve as a base upon which additional external
+        library
+        dependencies can be added if necessary.
       </dd>
 
       <dt id="algorithm-environment-uuid">algorithm environment UUID <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-environment-uuid">
-        Definition
+        Globally unique, cluster-specific identifier for a specific algorithm environment, in the format
+        1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d.
       </dd>
 
       <dt id="algorithm-endpoint">algorithm endpoint <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-endpoint">
-        Definition
+        Unique (within an Algorithmia cluster) name identifying a specific algorithm version, defined as
+        ALGO_OWNER/ALGO_NAME[/ALGO_VERSION], where ALGO_VERSION defaults to the latest published version if excluded.
       </dd>
 
       <dt id="algorithm-execution-request">algorithm execution request <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-execution-request">
-        Definition
+        Request made to execute an algorithm with an optional input.
+
       </dd>
 
       <dt id="algorithm-profile">algorithm profile <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-profile">
-        Definition
+        Profile page for an algorithm.
+
       </dd>
 
       <dt id="algorithm-instance">algorithm instance <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-instance">
-        Definition
+        Individual replica of an algorithm running on a worker node.
+
       </dd>
 
       <dt id="algorithm-language">algorithm language <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-language">
-        Definition
+        Programming language in which an algorithm is written.
+
       </dd>
 
       <dt id="algorithm-owner">algorithm owner <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-owner">
-        Definition
+        Account or org that owns an algorithm.
+
       </dd>
 
       <dt id="algorithm-pipelining">algorithm pipelining <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-pipelining">
-        Definition
+        When one algorithm calls another algorithm within an Algorithmia cluster.
       </dd>
 
       <dt id="algorithm-semantic-version">algorithm semantic version <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-semantic-version">
-        Definition
+        Specific published version of an algorithm build, where X, Y, and Z represent major version, minor version, and
+        revision.
+
       </dd>
 
       <dt id="algorithm-template">algorithm template <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-template">
-        Definition
+        Source code file or collection of files with boilerplate code that serves as a unified starting point for new
+        algorithms
+        that are created.
+
       </dd>
 
       <dt id="algorithm-uuid">algorithm UUID <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-uuid">
-        Definition
+        Globally unique identifier for a specific algorithm, in the format 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d.
+
       </dd>
 
       <dt id="algorithm-vanity-url">algorithm vanity URL <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-vanity-url">
-        Definition
+        Minimal URL for specific algorithm endpoint in a satellite deployment.
+
       </dd>
 
       <dt id="algorithm-version">algorithm version <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-version">
-        Definition
+        Generic name to refer to a specific algorithm build, which could be denoted by an algorithm semantic version or
+        an
+        algorithm version hash.
       </dd>
 
       <dt id="algorithm-version-hash">algorithm version hash <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-version-hash">
-        Definition
+        Unique value describing an algorithm version created from a specific Git commit when an algorithm builds
+        (compiles)
+        successfully. Synonymous with algorithm build hash.
       </dd>
 
       <dt id="api">API <code class="placeholder">{}</code></dt>
       <dd id="dd-api">
-        Definition
+        <!-- use this span id for referencing this definition in hoverable links -->
+        <span id="dd-api-hoverable">Generic term for individual Algorithmia REST API service. API endpoints are
+          grouped based on the functionality they provide for interacting with resources.</span> Algorithmia has the
+        following
+        APIs:<br /><br />
+        <ul>
+          <li><code>algorithms</code> : algorithm operations</li>
+          <li><code>users</code> : account operations</li>
+          <li><code>organizations</code> : organization operations</li>
+          <li><code>scm</code> : source control management operations</li>
+          <li><code>secrets</code> : secret store operations</li>
+          <li><code>connectors</code> : data connector operations</li>
+          <li><code>data</code> : data API operations</li>
+          <li><code>eventlisteners</code> : event flow-based operations</li>
+          <li><code>eventmanagers</code> : message broker operations</li>
+          <li><code>builds</code> : algorithm build operations</li>
+          <li><code>auth</code> : authentication factor and authentication token management</li>
+          <li><code>usage</code> : cluster usage information</li>
+          <li><code>invites</code> : cluster invite code management</li>
+          <li><code>admin</code> : cluster administration operations</li>
+          <li><code>style</code> : cluster front-end style configuration</li>
+          <li><code>frontend</code> : cluster front end configuration</li>
+        </ul>
       </dd>
 
       <dt id="api-docs">API Docs <code class="placeholder">{}</code></dt>
       <dd id="dd-api-docs">
-        Definition
+        Documentation for Algorithmia’s API, listing all available endpoints. Description here.
       </dd>
 
       <dt id="api-endpoint">API endpoint <code class="placeholder">{}</code></dt>
       <dd id="dd-api-endpoint">
-        Definition
+        Resource URL not including the base URL, for example /v1/algorithms/{ALGO_OWNER}/{ALGO_NAME}/{ALGO_VERSION}.
       </dd>
 
       <dt id="api-key">API key <code class="placeholder">{}</code></dt>
       <dd id="dd-api-key">
-        Definition
+        Secret authentication token associated with a specific account or org. As a security best practice, this value
+        should be
+        stored in the environment variable ALGORITHMIA_API_KEY.
       </dd>
 
       <dt id="api-method">API method <code class="placeholder">{}</code></dt>
       <dd id="dd-api-method">
-        Definition
+        Verb used to indicate an interaction with a resource through the REST API. Algorithmia primarily uses GET, PUT,
+        POST,
+        DELETE, HEAD, and PATCH methods.
       </dd>
 
       <dt id="authenticated-resource-request">authenticated resource request</dt>
       <dd id="dd-authenticated-resource-request">
-        Definition
+        Request for a resource that includes one or more authentication factors.
       </dd>
 
       <dt id="authentication">authentication <code class="placeholder">{}</code></dt>
       <dd id="dd-authentication">
-        Definition
+        The act of signing on to the Algorithmia platform in order to gain access to an authentication token that can
+        then be used to send authenticated resource requests.
       </dd>
 
       <dt id="authentication-factor">authentication factor <code class="placeholder">{}</code></dt>
       <dd id="dd-authentication-factor">
-        Definition
+        Property used to authenticate into an account to access resources. Algorithmia uses passwords for authentication
+        into
+        our browser UI.
       </dd>
 
       <dt id="authentication-token">authentication token <code class="placeholder">{}</code></dt>
       <dd id="dd-authentication-token">
-        Definition
+        Special type of authentication factor that’s granted as a digital “receipt” upon successful authentication. A
+        token may
+        have a validity time limit and may represent a limited set of actions that can be taken on specific resources.
       </dd>
 
       <dt id="authorization">authorization <code class="placeholder">{}</code></dt>
       <dd id="dd-authorization">
-        Definition
+        The act of granting an identity access to specific resources.
       </dd>
 
       <dt id="base-api-url">base API URL <code class="placeholder">{}</code></dt>
       <dd id="dd-base-api-url">
-        Definition
+        Resource URL for /v1 API, not including the endpoint. For example https://api.algorithmia.com.
       </dd>
 
       <dt id="base-url">base URL <code class="placeholder">{}</code></dt>
       <dd id="dd-base-url">
-        Definition
+        Resource URL not including a specific endpoint. For example https://algorithmia.com.
       </dd>
 
       <dt id="blog">blog <code class="placeholder">{}</code></dt>
       <dd id="dd-blog">
-        Definition
+        Algorithmia site where we share practical, relevant information about AI/ML and the industry, describe new
+        product
+        features and partnerships, pose new ideas, and share success stories in order to connect and build credibility
+        with the
+        reader. Blog posts are actively updated to reflect the state of the platform as product features and best
+        practices
+        change. Like the Developer Center, the blog is a resource to which customers can return at any time for accurate
+        information. Description here.
       </dd>
 
       <dt id="browser-ui">browser UI <code class="placeholder">{}</code></dt>
       <dd id="dd-browser-ui">
-        Definition
+        Algorithmia’s browser-based user interface.
       </dd>
 
       <dt id="caller">caller <code class="placeholder">{CALLER_NAME}</code></dt>
       <dd id="dd-caller">
-        Definition
+        Account associated with the authentication token used to call an algorithm.
       </dd>
 
       <dt id="collection-owner">collection owner <code class="placeholder">{}</code></dt>
       <dd id="dd-collection-owner">
-        Definition
+        Account or org that owns a hosted data collection.
       </dd>
 
       <dt id="closed-source-algorithm">closed-source algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-closed-source-algorithm">
-        Definition
+        Algorithm published with source code only visible via authenticated resource requests from the account or org
+        that owns
+        the algorithm.
       </dd>
 
       <dt id="cluster">cluster <code class="placeholder">{}</code></dt>
       <dd id="dd-cluster">
-        Definition
+        Individual instance of Algorithmia’s platform.
       </dd>
 
       <dt id="cluster-admin-account">cluster admin account <code class="placeholder">{}</code></dt>
       <dd id="dd-cluster-admin-account">
-        Definition
+        Account with administrative privileges on the cluster. Cluster admin and org admin roles aren’t related.
+        [Engineering
+        also calls this “platform administrator”]
       </dd>
 
       <dt id="cluster-domain">cluster domain <code class="placeholder">{}</code></dt>
       <dd id="dd-cluster-domain">
-        Definition
+        Specific domain associated with an Algorithmia cluster. For example, algorithmia.com. For usage, see base URL.
       </dd>
 
       <dt id="cluster-operator">cluster operator <code class="placeholder">{}</code></dt>
       <dd id="dd-cluster-operator">
-        Definition
+        The DevOps customer persona that works with Algorithmia I&O to deploy, upgrade, and maintain Algorithmia’s
+        infrastructure in their Enterprise environment. (Cluster operators have access to environment variables and
+        other
+        configuration through the terminal vs. cluster admins who are just using the UI or API w/ and Admin API key.)
       </dd>
 
       <dt id="cold-algorithm">cold algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-cold-algorithm">
-        Definition
+        Algorithm for which no instances are currently ready to process algorithm execution requests.
       </dd>
 
       <dt id="constellation-distributed-serving">Constellation Distributed Serving</dt>
       <dd id="dd-constellation-distributed-serving">
-        Definition
+        Flexible Algorithmia deployment option in which a mothership (any Enterprise cluster with the option enabled) is
+        distinct and separate from the satellite(s) (a set of containers including algorithms (one satellite to many
+        algorithms), RabbitMQ, API server, and a configuration file) for production runtime, thereby decoupling
+        algorithm development from runtime execution. Constellation enables customers with high security, high
+        availability, or high performance workloads to easily deploy and serve models where they need to and in the
+        environment that works best for them.
       </dd>
 
       <dt id="consumer">consumer <code class="placeholder">{}</code></dt>
       <dd id="dd-consumer">
-        Definition
+        Not used. See subscriber.
       </dd>
 
       <dt id="contorl-plane-node">control plane node <code class="placeholder">{}</code></dt>
       <dd id="dd-contorl-plane-node">
-        Definition
+        Node in Algorithmia’s Kubernetes environment that manages cluster health and provisioning of general purpose
+        nodes and
+        worker nodes. Put another way, this node runs Kubernetes—the orchestration of the containers. [Note: this used
+        to be
+        called “master node” but officially is now called “Control Plane Node” in K8s, so it should be updated in both
+        our UI
+        and documentation to align with that.]
       </dd>
 
       <dt id="data-connector">data connector <code class="placeholder">{}</code></dt>
       <dd id="dd-data-connector">
-        Definition
+        Specific cloud storage provider to which algorithms can connect through a built-in configuration on
+        Algorithmia’s
+        platform.
       </dd>
 
       <dt id="data-source">data source <code class="placeholder">{}</code></dt>
       <dd id="dd-data-source">
-        Definition
+        Generic term for hosted data collection, data connector, and external data source.
+
       </dd>
 
       <dt id="data-uri">data URI <code class="placeholder">{}</code></dt>
       <dd id="dd-data-uri">
-        Definition
+        Identifier that describes the location of a hosted data collection or native data connector to the API. The
+        location may
+        be a file “bucket” (i.e., a folder or directory) or a file itself.
+
       </dd>
 
       <dt id="developer-center">Developer Center <code class="placeholder">{}</code></dt>
       <dd id="dd-developer-center">
-        Definition
+        Quick-reference Algorithmia documentation. Description here.
       </dd>
 
       <dt id="directory">directory <code class="placeholder">{}</code></dt>
       <dd id="dd-directory">
-        Definition
+        Generic term for “bucket” that can hold files. Used synonymously with folder.
       </dd>
 
       <dt id="event-flow">Event Flow <code class="placeholder">{}</code></dt>
       <dd id="dd-event-flow">
-        Definition
+        Publisher or subscriber algorithm configured to read records from or write records to a message broker.
       </dd>
 
       <dt id="event-listener">event listener <code class="placeholder">{}</code></dt>
       <dd id="dd-event-listener">
-        Definition
+        Not used. See event flow.
       </dd>
 
       <dt id="event-manager">event manager <code class="placeholder">{}</code></dt>
       <dd id="dd-event-manager">
-        Definition
+        Not used. See message broker.
       </dd>
 
       <dt id="external-data-source">external data source <code class="placeholder">{}</code></dt>
       <dd id="dd-external-data-source">
-        Definition
+        Data source to which algorithms can connect using external standard SDKs and APIs but to which Algorithmia
+        doesn’t
+        provide a built-in data connector. [We differentiate between native data connectors and external data sources
+        because
+        connectors are supported through the API.]
       </dd>
 
       <dt id="file">file <code class="placeholder">{}</code></dt>
       <dd id="dd-file">
-        Definition
+        A file of any type (text, JSON, binary, etc.) in local, hosted, cloud, or other storage.
       </dd>
 
       <dt id="folder">folder <code class="placeholder">{}</code></dt>
       <dd id="dd-folder">
-        Definition
+        Generic term for “bucket” that can hold files. Used synonymously with directory.
       </dd>
 
       <dt id="general-purpose-node">general purpose node <code class="placeholder">{}</code></dt>
       <dd id="dd-general-purpose-node">
-        Definition
+        Node in Algorithmia’s Kubernetes environment that manages and schedules Algorithmia services (with the exception
+        of
+        algorithm workers) providing services such as logging, storage, source code management, billing, etc.
       </dd>
 
       <dt id="grafana">Grafana <code class="placeholder">{}</code></dt>
       <dd id="dd-grafana">
-        Definition
+        Numeric metrics visualization dashboard provisioned with each Algorithmia Enterprise installation.
       </dd>
 
       <dt id="hosted-data-collection">hosted data collection <code class="placeholder">{}</code></dt>
       <dd id="dd-hosted-data-collection">
-        Definition
+        Object storage hosted on the Algorithmia platform. Data collections are not “file storage” in that they can’t
+        store
+        nested data or data with a “/” character in the path.
       </dd>
 
       <dt id="hot-algorithm">hot algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-hot-algorithm">
-        Definition
+        Algorithm instance actively handling an algorithm execution request.
       </dd>
 
       <dt id="json-web-token">JSON Web Token (JWT) <code class="placeholder">{}</code></dt>
       <dd id="dd-json-web-token">
-        Definition
+        Open, industry-standard RFC 7519 method for representing proof of secure communication between two parties. On
+        Algorithmia a JWT can be used as an authentication token to grant an identity access to perform authenticated
+        resource
+        requests. If configured, permission tags can be extracted from a JWT and used to facilitate external management
+        of
+        organization membership and user security roles.
       </dd>
 
       <dt id="identity">identity <code class="placeholder">{}</code></dt>
       <dd id="dd-identity">
-        Definition
+        Digital representation of a real-world entity that attempts to access a resource. This could be a human user, a
+        service
+        account, or a server, for example.
       </dd>
 
       <dt id="kibana">Kibana <code class="placeholder">{}</code></dt>
       <dd id="dd-kibana">
-        Definition
+        Log query and visualization tool provisioned with each Algorithmia Enterprise installation.
       </dd>
 
       <dt id="machine-learning">machine learning (ML) <code class="placeholder">{}</code></dt>
@@ -601,24 +700,30 @@
         following explicit instructions from humans.
       </dd>
 
+      <dt id="machine-learning-operations">machine learning operations (MLOps)
+      <dd id="dd-machine-learning-operations">
+        The discipline of delivering ML models through repeatable and efficient workflows.
+      </dd>
       <dt id="master-node">master node <code class="placeholder">{}</code></dt>
       <dd id="dd-master-node">
-        Definition
+        Not used. See control plane node.
       </dd>
 
       <dt id="message-broker">message broker <code class="placeholder">{}</code></dt>
       <dd id="dd-message-broker">
-        Definition
+        Event-processing tool that stores records from publishers in a log or queue and makes them available to be read
+        by
+        subscribers.
       </dd>
 
       <dt id="message-broker-connection">message broker connection <code class="placeholder">{}</code></dt>
       <dd id="dd-message-broker-connection">
-        Definition
+        Cluster-level connection to a message broker, configured by a cluster admin.
       </dd>
 
       <dt id="ml-service-catalog">ML service catalog <code class="placeholder">{}</code></dt>
       <dd id="dd-ml-service-catalog">
-        Definition
+        Library of versioned algorithms ready to be served for inference.
       </dd>
 
       <dt id="model">model <code class="placeholder">{MODEL_NAME}</code></dt>
@@ -632,152 +737,200 @@
 
       <dt id="model-explainability">model explainability <code class="placeholder">{}</code></dt>
       <dd id="dd-model-explainability">
-        Definition
+        Ability to explain how a model was built and the reasons for its outputs. In some contexts this is used
+        interchangeably
+        with model interpretability.
       </dd>
 
       <dt id="model-governance">model governance <code class="placeholder">{}</code></dt>
       <dd id="dd-model-governance">
-        Definition
+        Process for how a company controls access to models, implements policy surrounding models, and tracks activity
+        of
+        models.
       </dd>
 
       <dt id="model-interpretability">model interpretability <code class="placeholder">{}</code></dt>
       <dd id="dd-model-interpretability">
-        Definition
+        Ability to understand the cause of a model decision. This can also refer to the ability for a human to
+        understand and
+        predict a model’s output, or the ability to observe cause and effect by changing model parameters. In some
+        contexts this
+        is used interchangeably with model explainability.
       </dd>
 
       <dt id="model-monitoring">model monitoring <code class="placeholder">{}</code></dt>
       <dd id="dd-model-monitoring">
-        Definition
+        Ability to assess a model’s performance, accuracy, drift, and errors.
       </dd>
 
       <dt id="model-observability">model observability <code class="placeholder">{}</code></dt>
       <dd id="dd-model-observability">
-        Definition
+        Ability to assess the state of a model through metrics and logs, and to understand and diagnose the operational
+        health of a model.
       </dd>
 
       <dt id="model-validation">model validation <code class="placeholder">{}</code></dt>
       <dd id="dd-model-validation">
-        Definition
+        Ability to confirm that outputs of a model are acceptable given real-world inputs.
       </dd>
 
       <dt id="mothership-cluster">mothership cluster <code class="placeholder">{}</code></dt>
       <dd id="dd-mothership-cluster">
-        Definition
+        Standard Algorithmia Enterprise cluster, consisting of a number of services for algorithm creation, management,
+        and
+        execution. A mothership cluster runs in an Algorithmia-installed and configured Kubernetes cluster on customer
+        infrastructure.
       </dd>
 
       <dt id="node">node <code class="placeholder">{}</code></dt>
       <dd id="dd-node">
-        Definition
+        Generic term for control plane node, general purpose node, or worker node in Algorithmia’s Kubernetes
+        environment. A
+        node is a virtualized compute resource on which Algorithmia services are run.
       </dd>
 
       <dt id="open-source-algorithm">open-source algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-open-source-algorithm">
-        Definition
+        Algorithm published with source code visible via an authenticated resource request to the cluster if it’s a
+        public
+        algorithm. If it’s a private algorithm, the source code is only visible via authenticated resource requests from
+        the
+        account owning the algorithm.
       </dd>
 
       <dt id="orchestration-algorithm">orchestration algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-orchestration-algorithm">
-        Definition
+        Algorithm that receives an API request directly from a caller and calls other algorithms internally in a
+        pipeline.
+        Synonymous with parent algorithm and top-level algorithm.
       </dd>
 
       <dt id="org-organization">org/organization <code class="placeholder">{}</code></dt>
       <dd id="dd-org-organization">
-        Definition
+        Logical construct for sharing resource access with an arbitrary number of accounts on the cluster. An org must
+        have at
+        least one org admin, and orgs can’t be deleted once created. Accounts can be members of zero, one, or multiple
+        orgs.
       </dd>
 
       <dt id="org-admin">org admin <code class="placeholder">{}</code></dt>
       <dd id="dd-org-admin">
-        Definition
+        Account that has elevated privileges within a specific org of which it’s a member. Anyone who creates an org is
+        automatically given the org admin role, and an account can be an org admin for zero, one, or multiple orgs. Org
+        admin and cluster admin roles aren’t related.
       </dd>
 
       <dt id="org-profile">org profile <code class="placeholder">{}</code></dt>
       <dd id="dd-org-profile">
-        Definition
+        Profile page for an org.
       </dd>
 
       <dt id="parent-algorithm">parent algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-parent-algorithm">
-        Definition
+        Algorithm that receives an API request directly from a caller and calls other algorithms internally in a
+        pipeline.
+        Synonymous with orchestration algorithm and top-level algorithm.
       </dd>
 
       <dt id="password">password <code class="placeholder">{}</code></dt>
       <dd id="dd-password">
-        Definition
+        Authentication factor used to authenticate to access the resources associated with an account on the Algorithmia
+        platform.
       </dd>
 
       <dt id="platform-version">platform version <code class="placeholder">{}</code></dt>
       <dd id="dd-platform-version">
-        Definition
+        Semantic version of Algorithmia’s software, for example “20.4.7” or “v20.4.7”.
       </dd>
 
       <dt id="private-algorithm">private algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-private-algorithm">
-        Definition
+        Algorithm published privately that can only be called by the account or org that owns the algorithm.
+      </dd>
+
+      <dt id="producer">producer <code class="placeholder">{}</code></dt>
+      <dd id="dd-producer">
+        Not used. See publisher.
       </dd>
 
       <dt id="public-algorithm">public algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-public-algorithm">
-        Definition
+        Algorithm published publicly that can be called by any account or org on the cluster.
       </dd>
 
       <dt id="publisher">publisher <code class="placeholder">{}</code></dt>
       <dd id="dd-publisher">
-        Definition
+        Entity that sends records to a message broker. Synonymous with producer.
       </dd>
 
       <dt id="record">record <code class="placeholder">{}</code></dt>
       <dd id="dd-record">
-        Definition
+        Data or message sent to or retrieved from a message broker. Also used to refer to a row of data in a relational
+        database
+        table.
       </dd>
 
       <dt id="replica">replica <code class="placeholder">{}</code></dt>
       <dd id="dd-replica">
-        Definition
+        Individual instance of a specific algorithm running on a worker node.
       </dd>
 
       <dt id="reservation">reservation <code class="placeholder">{}</code></dt>
       <dd id="dd-reservation">
-        Definition
+        Algorithm instance kept warm to eliminate cold-start overhead. Reservations are only configurable by cluster
+        admins.
       </dd>
 
       <dt id="resource">resource <code class="placeholder">{}</code></dt>
       <dd id="dd-resource">
-        Definition
+        Data on the Algorithmia platform. Examples include algorithms, files stored on the platform or available through
+        the
+        platform, account information, etc.
       </dd>
 
       <dt id="resource-request">resource request <code class="placeholder">{}</code></dt>
       <dd id="dd-resource-request">
-        Definition
+        Attempt by an identity to access a resource on the Algorithmia platform. Examples include executing an
+        algorithm,
+        publishing a new version of an algorithm, reading from or writing to a data source, etc.
       </dd>
 
       <dt id="resource-uri">resource URI <code class="placeholder">{}</code></dt>
       <dd id="dd-resource-uri">
-        Definition
+        Full path at which a resource exists, equivalent to API base URL + API endpoint.
       </dd>
 
       <dt id="satellite-cluster">satellite cluster <code class="placeholder">{}</code></dt>
       <dd id="dd-satellite-cluster">
-        Definition
+        Minimal version of Algorithmia Enterprise cluster with a subset of services, including algorithms, a RabbitMQ
+        queuing
+        system, configuration information, and an API server to handle algorithm execution requests. A satellite cluster
+        runs in
+        a customer-provided Kubernetes cluster on customer infrastructure.
       </dd>
 
       <dt id="satellite-launce-instance">satellite launce instance <code class="placeholder">{}</code></dt>
       <dd id="dd-satellite-launce-instance">
-        Definition
+        Individual instance of a satellite deployment.
       </dd>
 
       <dt id="satellite-version">satellite version <code class="placeholder">{}</code></dt>
       <dd id="dd-satellite-version">
-        Definition
+        Version number associated with a specific satellite deployment. Each satellite version is configured with a
+        specific
+        list of included algorithms and authentication keys.
       </dd>
 
       <dt id="secret">secret <code class="placeholder">{}</code></dt>
       <dd id="dd-secret">
-        Definition
+        Sensitive value (e.g., password, token, access key, credential, etc.) stored encrypted in the secret store and
+        accessed
+        from algorithm source code through an environment variable.
       </dd>
 
       <dt id="secret-store">Secret Store <code class="placeholder">{}</code></dt>
       <dd id="dd-secret-store">
-        Definition
+        Secure, encrypted vault that stores sensitive information such as access keys to external services.
       </dd>
 
       <dt id="serialized-model">serialized model <code class="placeholder">{MODEL_NAME}</code></dt>
@@ -790,52 +943,67 @@
 
       <dt id="service-account">service account <code class="placeholder">{}</code></dt>
       <dd id="dd-service-account">
-        Definition
+        Account not associated with a specific human.
       </dd>
 
       <dt id="slot">slot <code class="placeholder">{}</code></dt>
       <dd id="dd-slot">
-        Definition
+        Deprecated. See replica.
       </dd>
 
       <dt id="scm-configuration">SCM configuration <code class="placeholder">{}</code></dt>
       <dd id="dd-scm-configuration">
-        Definition
+        Cluster-level details about an SCM provider, such as provider type and URLs, configured by a cluster admin using
+        a
+        key-value pair generated within the SCM provider’s platform. There may be zero, one, or multiple SCM
+        configurations for
+        one SCM provider.
       </dd>
 
       <dt id="scm-connection">SCM connection <code class="placeholder">{}</code></dt>
       <dd id="dd-scm-connection">
-        Definition
+        Account-levels details that contain credentials for connecting to an SCM provider.
       </dd>
 
       <dt id="scm-provider">SCM provider <code class="placeholder">{}</code></dt>
       <dd id="dd-scm-provider">
-        Definition
+        Third-party SCM system to which an SCM configuration can be created for hosting algorithm source code outside of
+        the
+        Algorithmia platform. See a list of supported providers here.
       </dd>
 
       <dt id="source-code-management">source code management (SCM) <code class="placeholder">{}</code></dt>
       <dd id="dd-source-code-management">
-        Definition
+        Process of tracking modifications to a source code repository. Synonymous with version control. Also synonymous
+        with
+        source control management; this term is used widely in the industry but for the purpose of consistency
+        Algorithmia
+        doesn’t use this term.
       </dd>
 
       <dt id="subscriber">subscriber <code class="placeholder">{}</code></dt>
       <dd id="dd-subscriber">
-        Definition
+        Entity that reads records from a message broker. Synonymous with consumer.
       </dd>
 
       <dt id="test-console">test console <code class="placeholder">{}</code></dt>
       <dd id="dd-test-console">
-        Definition
+        The purple console at the bottom of the Web IDE, where algorithms may be executed with sample input to test
+        their
+        functionality after building.
       </dd>
 
       <dt id="top-level-algorithm">top-level algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-top-level-algorithm">
-        Definition
+        Algorithm that receives an API request directly from a caller and calls other algorithms internally in a
+        pipeline.
+        Synonymous with orchestration algorithm and parent algorithm.
+
       </dd>
 
       <dt id="topic">topic <code class="placeholder">{}</code></dt>
       <dd id="dd-topic">
-        Definition
+        Feed within a message broker to which publishers send records and from which subscribers read records.
       </dd>
 
       <dt id="trained-model">trained model <code class="placeholder">{MODEL_NAME}</code></dt>
@@ -849,37 +1017,43 @@
 
       <dt id="training-center">Training Center <code class="placeholder">{}</code></dt>
       <dd id="dd-training-center">
-        Definition
+        Learning management system with tutorial-based training content.
       </dd>
 
       <dt id="user">user <code class="placeholder">{}</code></dt>
       <dd id="dd-user">
-        Definition
+        Human interacting with the Algorithmia platform. See identity.
       </dd>
 
       <dt id="user-account">user account <code class="placeholder">{}</code></dt>
       <dd id="dd-user-account">
-        Definition
+        Account associated with a specific user.
       </dd>
 
       <dt id="unilog">UNILOG <code class="placeholder">{}</code></dt>
       <dd id="dd-unilog">
-        Definition
+        Text-based metrics visualization dashboard. Unilog data is the aggregation of application and (some) Kubernetes
+        logs
+        from the various services in an Algorithmia cluster. These logs are used for debugging and stability monitoring
+        by
+        engineers, and can be accessed through Kibana by cluster admins only.
       </dd>
 
       <dt id="warm-algorithm">warm algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-warm-algorithm">
-        Definition
+        Algorithm instance running on a worker node and ready to handle API requests.
       </dd>
 
       <dt id="web-ide">Web IDE <code class="placeholder">{}</code></dt>
       <dd id="dd-web-ide">
-        Definition
+        Algorithmia’s built-in source code editor and test console, accessible through the “Source” tab from an
+        algorithm’s
+        profile page.
       </dd>
 
       <dt id="worker-node">worker node <code class="placeholder">{}</code></dt>
       <dd id="dd-worker-node">
-        Definition
+        Compute node in Algorithmia’s Kubernetes environment on which algorithm instances are run.
       </dd>
 
     </dl>

--- a/_pages/glossary.html
+++ b/_pages/glossary.html
@@ -324,7 +324,7 @@
           parentId="dd-algorithm-build">algorithm build</a>, in the format <code>1234-1234-1234-1234</code>.
       </dd>
 
-      <dt id="algorithm-environment">algorithm environment <code class="placeholder">{ALGO_ENV}</code></dt>
+      <dt id="algorithm-environment">algorithm environment</dt>
       <dd id="dd-algorithm-environment">
         Predefined, optimized runtime configuration for an <a class="glossary-hoverable" href="#algorithm" title=""
           parentId="dd-algorithm">algorithm</a>. Environments usually contain specific <a class="glossary-hoverable"

--- a/_pages/glossary.html
+++ b/_pages/glossary.html
@@ -567,7 +567,10 @@
         Algorithmia site where we share practical, relevant information about <a class="glossary-hoverable"
           href="#machine-learning" title="" parentId="dd-machine-learning">ML</a>/<a class="glossary-hoverable"
           href="#machine-learning-operations" title="" parentId="dd-machine-learning-operations">MLOps</a> and the
-        industry, describe new product features and partnerships, and pose new ideas.
+        industry, describe new product features, and announce new partnerships. Algorithmia's blog is located at <a
+          href="https://algorithmia.com/blog" target="_blank"
+          rel="noopener noreferrer">algorithmia.com/blog</a>.
+
       </dd>
 
       <dt id="browser-ui">browser UI</dt>

--- a/_pages/glossary.html
+++ b/_pages/glossary.html
@@ -111,7 +111,6 @@
         <li><a href="#algorithm-build-hash">algorithm build hash</a></li>
         <li><a href="#algorithm-build-uuid">algorithm build UUID</a></li>
         <li><a href="#algorithm-environment">algorithm environment</a></li>
-        <li><a href="#algorithm-environment-uuid">algorithm environment UUID</a></li>
         <li><a href="#algorithm-endpoint">algorithm endpoint</a></li>
         <li><a href="#algorithm-execution-request">algorithm execution request</a></li>
         <li><a href="#algorithm-profile">algorithm profile</a></li>
@@ -162,12 +161,12 @@
         <li><a href="#folder">folder</a></li>
         <li><a href="#general-purpose-node">general purpose node</a></li>
         <li><a href="#grafana">Grafana</a></li>
+        <li><a href="#hosted-data-collection">hosted data collection</a></li>
       </ul>
     </div>
 
     <div>
       <ul>
-        <li><a href="#hosted-data-collection">hosted data collection</a></li>
         <li><a href="#hot-algorithm">hot algorithm</a></li>
         <li><a href="#http-method">HTTP method</a></li>
         <li><a href="#json-web-token">JSON Web Token (JWT)</a></li>
@@ -332,13 +331,6 @@
           href="#machine-learning" title="" parentId="dd-machine-learning">ML</a> framework
         dependencies optimized for Algorithmia’s architecture, and serve as a base upon which additional external
         library dependencies can be added if necessary.
-      </dd>
-
-      <dt id="algorithm-environment-uuid">algorithm environment UUID <code class="placeholder">{ENV_ID}</code></dt>
-      <dd id="dd-algorithm-environment-uuid">
-        Globally unique, cluster-specific identifier for a specific <a class="glossary-hoverable"
-          href="#algorithm-environment" title="" parentId="dd-algorithm-environment">algorithm environment</a>, in the
-        format <code>1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d</code>.
       </dd>
 
       <dt id="algorithm-endpoint">algorithm endpoint <code class="placeholder">{ALGO_ENDPOINT}</code></dt>
@@ -568,9 +560,7 @@
           href="#machine-learning" title="" parentId="dd-machine-learning">ML</a>/<a class="glossary-hoverable"
           href="#machine-learning-operations" title="" parentId="dd-machine-learning-operations">MLOps</a> and the
         industry, describe new product features, and announce new partnerships. Algorithmia's blog is located at <a
-          href="https://algorithmia.com/blog" target="_blank"
-          rel="noopener noreferrer">algorithmia.com/blog</a>.
-
+          href="https://algorithmia.com/blog" target="_blank" rel="noopener noreferrer">algorithmia.com/blog</a>.
       </dd>
 
       <dt id="browser-ui">browser UI</dt>

--- a/_pages/glossary.html
+++ b/_pages/glossary.html
@@ -1270,23 +1270,6 @@
       </dd>
 
       <script>
-        // assign id to parent element, prepending "" to child element id
-        function assignParentId(parentNode) {
-          childElem = parentNode.childElem
-
-
-            .document.getElementById(childId).parentElement
-          parentElem.setAttribute("id", "" + childId)
-        }
-
-        // assign ids to all parent elements
-        function assignParentIds() {
-          terms = document.getElementsByTagName("dd")
-          for (let index = 0; index < terms.length; index++) {
-            assignParentId(terms[index]);
-          }
-        }
-
         function assignTitle(parentId) {
           elem = document.getElementById(parentId)
           if (elem) {

--- a/_pages/glossary.html
+++ b/_pages/glossary.html
@@ -36,14 +36,14 @@
     <p>
     <ul>
       <dl>
-        <dt id="dt-">Example Glossary Term <code class="placeholder">{PLACEHOLDER_STRING}</code>
-        <dd id="glossary-term">
+        <dt id="example-glossary-term">Example Glossary Term <code class="placeholder">{PLACEHOLDER_STRING}</code>
+        <dd id="dd-example-glossary-term">
           Definition with a hoverable link to <a class="glossary-hoverable" href="#another-glossary-term" title=""
             parentId="another-glossary-term">another glossary term</a>.
         </dd>
         </dt>
-        <dt id="dt-">Another Glossary Term
-        <dd id="another-glossary-term">
+        <dt id="another-glossary-term">Another Glossary Term
+        <dd id="dd-another-glossary-term">
           This text is displayed when hovered above.
         </dd>
         </dt>
@@ -82,135 +82,135 @@
   <div id="glossary-index" class="row">
     <div class="column left" style="background-color: pink;">
       <ul>
-        <li><a href="#dt-account">account</a></li>
-        <li><a href="#dt-account-profile">account profile</a></li>
-        <li><a href="#dt-admin-account">admin account</a></li>
-        <li><a href="#dt-admin-api-key">admin API key</a></li>
-        <li><a href="#dt-admin-panel">admin panel</a></li>
-        <li><a href="#dt-algo-cli">algo CLI</a></li>
-        <li><a href="#dt-algorithm">algorithm</a></li>
-        <li><a href="#dt-algorithm-build">algorithm build</a></li>
-        <li><a href="#dt-algorithm-build-hash">algorithm build hash</a></li>
-        <li><a href="#dt-algorithm-build-uuid">algorithm build UUID</a></li>
-        <li><a href="#dt-algorithm-environment">algorithm environment</a></li>
-        <li><a href="#dt-algorithm-environment-uuid">algorithm environment UUID</a></li>
-        <li><a href="#dt-algorithm-endpoint">algorithm endpoint</a></li>
-        <li><a href="#dt-algorithm-execution-request">algorithm execution request</a></li>
-        <li><a href="#dt-algorithm-profile">algorithm profile</a></li>
-        <li><a href="#dt-algorithm-instance">algorithm instance</a></li>
-        <li><a href="#dt-algorithm-language">algorithm language</a></li>
-        <li><a href="#dt-algorithm-owner">algorithm owner</a></li>
-        <li><a href="#dt-algorithm-pipelining">algorithm pipelining</a></li>
-        <li><a href="#dt-algorithm-semantic-version">algorithm semantic version</a></li>
-        <li><a href="#dt-algorithm-template">algorithm template</a></li>
-        <li><a href="#dt-algorithm-uuid">algorithm UUID</a></li>
-        <li><a href="#dt-algorithm-vanity-url">algorithm vanity URL</a></li>
-        <li><a href="#dt-algorithm-version">algorithm version</a></li>
-        <li><a href="#dt-algorithm-version-hash">algorithm version hash</a></li>
-        <li><a href="#dt-api">API</a></li>
-        <li><a href="#dt-api-docs">API docs</a></li>
-        <li><a href="#dt-api-endpoint">API endpoint</a></li>
-        <li><a href="#dt-api-key">API key</a></li>
-        <li><a href="#dt-api-method">API method</a></li>
-        <li><a href="#dt-authenticated-resource-request">authenticated resource request</a></li>
-        <li><a href="#dt-authentication">authentication</a></li>
-        <li><a href="#dt-authentication-factor">authentication factor</a></li>
-        <li><a href="#dt-authentication-token">authentication token</a></li>
-        <li><a href="#dt-authorization">authorization</a></li>
-        <li><a href="#dt-base-api-url">base API URL</a></li>
-        <li><a href="#dt-base-url">base URL</a></li>
-        <li><a href="#dt-blog">blog</a></li>
-        <li><a href="#dt-browser-ui">browser UI</a></li>
-        <li><a href="#dt-caller">caller</a></li>
-        <li><a href="#dt-collection-owner">collection owner</a></li>
-        <li><a href="#dt-closed-source-algorithm">closed source algorithm</a></li>
-        <li><a href="#dt-cluster">cluster</a></li>
-        <li><a href="#dt-cluster-admin-account">cluster admin account</a></li>
-        <li><a href="#dt-cluster-domain">cluster domain</a></li>
-        <li><a href="#dt-cluster-operator">cluster operator</a></li>
-        <li><a href="#dt-cold-algorithm">cold algorithm</a></li>
-        <li><a href="#dt-constellation-distributed-serving">Constellation Distributed Serving</a></li>
-        <li><a href="#dt-consumer">consumer</a></li>
-        <li><a href="#dt-control-plane-node">control plane node</a></li>
-        <li><a href="#dt-data-connector">data connector</a></li>
-        <li><a href="#dt-data-source">data source</a></li>
-        <li><a href="#dt-data-uri">data URI</a></li>
-        <li><a href="#dt-developer-center">Developer Center</a></li>
-        <li><a href="#dt-directory">directory</a></li>
-        <li><a href="#dt-event-flow">Event Flow</a></li>
-        <li><a href="#dt-event-listener">event listener</a></li>
-        <li><a href="#dt-event-manager">event manager</a></li>
-        <li><a href="#dt-external-data-source">external data source</a></li>
-        <li><a href="#dt-file">file</a></li>
-        <li><a href="#dt-folder">folder</a></li>
-        <li><a href="#dt-general-purpose-node">general purpose node</a></li>
+        <li><a href="#account">account</a></li>
+        <li><a href="#account-profile">account profile</a></li>
+        <li><a href="#admin-account">admin account</a></li>
+        <li><a href="#admin-api-key">admin API key</a></li>
+        <li><a href="#admin-panel">admin panel</a></li>
+        <li><a href="#algo-cli">algo CLI</a></li>
+        <li><a href="#algorithm">algorithm</a></li>
+        <li><a href="#algorithm-build">algorithm build</a></li>
+        <li><a href="#algorithm-build-hash">algorithm build hash</a></li>
+        <li><a href="#algorithm-build-uuid">algorithm build UUID</a></li>
+        <li><a href="#algorithm-environment">algorithm environment</a></li>
+        <li><a href="#algorithm-environment-uuid">algorithm environment UUID</a></li>
+        <li><a href="#algorithm-endpoint">algorithm endpoint</a></li>
+        <li><a href="#algorithm-execution-request">algorithm execution request</a></li>
+        <li><a href="#algorithm-profile">algorithm profile</a></li>
+        <li><a href="#algorithm-instance">algorithm instance</a></li>
+        <li><a href="#algorithm-language">algorithm language</a></li>
+        <li><a href="#algorithm-owner">algorithm owner</a></li>
+        <li><a href="#algorithm-pipelining">algorithm pipelining</a></li>
+        <li><a href="#algorithm-semantic-version">algorithm semantic version</a></li>
+        <li><a href="#algorithm-template">algorithm template</a></li>
+        <li><a href="#algorithm-uuid">algorithm UUID</a></li>
+        <li><a href="#algorithm-vanity-url">algorithm vanity URL</a></li>
+        <li><a href="#algorithm-version">algorithm version</a></li>
+        <li><a href="#algorithm-version-hash">algorithm version hash</a></li>
+        <li><a href="#api">API</a></li>
+        <li><a href="#api-docs">API docs</a></li>
+        <li><a href="#api-endpoint">API endpoint</a></li>
+        <li><a href="#api-key">API key</a></li>
+        <li><a href="#api-method">API method</a></li>
+        <li><a href="#authenticated-resource-request">authenticated resource request</a></li>
+        <li><a href="#authentication">authentication</a></li>
+        <li><a href="#authentication-factor">authentication factor</a></li>
+        <li><a href="#authentication-token">authentication token</a></li>
+        <li><a href="#authorization">authorization</a></li>
+        <li><a href="#base-api-url">base API URL</a></li>
+        <li><a href="#base-url">base URL</a></li>
+        <li><a href="#blog">blog</a></li>
+        <li><a href="#browser-ui">browser UI</a></li>
+        <li><a href="#caller">caller</a></li>
+        <li><a href="#collection-owner">collection owner</a></li>
+        <li><a href="#closed-source-algorithm">closed source algorithm</a></li>
+        <li><a href="#cluster">cluster</a></li>
+        <li><a href="#cluster-admin-account">cluster admin account</a></li>
+        <li><a href="#cluster-domain">cluster domain</a></li>
+        <li><a href="#cluster-operator">cluster operator</a></li>
+        <li><a href="#cold-algorithm">cold algorithm</a></li>
+        <li><a href="#constellation-distributed-serving">Constellation Distributed Serving</a></li>
+        <li><a href="#consumer">consumer</a></li>
+        <li><a href="#control-plane-node">control plane node</a></li>
+        <li><a href="#data-connector">data connector</a></li>
+        <li><a href="#data-source">data source</a></li>
+        <li><a href="#data-uri">data URI</a></li>
+        <li><a href="#developer-center">Developer Center</a></li>
+        <li><a href="#directory">directory</a></li>
+        <li><a href="#event-flow">Event Flow</a></li>
+        <li><a href="#event-listener">event listener</a></li>
+        <li><a href="#event-manager">event manager</a></li>
+        <li><a href="#external-data-source">external data source</a></li>
+        <li><a href="#file">file</a></li>
+        <li><a href="#folder">folder</a></li>
+        <li><a href="#general-purpose-node">general purpose node</a></li>
       </ul>
     </div>
 
     <div class="column right" style="background-color: yellow;">
       <ul>
-        <li><a href="#dt-grafana">Grafana</a></li>
-        <li><a href="#dt-hosted-data-collection">hosted data collection</a></li>
-        <li><a href="#dt-hot-algorithm">hot algorithm</a></li>
-        <li><a href="#dt-json-web-token">JSON Web Token (JWT)</a></li>
-        <li><a href="#dt-identity">identity</a></li>
-        <li><a href="#dt-kibana">Kibana</a></li>
-        <li><a href="#dt-machine-learning">machine learning (ML)</a></li>
-        <li><a href="#dt-master-node">master node</a></li>
-        <li><a href="#dt-message-broker">message broker</a></li>
-        <li><a href="#dt-message-broker-connection">message broker connection</a></li>
-        <li><a href="#dt-ml-service-catalog">ML service catalog</a></li>
-        <li><a href="#dt-model">model</a></li>
-        <li><a href="#dt-model-explainability">model explainability</a></li>
-        <li><a href="#dt-model-governance">model governance</a></li>
-        <li><a href="#dt-model-interpretability">model interpretability</a></li>
-        <li><a href="#dt-model-monitoring">model monitoring</a></li>
-        <li><a href="#dt-model-observability">model observability</a></li>
-        <li><a href="#dt-model-validation">model validation</a></li>
-        <li><a href="#dt-mothership-cluster">mothership cluster</a></li>
-        <li><a href="#dt-node">node</a></li>
-        <li><a href="#dt-open-source-algorithm">open-source algorithm</a></li>
-        <li><a href="#dt-orchestration-algorithm">orchestration algorithm</a></li>
-        <li><a href="#dt-org-organization">org/organization</a></li>
-        <li><a href="#dt-org-admin">org admin</a></li>
-        <li><a href="#dt-org-profile">org profile</a></li>
-        <li><a href="#dt-parent-algorithm">parent algorithm</a></li>
-        <li><a href="#dt-password">password</a></li>
-        <li><a href="#dt-platform-version">platform version</a></li>
-        <li><a href="#dt-private-algorithm">private algorithm</a></li>
-        <li><a href="#dt-producer">producer</a></li>
-        <li><a href="#dt-public-algorithm">public algorithm</a></li>
-        <li><a href="#dt-publisher">publisher</a></li>
-        <li><a href="#dt-record">record</a></li>
-        <li><a href="#dt-replica">replica</a></li>
-        <li><a href="#dt-reservation">reservation</a></li>
-        <li><a href="#dt-resource">resource</a></li>
-        <li><a href="#dt-resource-request">resource request</a></li>
-        <li><a href="#dt-resource-uri">resource URI</a></li>
-        <li><a href="#dt-satellite-cluster">satellite cluster</a></li>
-        <li><a href="#dt-satellite-launch-instance">satellite launch instance</a></li>
-        <li><a href="#dt-satellite-version">satellite version</a></li>
-        <li><a href="#dt-secret">secret</a></li>
-        <li><a href="#dt-secret-store">Secret Store</a></li>
-        <li><a href="#dt-serialized-model">serialized model</a></li>
-        <li><a href="#dt-service-account">service account</a></li>
-        <li><a href="#dt-slot">slot</a></li>
-        <li><a href="#dt-scm-configuration">SCM configuration</a></li>
-        <li><a href="#dt-scm-connection">SCM connection</a></li>
-        <li><a href="#dt-scm-provider">SCM provider</a></li>
-        <li><a href="#dt-source-code-management">source code management (SCM)</a></li>
-        <li><a href="#dt-subscriber">subscriber</a></li>
-        <li><a href="#dt-test-console">test console</a></li>
-        <li><a href="#dt-top-level-algorithm">top level algorithm</a></li>
-        <li><a href="#dt-topic">topic</a></li>
-        <li><a href="#dt-trained-model">trained model</a></li>
-        <li><a href="#dt-training-center">Training Center</a></li>
-        <li><a href="#dt-user">user</a></li>
-        <li><a href="#dt-user-account">user account</a></li>
-        <li><a href="#dt-unilog">UNILOG</a></li>
-        <li><a href="#dt-warm-algorithm">warm algorithm</a></li>
-        <li><a href="#dt-web-ide">Web IDE</a></li>
-        <li><a href="#dt-worker-node">worker node</a></li>
+        <li><a href="#grafana">Grafana</a></li>
+        <li><a href="#hosted-data-collection">hosted data collection</a></li>
+        <li><a href="#hot-algorithm">hot algorithm</a></li>
+        <li><a href="#json-web-token">JSON Web Token (JWT)</a></li>
+        <li><a href="#identity">identity</a></li>
+        <li><a href="#kibana">Kibana</a></li>
+        <li><a href="#machine-learning">machine learning (ML)</a></li>
+        <li><a href="#master-node">master node</a></li>
+        <li><a href="#message-broker">message broker</a></li>
+        <li><a href="#message-broker-connection">message broker connection</a></li>
+        <li><a href="#ml-service-catalog">ML service catalog</a></li>
+        <li><a href="#model">model</a></li>
+        <li><a href="#model-explainability">model explainability</a></li>
+        <li><a href="#model-governance">model governance</a></li>
+        <li><a href="#model-interpretability">model interpretability</a></li>
+        <li><a href="#model-monitoring">model monitoring</a></li>
+        <li><a href="#model-observability">model observability</a></li>
+        <li><a href="#model-validation">model validation</a></li>
+        <li><a href="#mothership-cluster">mothership cluster</a></li>
+        <li><a href="#node">node</a></li>
+        <li><a href="#open-source-algorithm">open-source algorithm</a></li>
+        <li><a href="#orchestration-algorithm">orchestration algorithm</a></li>
+        <li><a href="#org-organization">org/organization</a></li>
+        <li><a href="#org-admin">org admin</a></li>
+        <li><a href="#org-profile">org profile</a></li>
+        <li><a href="#parent-algorithm">parent algorithm</a></li>
+        <li><a href="#password">password</a></li>
+        <li><a href="#platform-version">platform version</a></li>
+        <li><a href="#private-algorithm">private algorithm</a></li>
+        <li><a href="#producer">producer</a></li>
+        <li><a href="#public-algorithm">public algorithm</a></li>
+        <li><a href="#publisher">publisher</a></li>
+        <li><a href="#record">record</a></li>
+        <li><a href="#replica">replica</a></li>
+        <li><a href="#reservation">reservation</a></li>
+        <li><a href="#resource">resource</a></li>
+        <li><a href="#resource-request">resource request</a></li>
+        <li><a href="#resource-uri">resource URI</a></li>
+        <li><a href="#satellite-cluster">satellite cluster</a></li>
+        <li><a href="#satellite-launch-instance">satellite launch instance</a></li>
+        <li><a href="#satellite-version">satellite version</a></li>
+        <li><a href="#secret">secret</a></li>
+        <li><a href="#secret-store">Secret Store</a></li>
+        <li><a href="#serialized-model">serialized model</a></li>
+        <li><a href="#service-account">service account</a></li>
+        <li><a href="#slot">slot</a></li>
+        <li><a href="#scm-configuration">SCM configuration</a></li>
+        <li><a href="#scm-connection">SCM connection</a></li>
+        <li><a href="#scm-provider">SCM provider</a></li>
+        <li><a href="#source-code-management">source code management (SCM)</a></li>
+        <li><a href="#subscriber">subscriber</a></li>
+        <li><a href="#test-console">test console</a></li>
+        <li><a href="#top-level-algorithm">top level algorithm</a></li>
+        <li><a href="#topic">topic</a></li>
+        <li><a href="#trained-model">trained model</a></li>
+        <li><a href="#training-center">Training Center</a></li>
+        <li><a href="#user">user</a></li>
+        <li><a href="#user-account">user account</a></li>
+        <li><a href="#unilog">UNILOG</a></li>
+        <li><a href="#warm-algorithm">warm algorithm</a></li>
+        <li><a href="#web-ide">Web IDE</a></li>
+        <li><a href="#worker-node">worker node</a></li>
       </ul>
     </div>
   </div>
@@ -220,643 +220,643 @@
   <div id="glossary-definitions">
     <dl>
 
-      <dt id="dt-uniqueId">item name <code class="placeholder">{PLACEHOLDER}</code></dt>
+      <dt id="uniqueId">item name <code class="placeholder">{PLACEHOLDER}</code></dt>
       <dd id="dd-uniqueId">
         Definition
       </dd>
 
-      <dt id="dt-account">account <code class="placeholder">{ACCOUNT_NAME}</code></dt>
+      <dt id="account">account <code class="placeholder">{ACCOUNT_NAME}</code></dt>
       <dd id="dd-account">
-        <a class="glossary-hoverable" href="#dt-identity" title="" parentId="dd-identity">Identity</a> on the
+        <a class="glossary-hoverable" href="#identity" title="" parentId="dd-identity">Identity</a> on the
         Algorithmia
         platform that may own and/or be used to access a resource (e.g., an <a class="glossary-hoverable"
-          href="#dt-algorithm" title="" parentId="dd-algorithm">algorithm</a>).
+          href="#algorithm" title="" parentId="dd-algorithm">algorithm</a>).
       </dd>
 
-      <dt id="dt-account-profile">account profile <code class="placeholder">{/users/ACCOUNT_NAME}</code></dt>
+      <dt id="account-profile">account profile <code class="placeholder">{/users/ACCOUNT_NAME}</code></dt>
       <dd id="dd-account-profile">
-        Profile page for an <a class="glossary-hoverable" href="#dt-account" title="" parentId="dd-account">account</a>.
+        Profile page for an <a class="glossary-hoverable" href="#account" title="" parentId="dd-account">account</a>.
       </dd>
 
-      <dt id="dt-admin-account">admin account</dt>
+      <dt id="admin-account">admin account</dt>
       <dd id="dd-admin-account">
-        See <a class="glossary-hoverable" href="#dt-cluster-admin-account" title=""
+        See <a class="glossary-hoverable" href="#cluster-admin-account" title=""
           parentId="dd-cluster-admin-account">cluster admin account</a> or <a class="glossary-hoverable"
-          href="#dt-org-admin-account" title="" parentId="dd-org-admin-account">org admin account</a>.
+          href="#org-admin-account" title="" parentId="dd-org-admin-account">org admin account</a>.
       </dd>
 
-      <dt id="dt-admin-api-key">admin API key <code class="placeholder">{ADMIN_API_KEY}</code></dt>
+      <dt id="admin-api-key">admin API key <code class="placeholder">{ADMIN_API_KEY}</code></dt>
       <dd id="dd-admin-api-key">
         Secret authentication token associated with a specific cluster admin account. An admin API key can be used to
         make specific administrative authenticated resource requests through the API. Examples of admin-only requests
         include creating and deleting user accounts and organizations.
       </dd>
 
-      <dt id="dt-admin-panel">admin panel <code class="placeholder">{/admin/&lt;page name&gt;}</code></dt>
+      <dt id="admin-panel">admin panel <code class="placeholder">{/admin/&lt;page name&gt;}</code></dt>
       <dd id="dd-admin-panel">
         Navigation bar displaying administrative functionality available to a cluster admin.
       </dd>
 
-      <dt id="dt-algo-cli">algo CLI</dt>
+      <dt id="algo-cli">algo CLI</dt>
       <dd id="dd-algo-cli">
         Algorithmia’s command-line interface tool, called with algo [COMMAND [OPTIONS]].
       </dd>
 
-      <dt id="dt-algorithm">algorithm <code class="placeholder">{}</code></dt>
+      <dt id="algorithm">algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm">
         Definition
       </dd>
 
-      <dt id="dt-algorithm-build">algorithm build <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-build">algorithm build <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-build">
         Definition
       </dd>
 
-      <dt id="dt-algorithm-build-hash">algorithm build hash <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-build-hash">algorithm build hash <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-build-hash">
         Definition
       </dd>
 
-      <dt id="dt-algorithm-build-uuid">algorithm build UUID <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-build-uuid">algorithm build UUID <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-build-uuid">
         Definition
       </dd>
 
-      <dt id="dt-algorithm-environment">algorithm environment <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-environment">algorithm environment <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-environment">
         Definition
       </dd>
 
-      <dt id="dt-algorithm-environment-uuid">algorithm environment UUID <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-environment-uuid">algorithm environment UUID <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-environment-uuid">
         Definition
       </dd>
 
-      <dt id="dt-algorithm-endpoint">algorithm endpoint <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-endpoint">algorithm endpoint <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-endpoint">
         Definition
       </dd>
 
-      <dt id="dt-algorithm-execution-request">algorithm execution request <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-execution-request">algorithm execution request <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-execution-request">
         Definition
       </dd>
 
-      <dt id="dt-algorithm-profile">algorithm profile <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-profile">algorithm profile <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-profile">
         Definition
       </dd>
 
-      <dt id="dt-algorithm-instance">algorithm instance <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-instance">algorithm instance <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-instance">
         Definition
       </dd>
 
-      <dt id="dt-algorithm-language">algorithm language <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-language">algorithm language <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-language">
         Definition
       </dd>
 
-      <dt id="dt-algorithm-owner">algorithm owner <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-owner">algorithm owner <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-owner">
         Definition
       </dd>
 
-      <dt id="dt-algorithm-pipelining">algorithm pipelining <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-pipelining">algorithm pipelining <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-pipelining">
         Definition
       </dd>
 
-      <dt id="dt-algorithm-semantic-version">algorithm semantic version <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-semantic-version">algorithm semantic version <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-semantic-version">
         Definition
       </dd>
 
-      <dt id="dt-algorithm-template">algorithm template <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-template">algorithm template <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-template">
         Definition
       </dd>
 
-      <dt id="dt-algorithm-uuid">algorithm UUID <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-uuid">algorithm UUID <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-uuid">
         Definition
       </dd>
 
-      <dt id="dt-algorithm-vanity-url">algorithm vanity URL <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-vanity-url">algorithm vanity URL <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-vanity-url">
         Definition
       </dd>
 
-      <dt id="dt-algorithm-version">algorithm version <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-version">algorithm version <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-version">
         Definition
       </dd>
 
-      <dt id="dt-algorithm-version-hash">algorithm version hash <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-version-hash">algorithm version hash <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-version-hash">
         Definition
       </dd>
 
-      <dt id="dt-api">API <code class="placeholder">{}</code></dt>
+      <dt id="api">API <code class="placeholder">{}</code></dt>
       <dd id="dd-api">
         Definition
       </dd>
 
-      <dt id="dt-api-docs">API Docs <code class="placeholder">{}</code></dt>
+      <dt id="api-docs">API Docs <code class="placeholder">{}</code></dt>
       <dd id="dd-api-docs">
         Definition
       </dd>
 
-      <dt id="dt-api-endpoint">API endpoint <code class="placeholder">{}</code></dt>
+      <dt id="api-endpoint">API endpoint <code class="placeholder">{}</code></dt>
       <dd id="dd-api-endpoint">
         Definition
       </dd>
 
-      <dt id="dt-api-key">API key <code class="placeholder">{}</code></dt>
+      <dt id="api-key">API key <code class="placeholder">{}</code></dt>
       <dd id="dd-api-key">
         Definition
       </dd>
 
-      <dt id="dt-api-method">API method <code class="placeholder">{}</code></dt>
+      <dt id="api-method">API method <code class="placeholder">{}</code></dt>
       <dd id="dd-api-method">
         Definition
       </dd>
 
-      <dt id="dt-authenticated-resource-request">authenticated resource request</dt>
+      <dt id="authenticated-resource-request">authenticated resource request</dt>
       <dd id="dd-authenticated-resource-request">
         Definition
       </dd>
 
-      <dt id="dt-authentication">authentication <code class="placeholder">{}</code></dt>
+      <dt id="authentication">authentication <code class="placeholder">{}</code></dt>
       <dd id="dd-authentication">
         Definition
       </dd>
 
-      <dt id="dt-authentication-factor">authentication factor <code class="placeholder">{}</code></dt>
+      <dt id="authentication-factor">authentication factor <code class="placeholder">{}</code></dt>
       <dd id="dd-authentication-factor">
         Definition
       </dd>
 
-      <dt id="dt-authentication-token">authentication token <code class="placeholder">{}</code></dt>
+      <dt id="authentication-token">authentication token <code class="placeholder">{}</code></dt>
       <dd id="dd-authentication-token">
         Definition
       </dd>
 
-      <dt id="dt-authorization">authorization <code class="placeholder">{}</code></dt>
+      <dt id="authorization">authorization <code class="placeholder">{}</code></dt>
       <dd id="dd-authorization">
         Definition
       </dd>
 
-      <dt id="dt-base-api-url">base API URL <code class="placeholder">{}</code></dt>
+      <dt id="base-api-url">base API URL <code class="placeholder">{}</code></dt>
       <dd id="dd-base-api-url">
         Definition
       </dd>
 
-      <dt id="dt-base-url">base URL <code class="placeholder">{}</code></dt>
+      <dt id="base-url">base URL <code class="placeholder">{}</code></dt>
       <dd id="dd-base-url">
         Definition
       </dd>
 
-      <dt id="dt-blog">blog <code class="placeholder">{}</code></dt>
+      <dt id="blog">blog <code class="placeholder">{}</code></dt>
       <dd id="dd-blog">
         Definition
       </dd>
 
-      <dt id="dt-browser-ui">browser UI <code class="placeholder">{}</code></dt>
+      <dt id="browser-ui">browser UI <code class="placeholder">{}</code></dt>
       <dd id="dd-browser-ui">
         Definition
       </dd>
 
-      <dt id="dt-caller">caller <code class="placeholder">{CALLER_NAME}</code></dt>
+      <dt id="caller">caller <code class="placeholder">{CALLER_NAME}</code></dt>
       <dd id="dd-caller">
         Definition
       </dd>
 
-      <dt id="dt-collection-owner">collection owner <code class="placeholder">{}</code></dt>
+      <dt id="collection-owner">collection owner <code class="placeholder">{}</code></dt>
       <dd id="dd-collection-owner">
         Definition
       </dd>
 
-      <dt id="dt-closed-source-algorithm">closed-source algorithm <code class="placeholder">{}</code></dt>
+      <dt id="closed-source-algorithm">closed-source algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-closed-source-algorithm">
         Definition
       </dd>
 
-      <dt id="dt-cluster">cluster <code class="placeholder">{}</code></dt>
+      <dt id="cluster">cluster <code class="placeholder">{}</code></dt>
       <dd id="dd-cluster">
         Definition
       </dd>
 
-      <dt id="dt-cluster-admin-account">cluster admin account <code class="placeholder">{}</code></dt>
+      <dt id="cluster-admin-account">cluster admin account <code class="placeholder">{}</code></dt>
       <dd id="dd-cluster-admin-account">
         Definition
       </dd>
 
-      <dt id="dt-cluster-domain">cluster domain <code class="placeholder">{}</code></dt>
+      <dt id="cluster-domain">cluster domain <code class="placeholder">{}</code></dt>
       <dd id="dd-cluster-domain">
         Definition
       </dd>
 
-      <dt id="dt-cluster-operator">cluster operator <code class="placeholder">{}</code></dt>
+      <dt id="cluster-operator">cluster operator <code class="placeholder">{}</code></dt>
       <dd id="dd-cluster-operator">
         Definition
       </dd>
 
-      <dt id="dt-cold-algorithm">cold algorithm <code class="placeholder">{}</code></dt>
+      <dt id="cold-algorithm">cold algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-cold-algorithm">
         Definition
       </dd>
 
-      <dt id="dt-constellation-distributed-serving">Constellation Distributed Serving</dt>
+      <dt id="constellation-distributed-serving">Constellation Distributed Serving</dt>
       <dd id="dd-constellation-distributed-serving">
         Definition
       </dd>
 
-      <dt id="dt-consumer">consumer <code class="placeholder">{}</code></dt>
+      <dt id="consumer">consumer <code class="placeholder">{}</code></dt>
       <dd id="dd-consumer">
         Definition
       </dd>
 
-      <dt id="dt-contorl-plane-node">control plane node <code class="placeholder">{}</code></dt>
+      <dt id="contorl-plane-node">control plane node <code class="placeholder">{}</code></dt>
       <dd id="dd-contorl-plane-node">
         Definition
       </dd>
 
-      <dt id="dt-data-connector">data connector <code class="placeholder">{}</code></dt>
+      <dt id="data-connector">data connector <code class="placeholder">{}</code></dt>
       <dd id="dd-data-connector">
         Definition
       </dd>
 
-      <dt id="dt-data-source">data source <code class="placeholder">{}</code></dt>
+      <dt id="data-source">data source <code class="placeholder">{}</code></dt>
       <dd id="dd-data-source">
         Definition
       </dd>
 
-      <dt id="dt-data-uri">data URI <code class="placeholder">{}</code></dt>
+      <dt id="data-uri">data URI <code class="placeholder">{}</code></dt>
       <dd id="dd-data-uri">
         Definition
       </dd>
 
-      <dt id="dt-developer-center">Developer Center <code class="placeholder">{}</code></dt>
+      <dt id="developer-center">Developer Center <code class="placeholder">{}</code></dt>
       <dd id="dd-developer-center">
         Definition
       </dd>
 
-      <dt id="dt-directory">directory <code class="placeholder">{}</code></dt>
+      <dt id="directory">directory <code class="placeholder">{}</code></dt>
       <dd id="dd-directory">
         Definition
       </dd>
 
-      <dt id="dt-event-flow">Event Flow <code class="placeholder">{}</code></dt>
+      <dt id="event-flow">Event Flow <code class="placeholder">{}</code></dt>
       <dd id="dd-event-flow">
         Definition
       </dd>
 
-      <dt id="dt-event-listener">event listener <code class="placeholder">{}</code></dt>
+      <dt id="event-listener">event listener <code class="placeholder">{}</code></dt>
       <dd id="dd-event-listener">
         Definition
       </dd>
 
-      <dt id="dt-event-manager">event manager <code class="placeholder">{}</code></dt>
+      <dt id="event-manager">event manager <code class="placeholder">{}</code></dt>
       <dd id="dd-event-manager">
         Definition
       </dd>
 
-      <dt id="dt-external-data-source">external data source <code class="placeholder">{}</code></dt>
+      <dt id="external-data-source">external data source <code class="placeholder">{}</code></dt>
       <dd id="dd-external-data-source">
         Definition
       </dd>
 
-      <dt id="dt-file">file <code class="placeholder">{}</code></dt>
+      <dt id="file">file <code class="placeholder">{}</code></dt>
       <dd id="dd-file">
         Definition
       </dd>
 
-      <dt id="dt-folder">folder <code class="placeholder">{}</code></dt>
+      <dt id="folder">folder <code class="placeholder">{}</code></dt>
       <dd id="dd-folder">
         Definition
       </dd>
 
-      <dt id="dt-general-purpose-node">general purpose node <code class="placeholder">{}</code></dt>
+      <dt id="general-purpose-node">general purpose node <code class="placeholder">{}</code></dt>
       <dd id="dd-general-purpose-node">
         Definition
       </dd>
 
-      <dt id="dt-grafana">Grafana <code class="placeholder">{}</code></dt>
+      <dt id="grafana">Grafana <code class="placeholder">{}</code></dt>
       <dd id="dd-grafana">
         Definition
       </dd>
 
-      <dt id="dt-hosted-data-collection">hosted data collection <code class="placeholder">{}</code></dt>
+      <dt id="hosted-data-collection">hosted data collection <code class="placeholder">{}</code></dt>
       <dd id="dd-hosted-data-collection">
         Definition
       </dd>
 
-      <dt id="dt-hot-algorithm">hot algorithm <code class="placeholder">{}</code></dt>
+      <dt id="hot-algorithm">hot algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-hot-algorithm">
         Definition
       </dd>
       `
-      <dt id="dt-json-web-token">JSON Web Token (JWT) <code class="placeholder">{}</code></dt>
+      <dt id="json-web-token">JSON Web Token (JWT) <code class="placeholder">{}</code></dt>
       <dd id="dd-json-web-token">
         Definition
       </dd>
 
-      <dt id="dt-identity">identity <code class="placeholder">{}</code></dt>
+      <dt id="identity">identity <code class="placeholder">{}</code></dt>
       <dd id="dd-identity">
         Definition
       </dd>
 
-      <dt id="dt-kibana">Kibana <code class="placeholder">{}</code></dt>
+      <dt id="kibana">Kibana <code class="placeholder">{}</code></dt>
       <dd id="dd-kibana">
         Definition
       </dd>
 
-      <dt id="dt-machine-learning">machine learning (ML) <code class="placeholder">{}</code></dt>
+      <dt id="machine-learning">machine learning (ML) <code class="placeholder">{}</code></dt>
       <dd id="dd-machine-learning">
         Application of artificial intelligence in which a computer system uses algorithms and statistical models to
         analyze and draw inferences from patterns in data, learning and adapting in order to make decisions without
         following explicit instructions from humans.
       </dd>
 
-      <dt id="dt-master-node">master node <code class="placeholder">{}</code></dt>
+      <dt id="master-node">master node <code class="placeholder">{}</code></dt>
       <dd id="dd-master-node">
         Definition
       </dd>
 
-      <dt id="dt-message-broker">message broker <code class="placeholder">{}</code></dt>
+      <dt id="message-broker">message broker <code class="placeholder">{}</code></dt>
       <dd id="dd-message-broker">
         Definition
       </dd>
 
-      <dt id="dt-message-broker-connection">message broker connection <code class="placeholder">{}</code></dt>
+      <dt id="message-broker-connection">message broker connection <code class="placeholder">{}</code></dt>
       <dd id="dd-message-broker-connection">
         Definition
       </dd>
 
-      <dt id="dt-ml-service-catalog">ML service catalog <code class="placeholder">{}</code></dt>
+      <dt id="ml-service-catalog">ML service catalog <code class="placeholder">{}</code></dt>
       <dd id="dd-ml-service-catalog">
         Definition
       </dd>
 
-      <dt id="dt-model">model <code class="placeholder">{MODEL_NAME}</code></dt>
+      <dt id="model">model <code class="placeholder">{MODEL_NAME}</code></dt>
       <dd id="dd-model">
-        <a class="glossary-hoverable" href="#dt-machine-learning" title="" parentId="dd-machine-learning">ML</a> model
+        <a class="glossary-hoverable" href="#machine-learning" title="" parentId="dd-machine-learning">ML</a> model
         file that’s ready to be loaded into an algorithm and used for inference. Synonymous with <a
-          class="glossary-hoverable" href="#dt-serialized-model" title="" parentId="dd-serialized-model">serialized
-          model</a> and <a class="glossary-hoverable" href="#dt-trained-model" title=""
+          class="glossary-hoverable" href="#serialized-model" title="" parentId="dd-serialized-model">serialized
+          model</a> and <a class="glossary-hoverable" href="#trained-model" title=""
           parentId="dd-trained-model">trained
           model</a>.
       </dd>
 
-      <dt id="dt-model-explainability">model explainability <code class="placeholder">{}</code></dt>
+      <dt id="model-explainability">model explainability <code class="placeholder">{}</code></dt>
       <dd id="dd-model-explainability">
         Definition
       </dd>
 
-      <dt id="dt-model-governance">model governance <code class="placeholder">{}</code></dt>
+      <dt id="model-governance">model governance <code class="placeholder">{}</code></dt>
       <dd id="dd-model-governance">
         Definition
       </dd>
 
-      <dt id="dt-model-interpretability">model interpretability <code class="placeholder">{}</code></dt>
+      <dt id="model-interpretability">model interpretability <code class="placeholder">{}</code></dt>
       <dd id="dd-model-interpretability">
         Definition
       </dd>
 
-      <dt id="dt-model-monitoring">model monitoring <code class="placeholder">{}</code></dt>
+      <dt id="model-monitoring">model monitoring <code class="placeholder">{}</code></dt>
       <dd id="dd-model-monitoring">
         Definition
       </dd>
 
-      <dt id="dt-model-observability">model observability <code class="placeholder">{}</code></dt>
+      <dt id="model-observability">model observability <code class="placeholder">{}</code></dt>
       <dd id="dd-model-observability">
         Definition
       </dd>
 
-      <dt id="dt-model-validation">model validation <code class="placeholder">{}</code></dt>
+      <dt id="model-validation">model validation <code class="placeholder">{}</code></dt>
       <dd id="dd-model-validation">
         Definition
       </dd>
 
-      <dt id="dt-mothership-cluster">mothership cluster <code class="placeholder">{}</code></dt>
+      <dt id="mothership-cluster">mothership cluster <code class="placeholder">{}</code></dt>
       <dd id="dd-mothership-cluster">
         Definition
       </dd>
 
-      <dt id="dt-node">node <code class="placeholder">{}</code></dt>
+      <dt id="node">node <code class="placeholder">{}</code></dt>
       <dd id="dd-node">
         Definition
       </dd>
 
-      <dt id="dt-open-source-algorithm">open-source algorithm <code class="placeholder">{}</code></dt>
+      <dt id="open-source-algorithm">open-source algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-open-source-algorithm">
         Definition
       </dd>
 
-      <dt id="dt-orchestration-algorithm">orchestration algorithm <code class="placeholder">{}</code></dt>
+      <dt id="orchestration-algorithm">orchestration algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-orchestration-algorithm">
         Definition
       </dd>
 
-      <dt id="dt-org-organization">org/organization <code class="placeholder">{}</code></dt>
+      <dt id="org-organization">org/organization <code class="placeholder">{}</code></dt>
       <dd id="dd-org-organization">
         Definition
       </dd>
 
-      <dt id="dt-org-admin">org admin <code class="placeholder">{}</code></dt>
+      <dt id="org-admin">org admin <code class="placeholder">{}</code></dt>
       <dd id="dd-org-admin">
         Definition
       </dd>
 
-      <dt id="dt-org-profile">org profile <code class="placeholder">{}</code></dt>
+      <dt id="org-profile">org profile <code class="placeholder">{}</code></dt>
       <dd id="dd-org-profile">
         Definition
       </dd>
 
-      <dt id="dt-parent-algorithm">parent algorithm <code class="placeholder">{}</code></dt>
+      <dt id="parent-algorithm">parent algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-parent-algorithm">
         Definition
       </dd>
 
-      <dt id="dt-password">password <code class="placeholder">{}</code></dt>
+      <dt id="password">password <code class="placeholder">{}</code></dt>
       <dd id="dd-password">
         Definition
       </dd>
 
-      <dt id="dt-platform-version">platform version <code class="placeholder">{}</code></dt>
+      <dt id="platform-version">platform version <code class="placeholder">{}</code></dt>
       <dd id="dd-platform-version">
         Definition
       </dd>
 
-      <dt id="dt-private-algorithm">private algorithm <code class="placeholder">{}</code></dt>
+      <dt id="private-algorithm">private algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-private-algorithm">
         Definition
       </dd>
 
-      <dt id="dt-public-algorithm">public algorithm <code class="placeholder">{}</code></dt>
+      <dt id="public-algorithm">public algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-public-algorithm">
         Definition
       </dd>
 
-      <dt id="dt-publisher">publisher <code class="placeholder">{}</code></dt>
+      <dt id="publisher">publisher <code class="placeholder">{}</code></dt>
       <dd id="dd-publisher">
         Definition
       </dd>
 
-      <dt id="dt-record">record <code class="placeholder">{}</code></dt>
+      <dt id="record">record <code class="placeholder">{}</code></dt>
       <dd id="dd-record">
         Definition
       </dd>
 
-      <dt id="dt-replica">replica <code class="placeholder">{}</code></dt>
+      <dt id="replica">replica <code class="placeholder">{}</code></dt>
       <dd id="dd-replica">
         Definition
       </dd>
 
-      <dt id="dt-reservation">reservation <code class="placeholder">{}</code></dt>
+      <dt id="reservation">reservation <code class="placeholder">{}</code></dt>
       <dd id="dd-reservation">
         Definition
       </dd>
 
-      <dt id="dt-resource">resource <code class="placeholder">{}</code></dt>
+      <dt id="resource">resource <code class="placeholder">{}</code></dt>
       <dd id="dd-resource">
         Definition
       </dd>
 
-      <dt id="dt-resource-request">resource request <code class="placeholder">{}</code></dt>
+      <dt id="resource-request">resource request <code class="placeholder">{}</code></dt>
       <dd id="dd-resource-request">
         Definition
       </dd>
 
-      <dt id="dt-resource-uri">resource URI <code class="placeholder">{}</code></dt>
+      <dt id="resource-uri">resource URI <code class="placeholder">{}</code></dt>
       <dd id="dd-resource-uri">
         Definition
       </dd>
 
-      <dt id="dt-satellite-cluster">satellite cluster <code class="placeholder">{}</code></dt>
+      <dt id="satellite-cluster">satellite cluster <code class="placeholder">{}</code></dt>
       <dd id="dd-satellite-cluster">
         Definition
       </dd>
 
-      <dt id="dt-satellite-launce-instance">satellite launce instance <code class="placeholder">{}</code></dt>
+      <dt id="satellite-launce-instance">satellite launce instance <code class="placeholder">{}</code></dt>
       <dd id="dd-satellite-launce-instance">
         Definition
       </dd>
 
-      <dt id="dt-satellite-version">satellite version <code class="placeholder">{}</code></dt>
+      <dt id="satellite-version">satellite version <code class="placeholder">{}</code></dt>
       <dd id="dd-satellite-version">
         Definition
       </dd>
 
-      <dt id="dt-secret">secret <code class="placeholder">{}</code></dt>
+      <dt id="secret">secret <code class="placeholder">{}</code></dt>
       <dd id="dd-secret">
         Definition
       </dd>
 
-      <dt id="dt-secret-store">Secret Store <code class="placeholder">{}</code></dt>
+      <dt id="secret-store">Secret Store <code class="placeholder">{}</code></dt>
       <dd id="dd-secret-store">
         Definition
       </dd>
 
-      <dt id="dt-serialized-model">serialized model <code class="placeholder">{MODEL_NAME}</code></dt>
+      <dt id="serialized-model">serialized model <code class="placeholder">{MODEL_NAME}</code></dt>
       <dd id="dd-serialized-model">
-        <a class="glossary-hoverable" href="#dt-machine-learning" title="" parentId="dd-machine-learning">ML</a> model
+        <a class="glossary-hoverable" href="#machine-learning" title="" parentId="dd-machine-learning">ML</a> model
         file that’s ready to be loaded into an algorithm and used for inference. Synonymous with <a
-          class="glossary-hoverable" href="#dt-model" title="" parentId="dd-model">model</a> and <a
-          class="glossary-hoverable" href="#dt-trained-model" title="" parentId="dd-trained-model">trained model</a>.
+          class="glossary-hoverable" href="#model" title="" parentId="dd-model">model</a> and <a
+          class="glossary-hoverable" href="#trained-model" title="" parentId="dd-trained-model">trained model</a>.
       </dd>
 
-      <dt id="dt-service-account">service account <code class="placeholder">{}</code></dt>
+      <dt id="service-account">service account <code class="placeholder">{}</code></dt>
       <dd id="dd-service-account">
         Definition
       </dd>
 
-      <dt id="dt-slot">slot <code class="placeholder">{}</code></dt>
+      <dt id="slot">slot <code class="placeholder">{}</code></dt>
       <dd id="dd-slot">
         Definition
       </dd>
 
-      <dt id="dt-scm-configuration">SCM configuration <code class="placeholder">{}</code></dt>
+      <dt id="scm-configuration">SCM configuration <code class="placeholder">{}</code></dt>
       <dd id="dd-scm-configuration">
         Definition
       </dd>
 
-      <dt id="dt-scm-connection">SCM connection <code class="placeholder">{}</code></dt>
+      <dt id="scm-connection">SCM connection <code class="placeholder">{}</code></dt>
       <dd id="dd-scm-connection">
         Definition
       </dd>
 
-      <dt id="dt-scm-provider">SCM provider <code class="placeholder">{}</code></dt>
+      <dt id="scm-provider">SCM provider <code class="placeholder">{}</code></dt>
       <dd id="dd-scm-provider">
         Definition
       </dd>
 
-      <dt id="dt-source-code-management">source code management (SCM) <code class="placeholder">{}</code></dt>
+      <dt id="source-code-management">source code management (SCM) <code class="placeholder">{}</code></dt>
       <dd id="dd-source-code-management">
         Definition
       </dd>
 
-      <dt id="dt-subscriber">subscriber <code class="placeholder">{}</code></dt>
+      <dt id="subscriber">subscriber <code class="placeholder">{}</code></dt>
       <dd id="dd-subscriber">
         Definition
       </dd>
 
-      <dt id="dt-test-console">test console <code class="placeholder">{}</code></dt>
+      <dt id="test-console">test console <code class="placeholder">{}</code></dt>
       <dd id="dd-test-console">
         Definition
       </dd>
 
-      <dt id="dt-top-level-algorithm">top-level algorithm <code class="placeholder">{}</code></dt>
+      <dt id="top-level-algorithm">top-level algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-top-level-algorithm">
         Definition
       </dd>
 
-      <dt id="dt-topic">topic <code class="placeholder">{}</code></dt>
+      <dt id="topic">topic <code class="placeholder">{}</code></dt>
       <dd id="dd-topic">
         Definition
       </dd>
 
-      <dt id="dt-trained-model">trained model <code class="placeholder">{MODEL_NAME}</code></dt>
+      <dt id="trained-model">trained model <code class="placeholder">{MODEL_NAME}</code></dt>
       <dd id="dd-trained-model">
-        <a class="glossary-hoverable" href="#dt-machine-learning" title="" parentId="dd-machine-learning">ML</a> model
+        <a class="glossary-hoverable" href="#machine-learning" title="" parentId="dd-machine-learning">ML</a> model
         file that’s ready to be loaded into an algorithm and used for inference. Synonymous with <a
-          class="glossary-hoverable" href="#dt-model" title="" parentId="dd-model">model</a> and <a
-          class="glossary-hoverable" href="#dt-serialized-model" title="" parentId="dd-serialized-model">serialized
+          class="glossary-hoverable" href="#model" title="" parentId="dd-model">model</a> and <a
+          class="glossary-hoverable" href="#serialized-model" title="" parentId="dd-serialized-model">serialized
           model</a>.
       </dd>
 
-      <dt id="dt-training-center">Training Center <code class="placeholder">{}</code></dt>
+      <dt id="training-center">Training Center <code class="placeholder">{}</code></dt>
       <dd id="dd-training-center">
         Definition
       </dd>
 
-      <dt id="dt-user">user <code class="placeholder">{}</code></dt>
+      <dt id="user">user <code class="placeholder">{}</code></dt>
       <dd id="dd-user">
         Definition
       </dd>
 
-      <dt id="dt-user-account">user account <code class="placeholder">{}</code></dt>
+      <dt id="user-account">user account <code class="placeholder">{}</code></dt>
       <dd id="dd-user-account">
         Definition
       </dd>
 
-      <dt id="dt-unilog">UNILOG <code class="placeholder">{}</code></dt>
+      <dt id="unilog">UNILOG <code class="placeholder">{}</code></dt>
       <dd id="dd-unilog">
         Definition
       </dd>
 
-      <dt id="dt-warm-algorithm">warm algorithm <code class="placeholder">{}</code></dt>
+      <dt id="warm-algorithm">warm algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-warm-algorithm">
         Definition
       </dd>
 
-      <dt id="dt-web-ide">Web IDE <code class="placeholder">{}</code></dt>
+      <dt id="web-ide">Web IDE <code class="placeholder">{}</code></dt>
       <dd id="dd-web-ide">
         Definition
       </dd>
 
-      <dt id="dt-worker-node">worker node <code class="placeholder">{}</code></dt>
+      <dt id="worker-node">worker node <code class="placeholder">{}</code></dt>
       <dd id="dd-worker-node">
         Definition
       </dd>
@@ -865,13 +865,13 @@
   </div>
 
   <script>
-    // assign id to parent element, prepending "dt-" to child element id
+    // assign id to parent element, prepending "" to child element id
     function assignParentId(parentNode) {
       childElem = parentNode.childElem
 
 
         .document.getElementById(childId).parentElement
-      parentElem.setAttribute("id", "dt-" + childId)
+      parentElem.setAttribute("id", "" + childId)
     }
 
     // assign ids to all parent elements

--- a/_pages/glossary.html
+++ b/_pages/glossary.html
@@ -1,19 +1,13 @@
-<html lang="en">
+<div>
 
-<head>
-  <title>Glossary</title>
-</head>
-
-<body>
   <style>
     dt {
       font-weight: bold;
       font-size: 20px;
-      margin-bottom: 3px
     }
 
     dd {
-      margin-bottom: 25px;
+      margin-bottom: 50px;
     }
 
     .placeholder {
@@ -49,9 +43,10 @@
         Some terms have associated <code class="placeholder">{PLACEHOLDER_STRING}</code> values. We use these
         uppercase strings in our UI, and in code samples across our documentation, to denote generic values that must be
         replaced with custom values in your code. Placeholders <code
-          class="placeholder">{/beginning/with-a-slash}</code> are <a class="glossary-hoverable" href="#api-endpoint"
-          title="" parentId="dd-api-endpoint">endpoints</a> from the <a class="glossary-hoverable" href="#base-url"
-          title="" parentId="dd-base-url">base URL</a>, i.e.,
+          class="placeholder">{/beginning/with-a-slash}</code>
+        are <a class="glossary-hoverable" href="#api-endpoint" title="" parentId="dd-api-endpoint">endpoints</a> from
+        the
+        <a class="glossary-hoverable" href="#base-url" title="" parentId="dd-base-url">base URL</a>, i.e.,
         <code>https://<a class="glossary-hoverable" href="#cluster-domain" title="" parentId="dd-cluster-domain">CLUSTER_DOMAIN</a></code>
         (or <code>https://algorithmia.com</code> for non-Enterprise clusters).
       </li>
@@ -91,32 +86,19 @@
   <hr />
 
   <style>
-    /* Create two equal columns that float next to each other */
-    .column {
-      float: left;
-      width: 50%;
-      padding: 10px;
-      column-gap: 0ch;
+    .glossary-index {
+      display: flex;
+      flex-wrap: wrap;
+      padding: 4px;
     }
 
-    /* Clear floats after the columns */
-    .row:after {
-      content: "";
-      display: table;
-      clear: both;
-    }
-
-    /* Responsive layout - when the screen is less than 1000px wide, make the
-     two columns stack on top of each other instead of next to each other */
-    @media screen and (max-width: 1000px) {
-      .column {
-        width: 100%;
-      }
+    .glossary-index>div {
+      flex: 50%;
     }
   </style>
 
-  <div id="glossary-index" class="row">
-    <div class="column left">
+  <div class="glossary-index">
+    <div>
       <ul>
         <li><a href="#account">account</a></li>
         <li><a href="#account-profile">account profile</a></li>
@@ -183,7 +165,7 @@
       </ul>
     </div>
 
-    <div class="column right">
+    <div>
       <ul>
         <li><a href="#hosted-data-collection">hosted data collection</a></li>
         <li><a href="#hot-algorithm">hot algorithm</a></li>
@@ -285,9 +267,10 @@
           admin account</a>. An admin API key can be used to make specific administrative <a class="glossary-hoverable"
           href="#authenticated-resource-request" title="" parentId="dd-authenticated-resource-request">authenticated
           resource requests</a> through the <a class="glossary-hoverable" href="#api" title=""
-          parentId="dd-api">API</a>. Examples of admin-only requests include creating and deleting <a
-          class="glossary-hoverable" href="#user-account" title="" parentId="dd-user-account">user accounts</a> and <a
-          class="glossary-hoverable" href="#org-organization" title="" parentId="dd-org-organization">organizations</a>.
+          parentId="dd-api">API</a>.
+        Examples of admin-only requests include creating and deleting <a class="glossary-hoverable" href="#user-account"
+          title="" parentId="dd-user-account">user accounts</a> and <a class="glossary-hoverable"
+          href="#org-organization" title="" parentId="dd-org-organization">organizations</a>.
       </dd>
 
       <dt id="admin-panel">admin panel <code class="placeholder">{/admin}</code></dt>
@@ -380,7 +363,8 @@
       </dd>
 
       <dt id="algorithm-instance">algorithm instance <code
-          class="placeholder">{CALLER_NAME/ALGO_NAME/ALGO_VERSION}</code></dt>
+          class="placeholder">{CALLER_NAME/ALGO_NAME/ALGO_VERSION}</code>
+      </dt>
       <dd id="dd-algorithm-instance">
         Individual <a class="glossary-hoverable" href="#replica" title="" parentId="dd-replica">replica</a> of an <a
           class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">algorithm</a> running on
@@ -410,8 +394,8 @@
       <dt id="algorithm-semantic-version">algorithm semantic version <code class="placeholder">{X.Y.Z}</code></dt>
       <dd id="dd-algorithm-semantic-version">
         Specific published version of an <a class="glossary-hoverable" href="#algorithm-build" title=""
-          parentId="dd-algorithm-build">algorithm build</a>, where X, Y, and Z represent major version, minor version,
-        and revision.
+          parentId="dd-algorithm-build">algorithm build</a>, where <code>X</code>, <code>Y</code>, and <code>Z</code>
+        represent major version, minor version, and revision, respectively.
       </dd>
 
       <dt id="algorithm-template">algorithm template</dt>
@@ -675,8 +659,9 @@
       <dd id="dd-control-plane-node">
         <a class="glossary-hoverable" href="#node" title="" parentId="dd-node">Node</a> in Algorithmia’s Kubernetes
         environment that manages <a class="glossary-hoverable" href="#cluster" title=""
-          parentId="dd-cluster">cluster</a> health and provisioning of <a class="glossary-hoverable"
-          href="#general-purpose-node" title="" parentId="dd-general-purpose-node">general purpose nodes</a> and
+          parentId="dd-cluster">cluster</a>
+        health and provisioning of <a class="glossary-hoverable" href="#general-purpose-node" title=""
+          parentId="dd-general-purpose-node">general purpose nodes</a> and
         <a class="glossary-hoverable" href="#worker-node" title="" parentId="dd-worker-node">worker nodes</a>. Put
         another way, this node runs Kubernetes—the orchestration of the containers. Note that this was previously named
         <a class="glossary-hoverable" href="#master-node" title="" parentId="dd-master-node">master node</a>.
@@ -787,7 +772,7 @@
       <dd id="dd-hosted-data-collection">
         Object storage hosted on the Algorithmia platform. Data collections are not “file storage” in that they can’t
         store
-        nested data or data with a “/” character in the path.
+        nested data or data with a “<code>/</code>” character in the path.
       </dd>
 
       <dt id="hot-algorithm">hot algorithm</dt>
@@ -1291,64 +1276,57 @@
           parentId="dd-algorithm-instance">algorithm instances</a> are run.
       </dd>
 
-    </dl>
-  </div>
-</body>
-<script>
-  // assign id to parent element, prepending "" to child element id
-  function assignParentId(parentNode) {
-    childElem = parentNode.childElem
+      <script>
+        // assign id to parent element, prepending "" to child element id
+        function assignParentId(parentNode) {
+          childElem = parentNode.childElem
 
 
-      .document.getElementById(childId).parentElement
-    parentElem.setAttribute("id", "" + childId)
-  }
+            .document.getElementById(childId).parentElement
+          parentElem.setAttribute("id", "" + childId)
+        }
 
-  // assign ids to all parent elements
-  function assignParentIds() {
-    terms = document.getElementsByTagName("dd")
-    for (let index = 0; index < terms.length; index++) {
-      assignParentId(terms[index]);
+        // assign ids to all parent elements
+        function assignParentIds() {
+          terms = document.getElementsByTagName("dd")
+          for (let index = 0; index < terms.length; index++) {
+            assignParentId(terms[index]);
+          }
+        }
 
-    }
-  }
+        function assignTitle(parentId) {
+          elem = document.getElementById(parentId)
+          if (elem) {
+            return elem.innerText;
+          }
+          console.log("missing parentId: " + parentId)
+          return ""
+        }
 
+        var glossTerms = document.getElementsByClassName("glossary-hoverable");
+        for (i = 0; i < glossTerms.length; i++) {
+          currentElem = glossTerms.item(i);
+          parentId = currentElem.attributes.getNamedItem("parentId").nodeValue;
+          glossTerms.item(i).title = assignTitle(parentId);
+        }
 
-  function assignTitle(parentId) {
-    elem = document.getElementById(parentId)
-    if (elem) {
-      return elem.innerText;
-    }
-    console.log("missing parentId: " + parentId)
-    return ""
-  }
+        function countIndexTerms() {
+          // pass
+        }
 
-  var glossTerms = document.getElementsByClassName("glossary-hoverable");
-  for (i = 0; i < glossTerms.length; i++) {
-    currentElem = glossTerms.item(i);
-    parentId = currentElem.attributes.getNamedItem("parentId").nodeValue;
-    glossTerms.item(i).title = assignTitle(parentId);
-  }
+        function countDefinitionTerms() {
+          // pass
+        }
 
-  function countIndexTerms() {
-    // pass
-  }
-
-  function countDefinitionTerms() {
-    // pass
-  }
-
-  // make sure that count of index items match count of glossary terms
-  function verifyTermCounts() {
-    // pass
-    indexCount = countIndexItems()
-    termCount = countTermItems()
-    if (indexCount !== termCount) {
-      console.log("Missing Index or Definition")
-      console.log("Index count: " + indexCount)
-      console.log("Term count: " + termCount)
-    }
-  }
-</script>
-
-</html>
+        // make sure that count of index items match count of glossary terms
+        function verifyTermCounts() {
+          // pass
+          indexCount = countIndexItems()
+          termCount = countTermItems()
+          if (indexCount !== termCount) {
+            console.log("Missing Index or Definition")
+            console.log("Index count: " + indexCount)
+            console.log("Term count: " + termCount)
+          }
+        }
+      </script>

--- a/_pages/glossary.html
+++ b/_pages/glossary.html
@@ -8,6 +8,7 @@
   <style>
     dt {
       font-weight: bold;
+      font-size: 20px;
       margin-bottom: 3px
     }
 
@@ -27,26 +28,47 @@
     }
   </style>
   <div id="glossary-usage">
-    <p>This glossary provides definitions for terms used across the Algorithmia platform.</p>
-    <p>Note that some terms have <code class="placeholder">PLACEHOLDER_STRING</code> values. These placeholders are used
-      in our UI and in code samples across our documentation. The values are denoted in uppercase to indicate that you
-      must replace them with your own values in your code. Note that linked glossary terms are hoverable and clickable;
-      on hover, they'll display the linked definition for convenience.
-    </p>
-    <p>
+    <p>This page provides brief definitions for many of the terms used across Algorithmia's platform and documentation.
+      We also provide definitions for some terms commonly used in the practice of MLOps. Things to note when using this
+      glossary:</p>
     <ul>
+      <li>
+        Some terms have associated <code class="placeholder">{PLACEHOLDER_STRING}</code> values. We use these
+        uppercase strings in our UI, and in code samples across our documentation, to denote generic values that must be
+        replaced with custom values in your code. Placeholders <code
+          class="placeholder">{/beginning/with-a-slash}</code> are endpoints from the
+        <code>https://algorithmia.com</code> <a class="glossary-hoverable" href="#base-url" title=""
+          parentId="dd-base-url">base URL</a> (or from <code>https://<a class="glossary-hoverable" href="#cluster-domain" title=""
+          parentId="dd-cluster-domain">CLUSTER_DOMAIN</a></code> for enterprise clusters; see below).
+      </li>
       <dl>
-        <dt id="example-glossary-term">Example Glossary Term <code class="placeholder">{PLACEHOLDER_STRING}</code>
-        <dd id="dd-example-glossary-term">
-          Definition with a hoverable link to <a class="glossary-hoverable" href="#another-glossary-term" title=""
-            parentId="another-glossary-term">another glossary term</a>.
-        </dd>
-        </dt>
-        <dt id="another-glossary-term">Another Glossary Term
-        <dd id="dd-another-glossary-term">
-          This text is displayed when hovered above.
-        </dd>
-        </dt>
+        <ul>
+          <dt id="example-term-with-placeholder">example term with placeholder <code
+              class="placeholder">{PLACEHOLDER_STRING}</code>
+          </dt>
+          <dd id="dd-example-term-with-placeholder">
+            Definition of first term.
+          </dd>
+          <dt id="example-term-with-endpoint">example term with endpoint placeholder <code
+              class="placeholder">{/endpoint}</code>
+          </dt>
+          <dd id="dd-example-term-with-endpoint">
+            Definition of second term.
+          </dd>
+        </ul>
+      </dl>
+      <li>
+        Some definitions reference other glossary terms. Links are hoverable and clickable; on hover, they'll display
+        the linked definition for quick reference, e.g.:
+      </li>
+      <dl>
+        <ul>
+          <dt id="example-term-with-link">example term with link</dt>
+          <dd id="dd-example-term-with-link">
+            This term has a hoverable link to the <a class="glossary-hoverable" href="#example-term-with-placeholder"
+              title="" parentId="dd-example-term-with-placeholder">example term</a> from above.
+          </dd>
+        </ul>
       </dl>
     </ul>
   </div>
@@ -70,17 +92,17 @@
       clear: both;
     }
 
-    /* Responsive layout - when the screen is less than 600px wide, make the
+    /* Responsive layout - when the screen is less than 950px wide, make the
      two columns stack on top of each other instead of next to each other */
-    /* @media screen and (max-width: 600px) {
+    @media screen and (max-width: 1000px) {
       .column {
         width: 100%;
       }
-    } */
+    }
   </style>
 
   <div id="glossary-index" class="row">
-    <div class="column left" style="background-color: pink;">
+    <div class="column left">
       <ul>
         <li><a href="#account">account</a></li>
         <li><a href="#account-profile">account profile</a></li>
@@ -147,7 +169,7 @@
       </ul>
     </div>
 
-    <div class="column right" style="background-color: yellow;">
+    <div class="column right">
       <ul>
         <li><a href="#grafana">Grafana</a></li>
         <li><a href="#hosted-data-collection">hosted data collection</a></li>
@@ -556,7 +578,7 @@
       <dd id="dd-hot-algorithm">
         Definition
       </dd>
-      `
+
       <dt id="json-web-token">JSON Web Token (JWT) <code class="placeholder">{}</code></dt>
       <dd id="dd-json-web-token">
         Definition
@@ -604,8 +626,7 @@
         <a class="glossary-hoverable" href="#machine-learning" title="" parentId="dd-machine-learning">ML</a> model
         file that’s ready to be loaded into an algorithm and used for inference. Synonymous with <a
           class="glossary-hoverable" href="#serialized-model" title="" parentId="dd-serialized-model">serialized
-          model</a> and <a class="glossary-hoverable" href="#trained-model" title=""
-          parentId="dd-trained-model">trained
+          model</a> and <a class="glossary-hoverable" href="#trained-model" title="" parentId="dd-trained-model">trained
           model</a>.
       </dd>
 

--- a/_pages/glossary.html
+++ b/_pages/glossary.html
@@ -1141,7 +1141,7 @@
 
       <dt id="slot">slot</dt>
       <dd id="dd-slot">
-        Deprecated. See <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">replica</a>.
+        Deprecated. See <a class="glossary-hoverable" href="#replica" title="" parentId="dd-replica">replica</a>.
       </dd>
 
       <dt id="scm-configuration">SCM configuration <code class="placeholder">{SCM_CONFIG_ID}</code></dt>

--- a/_pages/glossary.html
+++ b/_pages/glossary.html
@@ -1,0 +1,925 @@
+<html lang="en">
+
+<head>
+  <title>Glossary</title>
+</head>
+
+<body>
+  <style>
+    dt {
+      font-weight: bold;
+      margin-bottom: 3px
+    }
+
+    dd {
+      margin-bottom: 15px;
+    }
+
+    .placeholder {
+      font-family: "Courier New", Courier, monospace;
+      font-weight: 300;
+    }
+
+    .glossary-hoverable {
+      text-decoration: none;
+      color: inherit;
+      border-bottom: 1px dotted;
+    }
+  </style>
+  <div id="glossary-usage">
+    <p>This glossary provides definitions for terms used across the Algorithmia platform.</p>
+    <p>Note that some terms have <code class="placeholder">PLACEHOLDER_STRING</code> values. These placeholders are used
+      in our UI and in code samples across our documentation. The values are denoted in uppercase to indicate that you
+      must replace them with your own values in your code. Note that linked glossary terms are hoverable and clickable;
+      on hover, they'll display the linked definition for convenience.
+    </p>
+    <p>
+    <ul>
+      <dl>
+        <dt id="dt-">Example Glossary Term <code class="placeholder">{PLACEHOLDER_STRING}</code>
+        <dd id="glossary-term">
+          Definition with a hoverable link to <a class="glossary-hoverable" href="#another-glossary-term" title=""
+            parentId="another-glossary-term">another glossary term</a>.
+        </dd>
+        </dt>
+        <dt id="dt-">Another Glossary Term
+        <dd id="another-glossary-term">
+          This text is displayed when hovered above.
+        </dd>
+        </dt>
+      </dl>
+    </ul>
+  </div>
+
+  <hr />
+
+  <style>
+    /* Create two equal columns that floats next to each other */
+    .column {
+      float: left;
+      width: 50%;
+      padding: 10px;
+      /* height: 1200px; */
+      /* Should be removed. Only for demonstration */
+    }
+
+    /* Clear floats after the columns */
+    .row:after {
+      content: "";
+      display: table;
+      clear: both;
+    }
+
+    /* Responsive layout - when the screen is less than 600px wide, make the
+     two columns stack on top of each other instead of next to each other */
+    /* @media screen and (max-width: 600px) {
+      .column {
+        width: 100%;
+      }
+    } */
+  </style>
+
+  <div id="glossary-index" class="row">
+    <div class="column left" style="background-color: pink;">
+      <ul>
+        <li><a href="#dt-account">account</a></li>
+        <li><a href="#dt-account-profile">account profile</a></li>
+        <li><a href="#dt-admin-account">admin account</a></li>
+        <li><a href="#dt-admin-api-key">admin API key</a></li>
+        <li><a href="#dt-admin-panel">admin panel</a></li>
+        <li><a href="#dt-algo-cli">algo CLI</a></li>
+        <li><a href="#dt-algorithm">algorithm</a></li>
+        <li><a href="#dt-algorithm-build">algorithm build</a></li>
+        <li><a href="#dt-algorithm-build-hash">algorithm build hash</a></li>
+        <li><a href="#dt-algorithm-build-uuid">algorithm build UUID</a></li>
+        <li><a href="#dt-algorithm-environment">algorithm environment</a></li>
+        <li><a href="#dt-algorithm-environment-uuid">algorithm environment UUID</a></li>
+        <li><a href="#dt-algorithm-endpoint">algorithm endpoint</a></li>
+        <li><a href="#dt-algorithm-execution-request">algorithm execution request</a></li>
+        <li><a href="#dt-algorithm-profile">algorithm profile</a></li>
+        <li><a href="#dt-algorithm-instance">algorithm instance</a></li>
+        <li><a href="#dt-algorithm-language">algorithm language</a></li>
+        <li><a href="#dt-algorithm-owner">algorithm owner</a></li>
+        <li><a href="#dt-algorithm-pipelining">algorithm pipelining</a></li>
+        <li><a href="#dt-algorithm-semantic-version">algorithm semantic version</a></li>
+        <li><a href="#dt-algorithm-template">algorithm template</a></li>
+        <li><a href="#dt-algorithm-uuid">algorithm UUID</a></li>
+        <li><a href="#dt-algorithm-vanity-url">algorithm vanity URL</a></li>
+        <li><a href="#dt-algorithm-version">algorithm version</a></li>
+        <li><a href="#dt-algorithm-version-hash">algorithm version hash</a></li>
+        <li><a href="#dt-api">API</a></li>
+        <li><a href="#dt-api-docs">API docs</a></li>
+        <li><a href="#dt-api-endpoint">API endpoint</a></li>
+        <li><a href="#dt-api-key">API key</a></li>
+        <li><a href="#dt-api-method">API method</a></li>
+        <li><a href="#dt-authenticated-resource-request">authenticated resource request</a></li>
+        <li><a href="#dt-authentication">authentication</a></li>
+        <li><a href="#dt-authentication-factor">authentication factor</a></li>
+        <li><a href="#dt-authentication-token">authentication token</a></li>
+        <li><a href="#dt-authorization">authorization</a></li>
+        <li><a href="#dt-base-api-url">base API URL</a></li>
+        <li><a href="#dt-base-url">base URL</a></li>
+        <li><a href="#dt-blog">blog</a></li>
+        <li><a href="#dt-browser-ui">browser UI</a></li>
+        <li><a href="#dt-caller">caller</a></li>
+        <li><a href="#dt-collection-owner">collection owner</a></li>
+        <li><a href="#dt-closed-source-algorithm">closed source algorithm</a></li>
+        <li><a href="#dt-cluster">cluster</a></li>
+        <li><a href="#dt-cluster-admin-account">cluster admin account</a></li>
+        <li><a href="#dt-cluster-domain">cluster domain</a></li>
+        <li><a href="#dt-cluster-operator">cluster operator</a></li>
+        <li><a href="#dt-cold-algorithm">cold algorithm</a></li>
+        <li><a href="#dt-constellation-distributed-serving">Constellation Distributed Serving</a></li>
+        <li><a href="#dt-consumer">consumer</a></li>
+        <li><a href="#dt-control-plane-node">control plane node</a></li>
+        <li><a href="#dt-data-connector">data connector</a></li>
+        <li><a href="#dt-data-source">data source</a></li>
+        <li><a href="#dt-data-uri">data URI</a></li>
+        <li><a href="#dt-developer-center">Developer Center</a></li>
+        <li><a href="#dt-directory">directory</a></li>
+        <li><a href="#dt-event-flow">Event Flow</a></li>
+        <li><a href="#dt-event-listener">event listener</a></li>
+        <li><a href="#dt-event-manager">event manager</a></li>
+        <li><a href="#dt-external-data-source">external data source</a></li>
+        <li><a href="#dt-file">file</a></li>
+        <li><a href="#dt-folder">folder</a></li>
+        <li><a href="#dt-general-purpose-node">general purpose node</a></li>
+      </ul>
+    </div>
+
+    <div class="column right" style="background-color: yellow;">
+      <ul>
+        <li><a href="#dt-grafana">Grafana</a></li>
+        <li><a href="#dt-hosted-data-collection">hosted data collection</a></li>
+        <li><a href="#dt-hot-algorithm">hot algorithm</a></li>
+        <li><a href="#dt-json-web-token">JSON Web Token (JWT)</a></li>
+        <li><a href="#dt-identity">identity</a></li>
+        <li><a href="#dt-kibana">Kibana</a></li>
+        <li><a href="#dt-machine-learning">machine learning (ML)</a></li>
+        <li><a href="#dt-master-node">master node</a></li>
+        <li><a href="#dt-message-broker">message broker</a></li>
+        <li><a href="#dt-message-broker-connection">message broker connection</a></li>
+        <li><a href="#dt-ml-service-catalog">ML service catalog</a></li>
+        <li><a href="#dt-model">model</a></li>
+        <li><a href="#dt-model-explainability">model explainability</a></li>
+        <li><a href="#dt-model-governance">model governance</a></li>
+        <li><a href="#dt-model-interpretability">model interpretability</a></li>
+        <li><a href="#dt-model-monitoring">model monitoring</a></li>
+        <li><a href="#dt-model-observability">model observability</a></li>
+        <li><a href="#dt-model-validation">model validation</a></li>
+        <li><a href="#dt-mothership-cluster">mothership cluster</a></li>
+        <li><a href="#dt-node">node</a></li>
+        <li><a href="#dt-open-source-algorithm">open-source algorithm</a></li>
+        <li><a href="#dt-orchestration-algorithm">orchestration algorithm</a></li>
+        <li><a href="#dt-org-organization">org/organization</a></li>
+        <li><a href="#dt-org-admin">org admin</a></li>
+        <li><a href="#dt-org-profile">org profile</a></li>
+        <li><a href="#dt-parent-algorithm">parent algorithm</a></li>
+        <li><a href="#dt-password">password</a></li>
+        <li><a href="#dt-platform-version">platform version</a></li>
+        <li><a href="#dt-private-algorithm">private algorithm</a></li>
+        <li><a href="#dt-producer">producer</a></li>
+        <li><a href="#dt-public-algorithm">public algorithm</a></li>
+        <li><a href="#dt-publisher">publisher</a></li>
+        <li><a href="#dt-record">record</a></li>
+        <li><a href="#dt-replica">replica</a></li>
+        <li><a href="#dt-reservation">reservation</a></li>
+        <li><a href="#dt-resource">resource</a></li>
+        <li><a href="#dt-resource-request">resource request</a></li>
+        <li><a href="#dt-resource-uri">resource URI</a></li>
+        <li><a href="#dt-satellite-cluster">satellite cluster</a></li>
+        <li><a href="#dt-satellite-launch-instance">satellite launch instance</a></li>
+        <li><a href="#dt-satellite-version">satellite version</a></li>
+        <li><a href="#dt-secret">secret</a></li>
+        <li><a href="#dt-secret-store">Secret Store</a></li>
+        <li><a href="#dt-serialized-model">serialized model</a></li>
+        <li><a href="#dt-service-account">service account</a></li>
+        <li><a href="#dt-slot">slot</a></li>
+        <li><a href="#dt-scm-configuration">SCM configuration</a></li>
+        <li><a href="#dt-scm-connection">SCM connection</a></li>
+        <li><a href="#dt-scm-provider">SCM provider</a></li>
+        <li><a href="#dt-source-code-management">source code management (SCM)</a></li>
+        <li><a href="#dt-subscriber">subscriber</a></li>
+        <li><a href="#dt-test-console">test console</a></li>
+        <li><a href="#dt-top-level-algorithm">top level algorithm</a></li>
+        <li><a href="#dt-topic">topic</a></li>
+        <li><a href="#dt-trained-model">trained model</a></li>
+        <li><a href="#dt-training-center">Training Center</a></li>
+        <li><a href="#dt-user">user</a></li>
+        <li><a href="#dt-user-account">user account</a></li>
+        <li><a href="#dt-unilog">UNILOG</a></li>
+        <li><a href="#dt-warm-algorithm">warm algorithm</a></li>
+        <li><a href="#dt-web-ide">Web IDE</a></li>
+        <li><a href="#dt-worker-node">worker node</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <hr />
+
+  <div id="glossary-definitions">
+    <dl>
+
+      <dt id="dt-uniqueId">item name <code class="placeholder">{PLACEHOLDER}</code></dt>
+      <dd id="dd-uniqueId">
+        Definition
+      </dd>
+
+      <dt id="dt-account">account <code class="placeholder">{ACCOUNT_NAME}</code></dt>
+      <dd id="dd-account">
+        <a class="glossary-hoverable" href="#dt-identity" title="" parentId="dd-identity">Identity</a> on the
+        Algorithmia
+        platform that may own and/or be used to access a resource (e.g., an <a class="glossary-hoverable"
+          href="#dt-algorithm" title="" parentId="dd-algorithm">algorithm</a>).
+      </dd>
+
+      <dt id="dt-account-profile">account profile <code class="placeholder">{/users/ACCOUNT_NAME}</code></dt>
+      <dd id="dd-account-profile">
+        Profile page for an <a class="glossary-hoverable" href="#dt-account" title="" parentId="dd-account">account</a>.
+      </dd>
+
+      <dt id="dt-admin-account">admin account</dt>
+      <dd id="dd-admin-account">
+        See <a class="glossary-hoverable" href="#dt-cluster-admin-account" title=""
+          parentId="dd-cluster-admin-account">cluster admin account</a> or <a class="glossary-hoverable"
+          href="#dt-org-admin-account" title="" parentId="dd-org-admin-account">org admin account</a>.
+      </dd>
+
+      <dt id="dt-admin-api-key">admin API key <code class="placeholder">{ADMIN_API_KEY}</code></dt>
+      <dd id="dd-admin-api-key">
+        Secret authentication token associated with a specific cluster admin account. An admin API key can be used to
+        make specific administrative authenticated resource requests through the API. Examples of admin-only requests
+        include creating and deleting user accounts and organizations.
+      </dd>
+
+      <dt id="dt-admin-panel">admin panel <code class="placeholder">{/admin/&lt;page name&gt;}</code></dt>
+      <dd id="dd-admin-panel">
+        Navigation bar displaying administrative functionality available to a cluster admin.
+      </dd>
+
+      <dt id="dt-algo-cli">algo CLI</dt>
+      <dd id="dd-algo-cli">
+        Algorithmia’s command-line interface tool, called with algo [COMMAND [OPTIONS]].
+      </dd>
+
+      <dt id="dt-algorithm">algorithm <code class="placeholder">{}</code></dt>
+      <dd id="dd-algorithm">
+        Definition
+      </dd>
+
+      <dt id="dt-algorithm-build">algorithm build <code class="placeholder">{}</code></dt>
+      <dd id="dd-algorithm-build">
+        Definition
+      </dd>
+
+      <dt id="dt-algorithm-build-hash">algorithm build hash <code class="placeholder">{}</code></dt>
+      <dd id="dd-algorithm-build-hash">
+        Definition
+      </dd>
+
+      <dt id="dt-algorithm-build-uuid">algorithm build UUID <code class="placeholder">{}</code></dt>
+      <dd id="dd-algorithm-build-uuid">
+        Definition
+      </dd>
+
+      <dt id="dt-algorithm-environment">algorithm environment <code class="placeholder">{}</code></dt>
+      <dd id="dd-algorithm-environment">
+        Definition
+      </dd>
+
+      <dt id="dt-algorithm-environment-uuid">algorithm environment UUID <code class="placeholder">{}</code></dt>
+      <dd id="dd-algorithm-environment-uuid">
+        Definition
+      </dd>
+
+      <dt id="dt-algorithm-endpoint">algorithm endpoint <code class="placeholder">{}</code></dt>
+      <dd id="dd-algorithm-endpoint">
+        Definition
+      </dd>
+
+      <dt id="dt-algorithm-execution-request">algorithm execution request <code class="placeholder">{}</code></dt>
+      <dd id="dd-algorithm-execution-request">
+        Definition
+      </dd>
+
+      <dt id="dt-algorithm-profile">algorithm profile <code class="placeholder">{}</code></dt>
+      <dd id="dd-algorithm-profile">
+        Definition
+      </dd>
+
+      <dt id="dt-algorithm-instance">algorithm instance <code class="placeholder">{}</code></dt>
+      <dd id="dd-algorithm-instance">
+        Definition
+      </dd>
+
+      <dt id="dt-algorithm-language">algorithm language <code class="placeholder">{}</code></dt>
+      <dd id="dd-algorithm-language">
+        Definition
+      </dd>
+
+      <dt id="dt-algorithm-owner">algorithm owner <code class="placeholder">{}</code></dt>
+      <dd id="dd-algorithm-owner">
+        Definition
+      </dd>
+
+      <dt id="dt-algorithm-pipelining">algorithm pipelining <code class="placeholder">{}</code></dt>
+      <dd id="dd-algorithm-pipelining">
+        Definition
+      </dd>
+
+      <dt id="dt-algorithm-semantic-version">algorithm semantic version <code class="placeholder">{}</code></dt>
+      <dd id="dd-algorithm-semantic-version">
+        Definition
+      </dd>
+
+      <dt id="dt-algorithm-template">algorithm template <code class="placeholder">{}</code></dt>
+      <dd id="dd-algorithm-template">
+        Definition
+      </dd>
+
+      <dt id="dt-algorithm-uuid">algorithm UUID <code class="placeholder">{}</code></dt>
+      <dd id="dd-algorithm-uuid">
+        Definition
+      </dd>
+
+      <dt id="dt-algorithm-vanity-url">algorithm vanity URL <code class="placeholder">{}</code></dt>
+      <dd id="dd-algorithm-vanity-url">
+        Definition
+      </dd>
+
+      <dt id="dt-algorithm-version">algorithm version <code class="placeholder">{}</code></dt>
+      <dd id="dd-algorithm-version">
+        Definition
+      </dd>
+
+      <dt id="dt-algorithm-version-hash">algorithm version hash <code class="placeholder">{}</code></dt>
+      <dd id="dd-algorithm-version-hash">
+        Definition
+      </dd>
+
+      <dt id="dt-api">API <code class="placeholder">{}</code></dt>
+      <dd id="dd-api">
+        Definition
+      </dd>
+
+      <dt id="dt-api-docs">API Docs <code class="placeholder">{}</code></dt>
+      <dd id="dd-api-docs">
+        Definition
+      </dd>
+
+      <dt id="dt-api-endpoint">API endpoint <code class="placeholder">{}</code></dt>
+      <dd id="dd-api-endpoint">
+        Definition
+      </dd>
+
+      <dt id="dt-api-key">API key <code class="placeholder">{}</code></dt>
+      <dd id="dd-api-key">
+        Definition
+      </dd>
+
+      <dt id="dt-api-method">API method <code class="placeholder">{}</code></dt>
+      <dd id="dd-api-method">
+        Definition
+      </dd>
+
+      <dt id="dt-authenticated-resource-request">authenticated resource request</dt>
+      <dd id="dd-authenticated-resource-request">
+        Definition
+      </dd>
+
+      <dt id="dt-authentication">authentication <code class="placeholder">{}</code></dt>
+      <dd id="dd-authentication">
+        Definition
+      </dd>
+
+      <dt id="dt-authentication-factor">authentication factor <code class="placeholder">{}</code></dt>
+      <dd id="dd-authentication-factor">
+        Definition
+      </dd>
+
+      <dt id="dt-authentication-token">authentication token <code class="placeholder">{}</code></dt>
+      <dd id="dd-authentication-token">
+        Definition
+      </dd>
+
+      <dt id="dt-authorization">authorization <code class="placeholder">{}</code></dt>
+      <dd id="dd-authorization">
+        Definition
+      </dd>
+
+      <dt id="dt-base-api-url">base API URL <code class="placeholder">{}</code></dt>
+      <dd id="dd-base-api-url">
+        Definition
+      </dd>
+
+      <dt id="dt-base-url">base URL <code class="placeholder">{}</code></dt>
+      <dd id="dd-base-url">
+        Definition
+      </dd>
+
+      <dt id="dt-blog">blog <code class="placeholder">{}</code></dt>
+      <dd id="dd-blog">
+        Definition
+      </dd>
+
+      <dt id="dt-browser-ui">browser UI <code class="placeholder">{}</code></dt>
+      <dd id="dd-browser-ui">
+        Definition
+      </dd>
+
+      <dt id="dt-caller">caller <code class="placeholder">{CALLER_NAME}</code></dt>
+      <dd id="dd-caller">
+        Definition
+      </dd>
+
+      <dt id="dt-collection-owner">collection owner <code class="placeholder">{}</code></dt>
+      <dd id="dd-collection-owner">
+        Definition
+      </dd>
+
+      <dt id="dt-closed-source-algorithm">closed-source algorithm <code class="placeholder">{}</code></dt>
+      <dd id="dd-closed-source-algorithm">
+        Definition
+      </dd>
+
+      <dt id="dt-cluster">cluster <code class="placeholder">{}</code></dt>
+      <dd id="dd-cluster">
+        Definition
+      </dd>
+
+      <dt id="dt-cluster-admin-account">cluster admin account <code class="placeholder">{}</code></dt>
+      <dd id="dd-cluster-admin-account">
+        Definition
+      </dd>
+
+      <dt id="dt-cluster-domain">cluster domain <code class="placeholder">{}</code></dt>
+      <dd id="dd-cluster-domain">
+        Definition
+      </dd>
+
+      <dt id="dt-cluster-operator">cluster operator <code class="placeholder">{}</code></dt>
+      <dd id="dd-cluster-operator">
+        Definition
+      </dd>
+
+      <dt id="dt-cold-algorithm">cold algorithm <code class="placeholder">{}</code></dt>
+      <dd id="dd-cold-algorithm">
+        Definition
+      </dd>
+
+      <dt id="dt-constellation-distributed-serving">Constellation Distributed Serving</dt>
+      <dd id="dd-constellation-distributed-serving">
+        Definition
+      </dd>
+
+      <dt id="dt-consumer">consumer <code class="placeholder">{}</code></dt>
+      <dd id="dd-consumer">
+        Definition
+      </dd>
+
+      <dt id="dt-contorl-plane-node">control plane node <code class="placeholder">{}</code></dt>
+      <dd id="dd-contorl-plane-node">
+        Definition
+      </dd>
+
+      <dt id="dt-data-connector">data connector <code class="placeholder">{}</code></dt>
+      <dd id="dd-data-connector">
+        Definition
+      </dd>
+
+      <dt id="dt-data-source">data source <code class="placeholder">{}</code></dt>
+      <dd id="dd-data-source">
+        Definition
+      </dd>
+
+      <dt id="dt-data-uri">data URI <code class="placeholder">{}</code></dt>
+      <dd id="dd-data-uri">
+        Definition
+      </dd>
+
+      <dt id="dt-developer-center">Developer Center <code class="placeholder">{}</code></dt>
+      <dd id="dd-developer-center">
+        Definition
+      </dd>
+
+      <dt id="dt-directory">directory <code class="placeholder">{}</code></dt>
+      <dd id="dd-directory">
+        Definition
+      </dd>
+
+      <dt id="dt-event-flow">Event Flow <code class="placeholder">{}</code></dt>
+      <dd id="dd-event-flow">
+        Definition
+      </dd>
+
+      <dt id="dt-event-listener">event listener <code class="placeholder">{}</code></dt>
+      <dd id="dd-event-listener">
+        Definition
+      </dd>
+
+      <dt id="dt-event-manager">event manager <code class="placeholder">{}</code></dt>
+      <dd id="dd-event-manager">
+        Definition
+      </dd>
+
+      <dt id="dt-external-data-source">external data source <code class="placeholder">{}</code></dt>
+      <dd id="dd-external-data-source">
+        Definition
+      </dd>
+
+      <dt id="dt-file">file <code class="placeholder">{}</code></dt>
+      <dd id="dd-file">
+        Definition
+      </dd>
+
+      <dt id="dt-folder">folder <code class="placeholder">{}</code></dt>
+      <dd id="dd-folder">
+        Definition
+      </dd>
+
+      <dt id="dt-general-purpose-node">general purpose node <code class="placeholder">{}</code></dt>
+      <dd id="dd-general-purpose-node">
+        Definition
+      </dd>
+
+      <dt id="dt-grafana">Grafana <code class="placeholder">{}</code></dt>
+      <dd id="dd-grafana">
+        Definition
+      </dd>
+
+      <dt id="dt-hosted-data-collection">hosted data collection <code class="placeholder">{}</code></dt>
+      <dd id="dd-hosted-data-collection">
+        Definition
+      </dd>
+
+      <dt id="dt-hot-algorithm">hot algorithm <code class="placeholder">{}</code></dt>
+      <dd id="dd-hot-algorithm">
+        Definition
+      </dd>
+      `
+      <dt id="dt-json-web-token">JSON Web Token (JWT) <code class="placeholder">{}</code></dt>
+      <dd id="dd-json-web-token">
+        Definition
+      </dd>
+
+      <dt id="dt-identity">identity <code class="placeholder">{}</code></dt>
+      <dd id="dd-identity">
+        Definition
+      </dd>
+
+      <dt id="dt-kibana">Kibana <code class="placeholder">{}</code></dt>
+      <dd id="dd-kibana">
+        Definition
+      </dd>
+
+      <dt id="dt-machine-learning">machine learning (ML) <code class="placeholder">{}</code></dt>
+      <dd id="dd-machine-learning">
+        Application of artificial intelligence in which a computer system uses algorithms and statistical models to
+        analyze and draw inferences from patterns in data, learning and adapting in order to make decisions without
+        following explicit instructions from humans.
+      </dd>
+
+      <dt id="dt-master-node">master node <code class="placeholder">{}</code></dt>
+      <dd id="dd-master-node">
+        Definition
+      </dd>
+
+      <dt id="dt-message-broker">message broker <code class="placeholder">{}</code></dt>
+      <dd id="dd-message-broker">
+        Definition
+      </dd>
+
+      <dt id="dt-message-broker-connection">message broker connection <code class="placeholder">{}</code></dt>
+      <dd id="dd-message-broker-connection">
+        Definition
+      </dd>
+
+      <dt id="dt-ml-service-catalog">ML service catalog <code class="placeholder">{}</code></dt>
+      <dd id="dd-ml-service-catalog">
+        Definition
+      </dd>
+
+      <dt id="dt-model">model <code class="placeholder">{MODEL_NAME}</code></dt>
+      <dd id="dd-model">
+        <a class="glossary-hoverable" href="#dt-machine-learning" title="" parentId="dd-machine-learning">ML</a> model
+        file that’s ready to be loaded into an algorithm and used for inference. Synonymous with <a
+          class="glossary-hoverable" href="#dt-serialized-model" title="" parentId="dd-serialized-model">serialized
+          model</a> and <a class="glossary-hoverable" href="#dt-trained-model" title=""
+          parentId="dd-trained-model">trained
+          model</a>.
+      </dd>
+
+      <dt id="dt-model-explainability">model explainability <code class="placeholder">{}</code></dt>
+      <dd id="dd-model-explainability">
+        Definition
+      </dd>
+
+      <dt id="dt-model-governance">model governance <code class="placeholder">{}</code></dt>
+      <dd id="dd-model-governance">
+        Definition
+      </dd>
+
+      <dt id="dt-model-interpretability">model interpretability <code class="placeholder">{}</code></dt>
+      <dd id="dd-model-interpretability">
+        Definition
+      </dd>
+
+      <dt id="dt-model-monitoring">model monitoring <code class="placeholder">{}</code></dt>
+      <dd id="dd-model-monitoring">
+        Definition
+      </dd>
+
+      <dt id="dt-model-observability">model observability <code class="placeholder">{}</code></dt>
+      <dd id="dd-model-observability">
+        Definition
+      </dd>
+
+      <dt id="dt-model-validation">model validation <code class="placeholder">{}</code></dt>
+      <dd id="dd-model-validation">
+        Definition
+      </dd>
+
+      <dt id="dt-mothership-cluster">mothership cluster <code class="placeholder">{}</code></dt>
+      <dd id="dd-mothership-cluster">
+        Definition
+      </dd>
+
+      <dt id="dt-node">node <code class="placeholder">{}</code></dt>
+      <dd id="dd-node">
+        Definition
+      </dd>
+
+      <dt id="dt-open-source-algorithm">open-source algorithm <code class="placeholder">{}</code></dt>
+      <dd id="dd-open-source-algorithm">
+        Definition
+      </dd>
+
+      <dt id="dt-orchestration-algorithm">orchestration algorithm <code class="placeholder">{}</code></dt>
+      <dd id="dd-orchestration-algorithm">
+        Definition
+      </dd>
+
+      <dt id="dt-org-organization">org/organization <code class="placeholder">{}</code></dt>
+      <dd id="dd-org-organization">
+        Definition
+      </dd>
+
+      <dt id="dt-org-admin">org admin <code class="placeholder">{}</code></dt>
+      <dd id="dd-org-admin">
+        Definition
+      </dd>
+
+      <dt id="dt-org-profile">org profile <code class="placeholder">{}</code></dt>
+      <dd id="dd-org-profile">
+        Definition
+      </dd>
+
+      <dt id="dt-parent-algorithm">parent algorithm <code class="placeholder">{}</code></dt>
+      <dd id="dd-parent-algorithm">
+        Definition
+      </dd>
+
+      <dt id="dt-password">password <code class="placeholder">{}</code></dt>
+      <dd id="dd-password">
+        Definition
+      </dd>
+
+      <dt id="dt-platform-version">platform version <code class="placeholder">{}</code></dt>
+      <dd id="dd-platform-version">
+        Definition
+      </dd>
+
+      <dt id="dt-private-algorithm">private algorithm <code class="placeholder">{}</code></dt>
+      <dd id="dd-private-algorithm">
+        Definition
+      </dd>
+
+      <dt id="dt-public-algorithm">public algorithm <code class="placeholder">{}</code></dt>
+      <dd id="dd-public-algorithm">
+        Definition
+      </dd>
+
+      <dt id="dt-publisher">publisher <code class="placeholder">{}</code></dt>
+      <dd id="dd-publisher">
+        Definition
+      </dd>
+
+      <dt id="dt-record">record <code class="placeholder">{}</code></dt>
+      <dd id="dd-record">
+        Definition
+      </dd>
+
+      <dt id="dt-replica">replica <code class="placeholder">{}</code></dt>
+      <dd id="dd-replica">
+        Definition
+      </dd>
+
+      <dt id="dt-reservation">reservation <code class="placeholder">{}</code></dt>
+      <dd id="dd-reservation">
+        Definition
+      </dd>
+
+      <dt id="dt-resource">resource <code class="placeholder">{}</code></dt>
+      <dd id="dd-resource">
+        Definition
+      </dd>
+
+      <dt id="dt-resource-request">resource request <code class="placeholder">{}</code></dt>
+      <dd id="dd-resource-request">
+        Definition
+      </dd>
+
+      <dt id="dt-resource-uri">resource URI <code class="placeholder">{}</code></dt>
+      <dd id="dd-resource-uri">
+        Definition
+      </dd>
+
+      <dt id="dt-satellite-cluster">satellite cluster <code class="placeholder">{}</code></dt>
+      <dd id="dd-satellite-cluster">
+        Definition
+      </dd>
+
+      <dt id="dt-satellite-launce-instance">satellite launce instance <code class="placeholder">{}</code></dt>
+      <dd id="dd-satellite-launce-instance">
+        Definition
+      </dd>
+
+      <dt id="dt-satellite-version">satellite version <code class="placeholder">{}</code></dt>
+      <dd id="dd-satellite-version">
+        Definition
+      </dd>
+
+      <dt id="dt-secret">secret <code class="placeholder">{}</code></dt>
+      <dd id="dd-secret">
+        Definition
+      </dd>
+
+      <dt id="dt-secret-store">Secret Store <code class="placeholder">{}</code></dt>
+      <dd id="dd-secret-store">
+        Definition
+      </dd>
+
+      <dt id="dt-serialized-model">serialized model <code class="placeholder">{MODEL_NAME}</code></dt>
+      <dd id="dd-serialized-model">
+        <a class="glossary-hoverable" href="#dt-machine-learning" title="" parentId="dd-machine-learning">ML</a> model
+        file that’s ready to be loaded into an algorithm and used for inference. Synonymous with <a
+          class="glossary-hoverable" href="#dt-model" title="" parentId="dd-model">model</a> and <a
+          class="glossary-hoverable" href="#dt-trained-model" title="" parentId="dd-trained-model">trained model</a>.
+      </dd>
+
+      <dt id="dt-service-account">service account <code class="placeholder">{}</code></dt>
+      <dd id="dd-service-account">
+        Definition
+      </dd>
+
+      <dt id="dt-slot">slot <code class="placeholder">{}</code></dt>
+      <dd id="dd-slot">
+        Definition
+      </dd>
+
+      <dt id="dt-scm-configuration">SCM configuration <code class="placeholder">{}</code></dt>
+      <dd id="dd-scm-configuration">
+        Definition
+      </dd>
+
+      <dt id="dt-scm-connection">SCM connection <code class="placeholder">{}</code></dt>
+      <dd id="dd-scm-connection">
+        Definition
+      </dd>
+
+      <dt id="dt-scm-provider">SCM provider <code class="placeholder">{}</code></dt>
+      <dd id="dd-scm-provider">
+        Definition
+      </dd>
+
+      <dt id="dt-source-code-management">source code management (SCM) <code class="placeholder">{}</code></dt>
+      <dd id="dd-source-code-management">
+        Definition
+      </dd>
+
+      <dt id="dt-subscriber">subscriber <code class="placeholder">{}</code></dt>
+      <dd id="dd-subscriber">
+        Definition
+      </dd>
+
+      <dt id="dt-test-console">test console <code class="placeholder">{}</code></dt>
+      <dd id="dd-test-console">
+        Definition
+      </dd>
+
+      <dt id="dt-top-level-algorithm">top-level algorithm <code class="placeholder">{}</code></dt>
+      <dd id="dd-top-level-algorithm">
+        Definition
+      </dd>
+
+      <dt id="dt-topic">topic <code class="placeholder">{}</code></dt>
+      <dd id="dd-topic">
+        Definition
+      </dd>
+
+      <dt id="dt-trained-model">trained model <code class="placeholder">{MODEL_NAME}</code></dt>
+      <dd id="dd-trained-model">
+        <a class="glossary-hoverable" href="#dt-machine-learning" title="" parentId="dd-machine-learning">ML</a> model
+        file that’s ready to be loaded into an algorithm and used for inference. Synonymous with <a
+          class="glossary-hoverable" href="#dt-model" title="" parentId="dd-model">model</a> and <a
+          class="glossary-hoverable" href="#dt-serialized-model" title="" parentId="dd-serialized-model">serialized
+          model</a>.
+      </dd>
+
+      <dt id="dt-training-center">Training Center <code class="placeholder">{}</code></dt>
+      <dd id="dd-training-center">
+        Definition
+      </dd>
+
+      <dt id="dt-user">user <code class="placeholder">{}</code></dt>
+      <dd id="dd-user">
+        Definition
+      </dd>
+
+      <dt id="dt-user-account">user account <code class="placeholder">{}</code></dt>
+      <dd id="dd-user-account">
+        Definition
+      </dd>
+
+      <dt id="dt-unilog">UNILOG <code class="placeholder">{}</code></dt>
+      <dd id="dd-unilog">
+        Definition
+      </dd>
+
+      <dt id="dt-warm-algorithm">warm algorithm <code class="placeholder">{}</code></dt>
+      <dd id="dd-warm-algorithm">
+        Definition
+      </dd>
+
+      <dt id="dt-web-ide">Web IDE <code class="placeholder">{}</code></dt>
+      <dd id="dd-web-ide">
+        Definition
+      </dd>
+
+      <dt id="dt-worker-node">worker node <code class="placeholder">{}</code></dt>
+      <dd id="dd-worker-node">
+        Definition
+      </dd>
+
+    </dl>
+  </div>
+
+  <script>
+    // assign id to parent element, prepending "dt-" to child element id
+    function assignParentId(parentNode) {
+      childElem = parentNode.childElem
+
+
+        .document.getElementById(childId).parentElement
+      parentElem.setAttribute("id", "dt-" + childId)
+    }
+
+    // assign ids to all parent elements
+    function assignParentIds() {
+      terms = document.getElementsByTagName("dd")
+      for (let index = 0; index < terms.length; index++) {
+        assignParentId(terms[index]);
+
+      }
+    }
+
+
+    function assignTitle(parentId) {
+      elem = document.getElementById(parentId)
+      if (elem) {
+        return elem.innerText;
+      }
+      console.log("missing parentId: " + parentId)
+      return ""
+    }
+
+    var glossTerms = document.getElementsByClassName("glossary-hoverable");
+    for (i = 0; i < glossTerms.length; i++) {
+      currentElem = glossTerms.item(i);
+      parentId = currentElem.attributes.getNamedItem("parentId").nodeValue;
+      glossTerms.item(i).title = assignTitle(parentId);
+    }
+
+    function countIndexTerms() {
+      // pass
+    }
+
+    function countDefinitionTerms() {
+      // pass
+    }
+
+    // make sure that count of index items match count of glossary terms
+    function verifyTermCounts() {
+      // pass
+      indexCount = countIndexItems()
+      termCount = countTermItems()
+      if (indexCount !== termCount) {
+        console.log("Missing Index or Definition")
+        console.log("Index count: " + indexCount)
+        console.log("Term count: " + termCount)
+      }
+    }
+  </script>
+</body>
+
+</html>

--- a/_pages/glossary.html
+++ b/_pages/glossary.html
@@ -36,10 +36,11 @@
         Some terms have associated <code class="placeholder">{PLACEHOLDER_STRING}</code> values. We use these
         uppercase strings in our UI, and in code samples across our documentation, to denote generic values that must be
         replaced with custom values in your code. Placeholders <code
-          class="placeholder">{/beginning/with-a-slash}</code> are endpoints from the
-        <code>https://algorithmia.com</code> <a class="glossary-hoverable" href="#base-url" title=""
-          parentId="dd-base-url">base URL</a> (or from <code>https://<a class="glossary-hoverable" href="#cluster-domain" title=""
-          parentId="dd-cluster-domain">CLUSTER_DOMAIN</a></code> for enterprise clusters; see below).
+          class="placeholder">{/beginning/with-a-slash}</code> are <a class="glossary-hoverable" href="#api-endpoint"
+          title="" parentId="dd-api-endpoint">endpoints</a> from the <code>https://algorithmia.com</code> <a
+          class="glossary-hoverable" href="#base-url" title="" parentId="dd-base-url">base URL</a> (or from
+        <code>https://<a class="glossary-hoverable" href="#cluster-domain" title="" parentId="dd-cluster-domain">CLUSTER_DOMAIN</a></code>
+        for enterprise clusters; see below).
       </li>
       <dl>
         <ul>
@@ -131,7 +132,6 @@
         <li><a href="#api-docs">API docs</a></li>
         <li><a href="#api-endpoint">API endpoint</a></li>
         <li><a href="#api-key">API key</a></li>
-        <li><a href="#api-method">API method</a></li>
         <li><a href="#authenticated-resource-request">authenticated resource request</a></li>
         <li><a href="#authentication">authentication</a></li>
         <li><a href="#authentication-factor">authentication factor</a></li>
@@ -164,14 +164,15 @@
         <li><a href="#file">file</a></li>
         <li><a href="#folder">folder</a></li>
         <li><a href="#general-purpose-node">general purpose node</a></li>
+        <li><a href="#grafana">Grafana</a></li>
       </ul>
     </div>
 
     <div class="column right">
       <ul>
-        <li><a href="#grafana">Grafana</a></li>
         <li><a href="#hosted-data-collection">hosted data collection</a></li>
         <li><a href="#hot-algorithm">hot algorithm</a></li>
+        <li><a href="#http-method">HTTP method</a></li>
         <li><a href="#json-web-token">JSON Web Token (JWT)</a></li>
         <li><a href="#identity">identity</a></li>
         <li><a href="#kibana">Kibana</a></li>
@@ -193,7 +194,7 @@
         <li><a href="#open-source-algorithm">open-source algorithm</a></li>
         <li><a href="#orchestration-algorithm">orchestration algorithm</a></li>
         <li><a href="#org-organization">org/organization</a></li>
-        <li><a href="#org-admin">org admin</a></li>
+        <li><a href="#org-admin-account">org admin account</a></li>
         <li><a href="#org-profile">org profile</a></li>
         <li><a href="#parent-algorithm">parent algorithm</a></li>
         <li><a href="#password">password</a></li>
@@ -222,7 +223,7 @@
         <li><a href="#source-code-management">source code management (SCM)</a></li>
         <li><a href="#subscriber">subscriber</a></li>
         <li><a href="#test-console">test console</a></li>
-        <li><a href="#top-level-algorithm">top level algorithm</a></li>
+        <li><a href="#top-level-algorithm">top-level algorithm</a></li>
         <li><a href="#topic">topic</a></li>
         <li><a href="#trained-model">trained model</a></li>
         <li><a href="#training-center">Training Center</a></li>
@@ -244,8 +245,9 @@
       <dt id="account">account <code class="placeholder">{ACCOUNT_NAME}</code></dt>
       <dd id="dd-account">
         <a class="glossary-hoverable" href="#identity" title="" parentId="dd-identity">Identity</a> on the Algorithmia
-        platform that may own and/or be used to access a resource (e.g., an <a class="glossary-hoverable"
-          href="#algorithm" title="" parentId="dd-algorithm">algorithm</a>).
+        platform that may own and/or be used to access a <a class="glossary-hoverable" href="#resource" title=""
+          parentId="dd-resource">resource</a> (e.g., an <a class="glossary-hoverable" href="#algorithm" title=""
+          parentId="dd-algorithm">algorithm</a>).
       </dd>
 
       <dt id="account-profile">account profile <code class="placeholder">{/users/ACCOUNT_NAME}</code></dt>
@@ -262,14 +264,22 @@
 
       <dt id="admin-api-key">admin API key <code class="placeholder">{ADMIN_API_KEY}</code></dt>
       <dd id="dd-admin-api-key">
-        Secret authentication token associated with a specific cluster admin account. An admin API key can be used to
-        make specific administrative authenticated resource requests through the API. Examples of admin-only requests
-        include creating and deleting user accounts and organizations.
+        Secret <a class="glossary-hoverable" href="#authentication-token" title=""
+          parentId="dd-authentication-token">authentication token</a> associated with a specific <a
+          class="glossary-hoverable" href="#cluster-admin-account" title="" parentId="dd-cluster-admin-account">cluster
+          admin account</a>. An admin API key can be used to make specific administrative <a class="glossary-hoverable"
+          href="#authenticated-resource-request" title="" parentId="dd-authenticated-resource-request">authenticated
+          resource requests</a> through the <a class="glossary-hoverable" href="#api" title=""
+          parentId="dd-api">API</a>. Examples of admin-only requests include creating and deleting <a
+          class="glossary-hoverable" href="#user-account" title="" parentId="dd-user-account">user accounts</a> and <a
+          class="glossary-hoverable" href="#org-organization" title="" parentId="dd-org-organization">organizations</a>.
       </dd>
 
-      <dt id="admin-panel">admin panel <code class="placeholder">{/admin/&lt;page name&gt;}</code></dt>
+      <dt id="admin-panel">admin panel <code class="placeholder">{/admin}</code></dt>
       <dd id="dd-admin-panel">
-        Navigation bar displaying administrative functionality available to a cluster admin.
+        Navigation bar displaying administrative functionality available to a <a class="glossary-hoverable"
+          href="#cluster-admin-account" title="" parentId="dd-cluster-admin-account">cluster
+          admin</a>.
       </dd>
 
       <dt id="algo-cli">algo CLI</dt>
@@ -277,423 +287,537 @@
         Algorithmia’s command-line interface tool, called with <code>algo [COMMAND [OPTIONS]]</code>.
       </dd>
 
-      <dt id="algorithm">algorithm <code class="placeholder">{}</code></dt>
+      <dt id="algorithm">algorithm <code class="placeholder">{ALGO_NAME}</code></dt>
       <dd id="dd-algorithm">
         Microservice on Algorithmia that accepts an input, may return an output, and may have side effects. An algorithm
         can only accept a JSON type as input, and if it returns an output, can only return a JSON type. Algorithms can
-        be pipelined together with other algorithms. The primary use case for algorithms on Algorithmia’s platform is to
-        provide functionality for loading and calling ML models for inference, but the scope of tasks that algorithms
-        can perform is not constrained to this. For example, algorithms can perform conventional deterministic
-        algorithmic routines (e.g., binary search), can read and write data, can be used to query or send data to an
-        external data source such as a database, can perform utility tasks such as downloading images and pre-processing
-        structured or unstructured data, and can be configured to orchestrate all of the above.
+        be <a class="glossary-hoverable" href="#algorithm-pipelining" title=""
+          parentId="dd-algorithm-pipelining">pipelined</a> together with other algorithms. The primary use case for
+        algorithms on Algorithmia’s platform is to provide functionality for loading and calling <a
+          class="glossary-hoverable" href="#machine-learning" title="" parentId="dd-machine-learning">ML</a> <a
+          class="glossary-hoverable" href="#model" title="" parentId="dd-model">models</a> for
+        inference, but the scope of tasks that algorithms can perform isn't constrained to this. For example,
+        algorithms can perform conventional deterministic algorithmic routines (e.g., binary search), can read and write
+        data, can be used to query or send data to an <a class="glossary-hoverable" href="#external-data-source"
+          title="" parentId="dd-external-data-source">external data source</a> such as a database, can perform utility
+        tasks such as downloading images and pre-processing structured or unstructured data, and can be configured to
+        orchestrate all of the above.
       </dd>
 
-      <dt id="algorithm-build">algorithm build <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-build">algorithm build <code class="placeholder">{ALGO_BUILD}</code></dt>
       <dd id="dd-algorithm-build">
-        Specific compiled version of an algorithm, described by an algorithm build hash.
+        Specific compiled version of an <a class="glossary-hoverable" href="#algorithm" title=""
+          parentId="dd-algorithm">algorithm</a>, described by an <a class="glossary-hoverable"
+          href="#algorithm-build-hash" title="" parentId="dd-algorithm-build-hash">algorithm
+          build hash</a>.
       </dd>
 
-      <dt id="algorithm-build-hash">algorithm build hash <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-build-hash">algorithm build hash <code class="placeholder">{ALGO_VERSION_HASH}</code></dt>
       <dd id="dd-algorithm-build-hash">
-        Unique value describing an algorithm version created from a specific Git commit when an algorithm builds
-        (compiles) successfully. Synonymous with algorithm version hash.
+        Unique value describing an <a class="glossary-hoverable" href="#algorithm-version" title=""
+          parentId="dd-algorithm-version">algorithm version</a> created from a specific Git commit when an <a
+          class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">algorithm</a> builds (compiles)
+        successfully. Synonymous with <a class="glossary-hoverable" href="#algorithm-version-hash" title=""
+          parentId="dd-algorithm-version-hash">algorithm version hash</a>.
       </dd>
 
-      <dt id="algorithm-build-uuid">algorithm build UUID <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-build-uuid">algorithm build UUID <code class="placeholder">{BUILD_ID}</code></dt>
       <dd id="dd-algorithm-build-uuid">
-        Globally unique identifier for a specific algorithm build, in the format <code>1234-1234-1234-1234</code>.
+        Globally unique identifier for a specific <a class="glossary-hoverable" href="#algorithm-build" title=""
+          parentId="dd-algorithm-build">algorithm build</a>, in the format <code>1234-1234-1234-1234</code>.
       </dd>
 
-      <dt id="algorithm-environment">algorithm environment <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-environment">algorithm environment <code class="placeholder">{ALGO_ENV}</code></dt>
       <dd id="dd-algorithm-environment">
-        Predefined, optimized runtime configuration for an algorithm. Environments usually contain specific ML framework
+        Predefined, optimized runtime configuration for an <a class="glossary-hoverable" href="#algorithm" title=""
+          parentId="dd-algorithm">algorithm</a>. Environments usually contain specific <a class="glossary-hoverable"
+          href="#machine-learning" title="" parentId="dd-machine-learning">ML</a> framework
         dependencies optimized for Algorithmia’s architecture, and serve as a base upon which additional external
-        library
-        dependencies can be added if necessary.
+        library dependencies can be added if necessary.
       </dd>
 
-      <dt id="algorithm-environment-uuid">algorithm environment UUID <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-environment-uuid">algorithm environment UUID <code class="placeholder">{ENV_ID}</code></dt>
       <dd id="dd-algorithm-environment-uuid">
-        Globally unique, cluster-specific identifier for a specific algorithm environment, in the format
-        1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d.
+        Globally unique, cluster-specific identifier for a specific <a class="glossary-hoverable"
+          href="#algorithm-environment" title="" parentId="dd-algorithm-environment">algorithm environment</a>, in the
+        format <code>1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d</code>.
       </dd>
 
-      <dt id="algorithm-endpoint">algorithm endpoint <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-endpoint">algorithm endpoint <code class="placeholder">{ALGO_ENDPOINT}</code></dt>
       <dd id="dd-algorithm-endpoint">
-        Unique (within an Algorithmia cluster) name identifying a specific algorithm version, defined as
-        ALGO_OWNER/ALGO_NAME[/ALGO_VERSION], where ALGO_VERSION defaults to the latest published version if excluded.
+        Unique (within an Algorithmia cluster) name identifying a specific <a class="glossary-hoverable"
+          href="#algorithm-version" title="" parentId="dd-algorithm-version">algorithm version</a>, defined as
+        <code class="placeholder">ALGO_OWNER/ALGO_NAME[/ALGO_VERSION]</code>, where <code
+          class="placeholder">ALGO_VERSION</code> defaults to the latest published version if excluded.
       </dd>
 
-      <dt id="algorithm-execution-request">algorithm execution request <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-execution-request">algorithm execution request</dt>
       <dd id="dd-algorithm-execution-request">
-        Request made to execute an algorithm with an optional input.
-
+        Request made to execute an <a class="glossary-hoverable" href="#algorithm" title=""
+          parentId="dd-algorithm">algorithm</a> with an optional input.
       </dd>
 
-      <dt id="algorithm-profile">algorithm profile <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-profile">algorithm profile <code class="placeholder">{/algorithms/ALGO_OWNER/ALGO_NAME}</code>
+      </dt>
       <dd id="dd-algorithm-profile">
-        Profile page for an algorithm.
-
+        Profile page for an <a class="glossary-hoverable" href="#algorithm" title=""
+          parentId="dd-algorithm">algorithm</a>.
       </dd>
 
-      <dt id="algorithm-instance">algorithm instance <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-instance">algorithm instance <code
+          class="placeholder">{CALLER_NAME/ALGO_NAME/ALGO_VERSION}</code></dt>
       <dd id="dd-algorithm-instance">
-        Individual replica of an algorithm running on a worker node.
-
+        Individual <a class="glossary-hoverable" href="#replica" title="" parentId="dd-replica">replica</a> of an <a
+          class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">algorithm</a> running on
+        a <a class="glossary-hoverable" href="#worker-node" title="" parentId="dd-worker-node">worker node</a>.
       </dd>
 
-      <dt id="algorithm-language">algorithm language <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-language">algorithm language <code class="placeholder">{ALGO_LANG}</code></dt>
       <dd id="dd-algorithm-language">
-        Programming language in which an algorithm is written.
-
+        Programming language in which an <a class="glossary-hoverable" href="#algorithm" title=""
+          parentId="dd-algorithm">algorithm</a> is written.
       </dd>
 
-      <dt id="algorithm-owner">algorithm owner <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-owner">algorithm owner <code class="placeholder">{ALGO_OWNER}</code></dt>
       <dd id="dd-algorithm-owner">
-        Account or org that owns an algorithm.
-
+        <a class="glossary-hoverable" href="#account" title="" parentId="dd-account">Account</a> or <a
+          class="glossary-hoverable" href="#org-organization" title="" parentId="dd-org-organization">org</a> that owns
+        an <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">algorithm</a>.
       </dd>
 
-      <dt id="algorithm-pipelining">algorithm pipelining <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-pipelining">algorithm pipelining</dt>
       <dd id="dd-algorithm-pipelining">
-        When one algorithm calls another algorithm within an Algorithmia cluster.
+        When one <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">algorithm</a> calls
+        another algorithm within an Algorithmia <a class="glossary-hoverable" href="#cluster" title=""
+          parentId="dd-cluster">cluster</a>.
       </dd>
 
-      <dt id="algorithm-semantic-version">algorithm semantic version <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-semantic-version">algorithm semantic version <code class="placeholder">{X.Y.Z}</code></dt>
       <dd id="dd-algorithm-semantic-version">
-        Specific published version of an algorithm build, where X, Y, and Z represent major version, minor version, and
-        revision.
-
+        Specific published version of an <a class="glossary-hoverable" href="#algorithm-build" title=""
+          parentId="dd-algorithm-build">algorithm build</a>, where X, Y, and Z represent major version, minor version,
+        and revision.
       </dd>
 
       <dt id="algorithm-template">algorithm template <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-template">
         Source code file or collection of files with boilerplate code that serves as a unified starting point for new
-        algorithms
+        <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">algorithms</a>
         that are created.
-
       </dd>
 
-      <dt id="algorithm-uuid">algorithm UUID <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-uuid">algorithm UUID <code class="placeholder">{ALGO_ID}</code></dt>
       <dd id="dd-algorithm-uuid">
-        Globally unique identifier for a specific algorithm, in the format 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d.
-
+        Globally unique identifier for a specific <a class="glossary-hoverable" href="#algorithm" title=""
+          parentId="dd-algorithm">algorithm</a>, in the format
+        <code>1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d</code>.
       </dd>
 
       <dt id="algorithm-vanity-url">algorithm vanity URL <code class="placeholder">{}</code></dt>
       <dd id="dd-algorithm-vanity-url">
-        Minimal URL for specific algorithm endpoint in a satellite deployment.
-
+        Minimal URL for specific <a class="glossary-hoverable" href="#algorithm-endpoint" title=""
+          parentId="dd-algorithm-endpoint">algorithm endpoint</a> in a <a class="glossary-hoverable"
+          href="#satellite-cluster" title="" parentId="dd-satellite-cluster">satellite</a> deployment.
       </dd>
 
-      <dt id="algorithm-version">algorithm version <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-version">algorithm version <code class="placeholder">{ALGO_VERSION}</code></dt>
       <dd id="dd-algorithm-version">
-        Generic name to refer to a specific algorithm build, which could be denoted by an algorithm semantic version or
-        an
-        algorithm version hash.
+        Generic name to refer to a specific <a class="glossary-hoverable" href="#algorithm-build" title=""
+          parentId="dd-algorithm-build">algorithm build</a>, which could be denoted by an <a class="glossary-hoverable"
+          href="#algorithm-semantic-version" title="" parentId="dd-algorithm-semantic-version">algorithm semantic
+          version</a> or an <a class="glossary-hoverable" href="#algorithm-version-hash" title=""
+          parentId="dd-algorithm-version-hash">algorithm version hash</a>.
       </dd>
 
-      <dt id="algorithm-version-hash">algorithm version hash <code class="placeholder">{}</code></dt>
+      <dt id="algorithm-version-hash">algorithm version hash <code class="placeholder">{ALGO_VERSION_HASH}</code></dt>
       <dd id="dd-algorithm-version-hash">
-        Unique value describing an algorithm version created from a specific Git commit when an algorithm builds
-        (compiles)
-        successfully. Synonymous with algorithm build hash.
+        Unique value describing an <a class="glossary-hoverable" href="#algorithm-version" title=""
+          parentId="dd-algorithm-version">algorithm version</a> created from a specific Git commit when an <a
+          class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">algorithm</a>
+        builds (compiles) successfully. Synonymous with <a class="glossary-hoverable" href="#algorithm-build-hash"
+          title="" parentId="dd-algorithm-build-hash">algorithm build hash</a>.
       </dd>
 
-      <dt id="api">API <code class="placeholder">{}</code></dt>
+      <dt id="api">API <code class="placeholder">{/v1/openapispec}</code></dt>
       <dd id="dd-api">
-        <!-- use this span id for referencing this definition in hoverable links -->
-        <span id="dd-api-hoverable">Generic term for individual Algorithmia REST API service. API endpoints are
-          grouped based on the functionality they provide for interacting with resources.</span> Algorithmia has the
-        following
-        APIs:<br /><br />
+        Generic term for individual Algorithmia REST API service. <a class="glossary-hoverable" href="#api-endpoint"
+          title="" parentId="dd-api-endpoint">API endpoints</a> are grouped based on the functionality they provide for
+        interacting with <a class="glossary-hoverable" href="#cluster" title="" parentId="dd-cluster">cluster</a> <a
+          class="glossary-hoverable" href="#resource" title="" parentId="dd-resource">resources</a>. Algorithmia has the
+        following APIs:<br /><br />
         <ul>
-          <li><code>algorithms</code> : algorithm operations</li>
-          <li><code>users</code> : account operations</li>
-          <li><code>organizations</code> : organization operations</li>
-          <li><code>scm</code> : source control management operations</li>
-          <li><code>secrets</code> : secret store operations</li>
-          <li><code>connectors</code> : data connector operations</li>
-          <li><code>data</code> : data API operations</li>
-          <li><code>eventlisteners</code> : event flow-based operations</li>
-          <li><code>eventmanagers</code> : message broker operations</li>
-          <li><code>builds</code> : algorithm build operations</li>
-          <li><code>auth</code> : authentication factor and authentication token management</li>
-          <li><code>usage</code> : cluster usage information</li>
-          <li><code>invites</code> : cluster invite code management</li>
-          <li><code>admin</code> : cluster administration operations</li>
-          <li><code>style</code> : cluster front-end style configuration</li>
-          <li><code>frontend</code> : cluster front end configuration</li>
+          <li><code>algorithms</code> : <a class="glossary-hoverable" href="#algorithm" title=""
+              parentId="dd-algorithm">algorithm</a> operations</li>
+          <li><code>users</code> : <a class="glossary-hoverable" href="#account" title=""
+              parentId="dd-account">account</a> operations</li>
+          <li><code>organizations</code> : <a class="glossary-hoverable" href="#org-organization" title=""
+              parentId="dd-org-organization">organization</a> operations</li>
+          <li><code>scm</code> : <a class="glossary-hoverable" href="#source-code-management" title=""
+              parentId="dd-source-code-management">source code management</a> operations</li>
+          <li><code>secrets</code> : <a class="glossary-hoverable" href="#secret-store" title=""
+              parentId="dd-secret-store">Secret Store</a> operations</li>
+          <li><code>connectors</code> : <a class="glossary-hoverable" href="#data-connector" title=""
+              parentId="dd-data-connector">data connector</a> operations</li>
+          <li><code>data</code> : <a class="glossary-hoverable" href="#api" title="" parentId="dd-api">data API</a>
+            operations</li>
+          <li><code>eventlisteners</code> : <a class="glossary-hoverable" href="#event-flow" title=""
+              parentId="dd-event-flow">Event Flow</a>-based operations</li>
+          <li><code>eventmanagers</code> : <a class="glossary-hoverable" href="#message-broker" title=""
+              parentId="dd-message-broker">message broker</a> operations</li>
+          <li><code>builds</code> : <a class="glossary-hoverable" href="#algorithm-build" title=""
+              parentId="dd-algorithm-build">algorithm build</a> operations</li>
+          <li><code>auth</code> : <a class="glossary-hoverable" href="#authentication-factor" title=""
+              parentId="dd-authentication-factor">authentication factor</a> and <a class="glossary-hoverable"
+              href="#authentication-token" title="" parentId="dd-authentication-token">authentication token</a>
+            management
+          </li>
+          <li><code>usage</code> : <a class="glossary-hoverable" href="#cluster" title=""
+              parentId="dd-cluster">cluster</a> usage information</li>
+          <li><code>invites</code> : <a class="glossary-hoverable" href="#cluster" title=""
+              parentId="dd-cluster">cluster</a> invite code management</li>
+          <li><code>admin</code> : <a class="glossary-hoverable" href="#cluster" title=""
+              parentId="dd-cluster">cluster</a> administration operations</li>
+          <li><code>style</code> : <a class="glossary-hoverable" href="#cluster" title=""
+              parentId="dd-cluster">cluster</a> front-end style configuration</li>
+          <li><code>frontend</code> : <a class="glossary-hoverable" href="#cluster" title=""
+              parentId="dd-cluster">cluster</a> front-end configuration</li>
         </ul>
       </dd>
 
-      <dt id="api-docs">API Docs <code class="placeholder">{}</code></dt>
+      <dt id="api-docs">API Docs <code class="placeholder">{/api}</code></dt>
       <dd id="dd-api-docs">
-        Documentation for Algorithmia’s API, listing all available endpoints. Description here.
+        Documentation for Algorithmia’s <a class="glossary-hoverable" href="#api" title="" parentId="dd-api">API</a>,
+        listing all available <a class="glossary-hoverable" href="#api-endpoint" title="" parentId="dd-api-endpoint">API
+          endpoints</a>.
       </dd>
 
-      <dt id="api-endpoint">API endpoint <code class="placeholder">{}</code></dt>
+      <dt id="api-endpoint">API endpoint <code class="placeholder">{/path/to/endpoint}</code></dt>
       <dd id="dd-api-endpoint">
-        Resource URL not including the base URL, for example /v1/algorithms/{ALGO_OWNER}/{ALGO_NAME}/{ALGO_VERSION}.
+        <a class="glossary-hoverable" href="#resource-uri" title="" parentId="dd-resource-uri">Resource URI</a> not
+        including the <a class="glossary-hoverable" href="#base-url" title="" parentId="dd-base-url">
+          base URL</a>, e.g., <code class="placeholder">/v1/algorithms/ALGO_OWNER/ALGO_NAME/ALGO_VERSION</code>.
       </dd>
 
-      <dt id="api-key">API key <code class="placeholder">{}</code></dt>
+      <dt id="api-key">API key <code class="placeholder">{API_KEY}</code></dt>
       <dd id="dd-api-key">
-        Secret authentication token associated with a specific account or org. As a security best practice, this value
-        should be
-        stored in the environment variable ALGORITHMIA_API_KEY.
-      </dd>
-
-      <dt id="api-method">API method <code class="placeholder">{}</code></dt>
-      <dd id="dd-api-method">
-        Verb used to indicate an interaction with a resource through the REST API. Algorithmia primarily uses GET, PUT,
-        POST,
-        DELETE, HEAD, and PATCH methods.
+        Secret <a class="glossary-hoverable" href="#authentication-token" title=""
+          parentId="dd-authentication-token">authentication token</a> associated with a specific <a
+          class="glossary-hoverable" href="#account" title="" parentId="dd-account">account</a> or <a
+          class="glossary-hoverable" href="#org-organization" title="" parentId="dd-org-organization">org</a>. As a
+        security best practice, this value should be stored in the environment variable
+        <code>ALGORITHMIA_API_KEY</code>.
       </dd>
 
       <dt id="authenticated-resource-request">authenticated resource request</dt>
       <dd id="dd-authenticated-resource-request">
-        Request for a resource that includes one or more authentication factors.
+        Request for a <a class="glossary-hoverable" href="#resource" title="" parentId="dd-resource">resource</a> that
+        includes one or more <a class="glossary-hoverable" href="#authentication-factor" title=""
+          parentId="dd-authentication-factor">authentication factors</a>.
       </dd>
 
       <dt id="authentication">authentication <code class="placeholder">{}</code></dt>
       <dd id="dd-authentication">
-        The act of signing on to the Algorithmia platform in order to gain access to an authentication token that can
-        then be used to send authenticated resource requests.
+        The act of signing on to the Algorithmia platform in order to gain access to an <a class="glossary-hoverable"
+          href="#authentication-token" title="" parentId="dd-authentication-token">authentication
+          token</a> that can then be used to send <a class="glossary-hoverable" href="#authenticated-resource-request"
+          title="" parentId="dd-authenticated-resource-request">authenticated resource requests</a>.
       </dd>
 
       <dt id="authentication-factor">authentication factor <code class="placeholder">{}</code></dt>
       <dd id="dd-authentication-factor">
-        Property used to authenticate into an account to access resources. Algorithmia uses passwords for authentication
-        into
-        our browser UI.
+        Property used to authenticate into an <a class="glossary-hoverable" href="#account" title=""
+          parentId="dd-account">account</a> to access <a class="glossary-hoverable" href="#resource" title=""
+          parentId="dd-resource">resources</a>. Algorithmia uses passwords for authentication into our browser UI.
       </dd>
 
-      <dt id="authentication-token">authentication token <code class="placeholder">{}</code></dt>
+      <dt id="authentication-token">authentication token <code class="placeholder">{AUTH_TOKEN}</code></dt>
       <dd id="dd-authentication-token">
-        Special type of authentication factor that’s granted as a digital “receipt” upon successful authentication. A
-        token may
-        have a validity time limit and may represent a limited set of actions that can be taken on specific resources.
+        Special type of <a class="glossary-hoverable" href="#authentication-factor" title=""
+          parentId="dd-authentication-factor">authentication
+          factor</a> that’s granted as a digital “receipt” upon successful <a class="glossary-hoverable"
+          href="#authentication" title="" parentId="dd-authentication">authentication</a>. A token may have a validity
+        time limit and may represent a limited set of actions that can be taken on specific <a
+          class="glossary-hoverable" href="#resource" title="" parentId="dd-resource">resources</a>.
       </dd>
 
       <dt id="authorization">authorization <code class="placeholder">{}</code></dt>
       <dd id="dd-authorization">
-        The act of granting an identity access to specific resources.
+        The act of granting an identity access to specific <a class="glossary-hoverable" href="#resource" title=""
+          parentId="dd-resource">resources</a>.
       </dd>
 
-      <dt id="base-api-url">base API URL <code class="placeholder">{}</code></dt>
+      <dt id="base-api-url">base API URL <code class="placeholder">{BASE_API_URL | https://api.CLUSTER_DOMAIN}</code>
+      </dt>
       <dd id="dd-base-api-url">
-        Resource URL for /v1 API, not including the endpoint. For example https://api.algorithmia.com.
+        <a class="glossary-hoverable" href="#resource-uri" title="" parentId="dd-resource-uri">Resource URI</a> for
+        Algorithmia’s <a class="glossary-hoverable" href="#api" title="" parentId="dd-api">API</a>, not including a
+        specific <a class="glossary-hoverable" href="#api-endpoint" title="" parentId="dd-api-endpoint">endpoint</a>,
+        e.g., <code>https://api.algorithmia.com</code>.
       </dd>
 
-      <dt id="base-url">base URL <code class="placeholder">{}</code></dt>
+      <dt id="base-url">base URL <code class="placeholder">{BASE_URL | https://CLUSTER_DOMAIN}</code></dt>
       <dd id="dd-base-url">
-        Resource URL not including a specific endpoint. For example https://algorithmia.com.
+        <a class="glossary-hoverable" href="#resource-uri" title="" parentId="dd-resource-uri">Resource URI</a> not
+        including a
+        specific <a class="glossary-hoverable" href="#api-endpoint" title="" parentId="dd-api-endpoint">endpoint</a>,
+        e.g., <code>https://algorithmia.com</code>.
       </dd>
 
-      <dt id="blog">blog <code class="placeholder">{}</code></dt>
+      <dt id="blog">blog <code class="placeholder">{/blog}</code></dt>
       <dd id="dd-blog">
-        Algorithmia site where we share practical, relevant information about AI/ML and the industry, describe new
-        product
-        features and partnerships, pose new ideas, and share success stories in order to connect and build credibility
-        with the
-        reader. Blog posts are actively updated to reflect the state of the platform as product features and best
-        practices
-        change. Like the Developer Center, the blog is a resource to which customers can return at any time for accurate
-        information. Description here.
+        Algorithmia site where we share practical, relevant information about <a class="glossary-hoverable"
+          href="#machine-learning" title="" parentId="dd-machine-learning">ML</a>/<a class="glossary-hoverable"
+          href="#machine-learning-operations" title="" parentId="dd-machine-learning-operations">MLOps</a> and the
+        industry, describe new product features and partnerships, and pose new ideas.
       </dd>
 
-      <dt id="browser-ui">browser UI <code class="placeholder">{}</code></dt>
+      <dt id="browser-ui">browser UI</dt>
       <dd id="dd-browser-ui">
         Algorithmia’s browser-based user interface.
       </dd>
 
       <dt id="caller">caller <code class="placeholder">{CALLER_NAME}</code></dt>
       <dd id="dd-caller">
-        Account associated with the authentication token used to call an algorithm.
+        <a class="glossary-hoverable" href="#account" title="" parentId="dd-account">Account</a> associated with the <a
+          class="glossary-hoverable" href="#authentication-token" title=""
+          parentId="dd-authentication-token">authentication token</a> used to call an <a class="glossary-hoverable"
+          href="#algorithm" title="" parentId="dd-algorithm">algorithm</a>.
       </dd>
 
-      <dt id="collection-owner">collection owner <code class="placeholder">{}</code></dt>
+      <dt id="collection-owner">collection owner <code class="placeholder">{COLLECTION_OWNER}</code></dt>
       <dd id="dd-collection-owner">
-        Account or org that owns a hosted data collection.
+        <a class="glossary-hoverable" href="#account" title="" parentId="dd-account">Account</a> or <a
+          class="glossary-hoverable" href="#org-organization" title="" parentId="dd-org-organization">org</a> that owns
+        a <a class="glossary-hoverable" href="#hosted-data-collection" title=""
+          parentId="dd-hosted-data-collection">hosted data collection</a>.
       </dd>
 
-      <dt id="closed-source-algorithm">closed-source algorithm <code class="placeholder">{}</code></dt>
+      <dt id="closed-source-algorithm">closed-source algorithm</dt>
       <dd id="dd-closed-source-algorithm">
-        Algorithm published with source code only visible via authenticated resource requests from the account or org
-        that owns
-        the algorithm.
+        <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">Algorithm</a> published with
+        source code only visible via <a class="glossary-hoverable" href="#authenticated-resource-request" title=""
+          parentId="dd-authenticated-resource-request">authenticated resource requests</a> from the <a
+          class="glossary-hoverable" href="#account" title="" parentId="dd-account">account</a> or <a
+          class="glossary-hoverable" href="#org-organization" title="" parentId="dd-org-organization">org</a> that
+        owns the algorithm.
       </dd>
 
-      <dt id="cluster">cluster <code class="placeholder">{}</code></dt>
+      <dt id="cluster">cluster</dt>
       <dd id="dd-cluster">
         Individual instance of Algorithmia’s platform.
       </dd>
 
-      <dt id="cluster-admin-account">cluster admin account <code class="placeholder">{}</code></dt>
+      <dt id="cluster-admin-account">cluster admin account <code class="placeholder">{CLUSTER_ADMIN_NAME}</code></dt>
       <dd id="dd-cluster-admin-account">
-        Account with administrative privileges on the cluster. Cluster admin and org admin roles aren’t related.
-        [Engineering
-        also calls this “platform administrator”]
+        <a class="glossary-hoverable" href="#account" title="" parentId="dd-account">Account</a> that has administrative
+        privileges on the <a class="glossary-hoverable" href="#cluster" title="" parentId="dd-cluster">cluster</a>.
+        Cluster admin and <a class="glossary-hoverable" href="#org-admin-account" title=""
+          parentId="dd-org-admin-account">org admin</a> roles aren’t related.
       </dd>
 
-      <dt id="cluster-domain">cluster domain <code class="placeholder">{}</code></dt>
+      <dt id="cluster-domain">cluster domain <code class="placeholder">{CLUSTER_DOMAIN}</code></dt>
       <dd id="dd-cluster-domain">
-        Specific domain associated with an Algorithmia cluster. For example, algorithmia.com. For usage, see base URL.
+        Specific domain associated with an Algorithmia <a class="glossary-hoverable" href="#cluster" title=""
+          parentId="dd-cluster">cluster</a>, e.g., <code>algorithmia.com</code>. For usage, see <a
+          class="glossary-hoverable" href="#base-url" title="" parentId="dd-base-url">base URL</a>.
       </dd>
 
       <dt id="cluster-operator">cluster operator <code class="placeholder">{}</code></dt>
       <dd id="dd-cluster-operator">
         The DevOps customer persona that works with Algorithmia I&O to deploy, upgrade, and maintain Algorithmia’s
-        infrastructure in their Enterprise environment. (Cluster operators have access to environment variables and
-        other
-        configuration through the terminal vs. cluster admins who are just using the UI or API w/ and Admin API key.)
+        infrastructure in their Enterprise environment.
       </dd>
 
       <dt id="cold-algorithm">cold algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-cold-algorithm">
-        Algorithm for which no instances are currently ready to process algorithm execution requests.
+        <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">Algorithm</a> for which no
+        <a class="glossary-hoverable" href="#algorithm-instance" title="" parentId="dd-algorithm-instance">instances</a>
+        are currently ready to process <a class="glossary-hoverable" href="#algorithm-execution-request" title=""
+          parentId="dd-algorithm-execution-request">algorithm execution requests</a>.
       </dd>
 
       <dt id="constellation-distributed-serving">Constellation Distributed Serving</dt>
       <dd id="dd-constellation-distributed-serving">
-        Flexible Algorithmia deployment option in which a mothership (any Enterprise cluster with the option enabled) is
-        distinct and separate from the satellite(s) (a set of containers including algorithms (one satellite to many
-        algorithms), RabbitMQ, API server, and a configuration file) for production runtime, thereby decoupling
-        algorithm development from runtime execution. Constellation enables customers with high security, high
-        availability, or high performance workloads to easily deploy and serve models where they need to and in the
-        environment that works best for them.
+        Flexible Algorithmia deployment option in which a <a class="glossary-hoverable" href="#mothership-cluster"
+          title="" parentId="dd-mothership-cluster">mothership</a> (any Enterprise <a class="glossary-hoverable"
+          href="#cluster" title="" parentId="dd-cluster">cluster</a> with the option enabled) is distinct and separate
+        from the <a class="glossary-hoverable" href="#satellite-cluster" title=""
+          parentId="dd-satellite-cluster">satellite</a>(s) (a set of containers including <a class="glossary-hoverable"
+          href="#algorithm" title="" parentId="dd-algorithm">algorithms</a> (one satellite to
+        many algorithms), RabbitMQ, <a class="glossary-hoverable" href="#api" title="" parentId="dd-api">API</a> server,
+        and a configuration file) for production runtime, thereby decoupling algorithm development from runtime
+        execution. Constellation enables customers with high security, high availability, or high performance workloads
+        to easily deploy and serve <a class="glossary-hoverable" href="#model" title="" parentId="dd-model">models</a>
+        where they need to and in the environment that works best for them.
       </dd>
 
       <dt id="consumer">consumer <code class="placeholder">{}</code></dt>
       <dd id="dd-consumer">
-        Not used. See subscriber.
+        Not used. See <a class="glossary-hoverable" href="#subscriber" title="" parentId="dd-subscriber">subscriber</a>.
       </dd>
 
-      <dt id="contorl-plane-node">control plane node <code class="placeholder">{}</code></dt>
-      <dd id="dd-contorl-plane-node">
-        Node in Algorithmia’s Kubernetes environment that manages cluster health and provisioning of general purpose
-        nodes and
-        worker nodes. Put another way, this node runs Kubernetes—the orchestration of the containers. [Note: this used
-        to be
-        called “master node” but officially is now called “Control Plane Node” in K8s, so it should be updated in both
-        our UI
-        and documentation to align with that.]
+      <dt id="control-plane-node">control plane node</dt>
+      <dd id="dd-control-plane-node">
+        <a class="glossary-hoverable" href="#node" title="" parentId="dd-node">Node</a> in Algorithmia’s Kubernetes
+        environment that manages <a class="glossary-hoverable" href="#cluster" title=""
+          parentId="dd-cluster">cluster</a> health and provisioning of <a class="glossary-hoverable"
+          href="#general-purpose-node" title="" parentId="dd-general-purpose-node">general purpose nodes</a> and
+        <a class="glossary-hoverable" href="#worker-node" title="" parentId="dd-worker-node">worker nodes</a>. Put
+        another way, this node runs Kubernetes—the orchestration of the containers. Note that this was previously named
+        <a class="glossary-hoverable" href="#master-node" title="" parentId="dd-master-node">master node</a>.
       </dd>
 
-      <dt id="data-connector">data connector <code class="placeholder">{}</code></dt>
+      <dt id="data-connector">data connector <code class="placeholder">{CONNECTOR_ID}</code></dt>
       <dd id="dd-data-connector">
-        Specific cloud storage provider to which algorithms can connect through a built-in configuration on
-        Algorithmia’s
+        Specific cloud storage provider to which <a class="glossary-hoverable" href="#algorithm" title=""
+          parentId="dd-algorithm">algorithms</a> can connect natively through a built-in configuration on Algorithmia’s
         platform.
       </dd>
 
-      <dt id="data-source">data source <code class="placeholder">{}</code></dt>
+      <dt id="data-source">data source</dt>
       <dd id="dd-data-source">
-        Generic term for hosted data collection, data connector, and external data source.
-
+        Generic term for <a class="glossary-hoverable" href="#hosted-data-collection" title=""
+          parentId="dd-hosted-data-collection">hosted data collection</a>, <a class="glossary-hoverable"
+          href="#data-connector" title="" parentId="dd-data-connector">data connector</a>, or <a
+          class="glossary-hoverable" href="#external-data-source" title="" parentId="dd-external-data-source">external
+          data source</a>.
       </dd>
 
-      <dt id="data-uri">data URI <code class="placeholder">{}</code></dt>
+      <dt id="data-uri">data URI <code
+          class="placeholder">{CONNECTOR_ID://COLLECTION_OWNER/COLLECTION_NAME[/FILE_NAME]}</code></dt>
       <dd id="dd-data-uri">
-        Identifier that describes the location of a hosted data collection or native data connector to the API. The
-        location may
-        be a file “bucket” (i.e., a folder or directory) or a file itself.
-
+        Identifier that describes the location of a <a class="glossary-hoverable" href="#hosted-data-collection"
+          title="" parentId="dd-hosted-data-collection">hosted data collection</a> or native <a
+          class="glossary-hoverable" href="#data-connector" title="" parentId="dd-data-connector">data connector</a> to
+        the <a class="glossary-hoverable" href="#api" title="" parentId="dd-api">API</a>. The location may be a <a
+          class="glossary-hoverable" href="#file" title="" parentId="dd-file">file</a> “bucket”
+        (i.e., a <a class="glossary-hoverable" href="#folder" title="" parentId="dd-folder">folder</a> or
+        <a class="glossary-hoverable" href="#directory" title="" parentId="dd-directory">directory</a>) or a file
+        itself.
       </dd>
 
-      <dt id="developer-center">Developer Center <code class="placeholder">{}</code></dt>
+      <dt id="developer-center">Developer Center <code class="placeholder">{/developers}</code></dt>
       <dd id="dd-developer-center">
-        Quick-reference Algorithmia documentation. Description here.
+        Quick-reference Algorithmia technical documentation.
       </dd>
 
-      <dt id="directory">directory <code class="placeholder">{}</code></dt>
+      <dt id="directory">directory <code class="placeholder">{DIR_NAME}</code></dt>
       <dd id="dd-directory">
-        Generic term for “bucket” that can hold files. Used synonymously with folder.
+        Generic term for “bucket” that can hold <a class="glossary-hoverable" href="#file" title=""
+          parentId="dd-file">files</a>. Used synonymously with <a class="glossary-hoverable" href="#folder" title=""
+          parentId="dd-folder">folder</a>.
       </dd>
 
-      <dt id="event-flow">Event Flow <code class="placeholder">{}</code></dt>
+      <dt id="event-flow">Event Flow</dt>
       <dd id="dd-event-flow">
-        Publisher or subscriber algorithm configured to read records from or write records to a message broker.
+        <a class="glossary-hoverable" href="#publisher" title="" parentId="dd-publisher">Publisher</a> or <a
+          class="glossary-hoverable" href="#subscriber" title="" parentId="dd-subscriber">subscriber</a>
+        <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">algorithm</a> configured to
+        read <a class="glossary-hoverable" href="#record" title="" parentId="dd-record">records</a> from or write
+        records to a <a class="glossary-hoverable" href="#message-broker" title="" parentId="dd-message-broker">message
+          broker</a>.
       </dd>
 
-      <dt id="event-listener">event listener <code class="placeholder">{}</code></dt>
+      <dt id="event-listener">event listener</dt>
       <dd id="dd-event-listener">
-        Not used. See event flow.
+        Not used. See <a class="glossary-hoverable" href="#event-flow" title="" parentId="dd-event-flow">Event Flow</a>.
       </dd>
 
-      <dt id="event-manager">event manager <code class="placeholder">{}</code></dt>
+      <dt id="event-manager">event manager</dt>
       <dd id="dd-event-manager">
-        Not used. See message broker.
+        Not used. See <a class="glossary-hoverable" href="#message-broker" title="" parentId="dd-message-broker">message
+          broker</a>.
       </dd>
 
-      <dt id="external-data-source">external data source <code class="placeholder">{}</code></dt>
+      <dt id="external-data-source">external data source</dt>
       <dd id="dd-external-data-source">
-        Data source to which algorithms can connect using external standard SDKs and APIs but to which Algorithmia
-        doesn’t
-        provide a built-in data connector. [We differentiate between native data connectors and external data sources
-        because
-        connectors are supported through the API.]
+        <a class="glossary-hoverable" href="#data-source" title="" parentId="dd-data-source">Data source</a> to which <a
+          class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">algorithms</a> can connect using
+        external standard SDKs and APIs but to which
+        Algorithmia doesn’t provide a built-in <a class="glossary-hoverable" href="#data-connector" title=""
+          parentId="dd-data-connector">data connector</a> accessible through the <a class="glossary-hoverable"
+          href="#api" title="" parentId="dd-api">API</a>.
       </dd>
 
-      <dt id="file">file <code class="placeholder">{}</code></dt>
+      <dt id="file">file <code class="placeholder">{FILE_NAME}</code></dt>
       <dd id="dd-file">
-        A file of any type (text, JSON, binary, etc.) in local, hosted, cloud, or other storage.
+        A file of any type (text, JSON, binary, etc.) in local, <a class="glossary-hoverable"
+          href="#hosted-data-collection" title="" parentId="dd-hosted-data-collection">hosted</a>, cloud, or other
+        storage.
       </dd>
 
-      <dt id="folder">folder <code class="placeholder">{}</code></dt>
+      <dt id="folder">folder <code class="placeholder">{FOLDER_NAME}</code></dt>
       <dd id="dd-folder">
-        Generic term for “bucket” that can hold files. Used synonymously with directory.
+        Generic term for “bucket” that can hold <a class="glossary-hoverable" href="#file" title=""
+          parentId="dd-file">files</a>. Used synonymously with <a class="glossary-hoverable" href="#directory" title=""
+          parentId="dd-directory">directory</a>.
       </dd>
 
-      <dt id="general-purpose-node">general purpose node <code class="placeholder">{}</code></dt>
+      <dt id="general-purpose-node">general purpose node</dt>
       <dd id="dd-general-purpose-node">
-        Node in Algorithmia’s Kubernetes environment that manages and schedules Algorithmia services (with the exception
-        of
-        algorithm workers) providing services such as logging, storage, source code management, billing, etc.
+        <a class="glossary-hoverable" href="#node" title="" parentId="dd-node">Node</a> in Algorithmia’s Kubernetes
+        environment that manages and schedules Algorithmia services (with the exception
+        of <a class="glossary-hoverable" href="#worker-node" title="" parentId="dd-worker-node"> algorithm worker
+          nodes</a>) providing services such as logging, storage, <a class="glossary-hoverable"
+          href="#source-code-management" title="" parentId="dd-source-code-management">source code
+          management</a>, billing, etc.
       </dd>
 
-      <dt id="grafana">Grafana <code class="placeholder">{}</code></dt>
+      <dt id="grafana">Grafana</dt>
       <dd id="dd-grafana">
         Numeric metrics visualization dashboard provisioned with each Algorithmia Enterprise installation.
       </dd>
 
-      <dt id="hosted-data-collection">hosted data collection <code class="placeholder">{}</code></dt>
+      <dt id="hosted-data-collection">hosted data collection <code class="placeholder">{COLLECTION_NAME}</code></dt>
       <dd id="dd-hosted-data-collection">
         Object storage hosted on the Algorithmia platform. Data collections are not “file storage” in that they can’t
         store
         nested data or data with a “/” character in the path.
       </dd>
 
-      <dt id="hot-algorithm">hot algorithm <code class="placeholder">{}</code></dt>
+      <dt id="hot-algorithm">hot algorithm</dt>
       <dd id="dd-hot-algorithm">
-        Algorithm instance actively handling an algorithm execution request.
+        <a class="glossary-hoverable" href="#algorithm-instance" title="" parentId="dd-algorithm-instance">Algorithm
+          instance</a> actively handling an <a class="glossary-hoverable" href="#algorithm-execution-request" title=""
+          parentId="dd-algorithm-execution-request">algorithm execution request</a>.
       </dd>
 
-      <dt id="json-web-token">JSON Web Token (JWT) <code class="placeholder">{}</code></dt>
+      <dt id="http-method">HTTP method</dt>
+      <dd id="dd-http-method">
+        Verb used to indicate an interaction with a <a class="glossary-hoverable" href="#resource" title=""
+          parentId="dd-resource">resource</a> through the REST <a class="glossary-hoverable" href="#api" title=""
+          parentId="dd-api">API</a>. Algorithmia primarily uses <code>GET</code>, <code>PUT</code>, <code>POST</code>,
+        <code>DELETE</code>, <code>HEAD</code>, and <code>PATCH</code> methods.
+      </dd>
+
+      <dt id="json-web-token">JSON Web Token (JWT) <code class="placeholder">{JSON_WEB_TOKEN}</code></dt>
       <dd id="dd-json-web-token">
         Open, industry-standard RFC 7519 method for representing proof of secure communication between two parties. On
-        Algorithmia a JWT can be used as an authentication token to grant an identity access to perform authenticated
-        resource
-        requests. If configured, permission tags can be extracted from a JWT and used to facilitate external management
-        of
-        organization membership and user security roles.
+        Algorithmia a JWT can be used as an <a class="glossary-hoverable" href="#authentication-token" title=""
+          parentId="dd-authentication-token">authentication token</a> to grant an <a class="glossary-hoverable"
+          href="#identity" title="" parentId="dd-identity">identity</a> access to perform
+        <a class="glossary-hoverable" href="#authenticated-resource-request" title=""
+          parentId="dd-authenticated-resource-request">authenticated resource requests</a>. If configured, permission
+        tags can be extracted from a JWT and used to facilitate external management of <a class="glossary-hoverable"
+          href="#org-organization" title="" parentId="dd-org-organization">organization</a> membership and <a
+          class="glossary-hoverable" href="#user" title="" parentId="dd-user">user</a> security roles.
       </dd>
 
-      <dt id="identity">identity <code class="placeholder">{}</code></dt>
+      <dt id="identity">identity</dt>
       <dd id="dd-identity">
-        Digital representation of a real-world entity that attempts to access a resource. This could be a human user, a
-        service
-        account, or a server, for example.
+        Digital representation of a real-world entity that attempts to access a <a class="glossary-hoverable"
+          href="#resource" title="" parentId="dd-resource">resource</a>. This could be a human <a
+          class="glossary-hoverable" href="#user" title="" parentId="dd-user">user</a>, a
+        <a class="glossary-hoverable" href="#service-account" title="" parentId="dd-service-account">service
+          account</a>, or a server, for example.
       </dd>
 
-      <dt id="kibana">Kibana <code class="placeholder">{}</code></dt>
+      <dt id="kibana">Kibana</dt>
       <dd id="dd-kibana">
         Log query and visualization tool provisioned with each Algorithmia Enterprise installation.
       </dd>
 
-      <dt id="machine-learning">machine learning (ML) <code class="placeholder">{}</code></dt>
+      <dt id="machine-learning">machine learning (ML)</dt>
       <dd id="dd-machine-learning">
         Application of artificial intelligence in which a computer system uses algorithms and statistical models to
         analyze and draw inferences from patterns in data, learning and adapting in order to make decisions without
@@ -702,419 +826,513 @@
 
       <dt id="machine-learning-operations">machine learning operations (MLOps)
       <dd id="dd-machine-learning-operations">
-        The discipline of delivering ML models through repeatable and efficient workflows.
+        The discipline of delivering <a class="glossary-hoverable" href="#machine-learning" title=""
+          parentId="dd-machine-learning">ML</a> <a class="glossary-hoverable" href="#model" title=""
+          parentId="dd-model">models</a> through repeatable and efficient workflows.
       </dd>
-      <dt id="master-node">master node <code class="placeholder">{}</code></dt>
+
+      <dt id="master-node">master node</dt>
       <dd id="dd-master-node">
-        Not used. See control plane node.
+        Deprecated. See <a class="glossary-hoverable" href="#control-plane-node" title=""
+          parentId="dd-control-plane-node">control plane node</a>.
       </dd>
 
-      <dt id="message-broker">message broker <code class="placeholder">{}</code></dt>
+      <dt id="message-broker">message broker</dt>
       <dd id="dd-message-broker">
-        Event-processing tool that stores records from publishers in a log or queue and makes them available to be read
-        by
-        subscribers.
+        Event-processing tool that stores <a class="glossary-hoverable" href="#record" title=""
+          parentId="dd-record">record</a> from <a class="glossary-hoverable" href="#publisher" title=""
+          parentId="dd-publisher">publishers</a> in a log or queue and makes them available to be read
+        by <a class="glossary-hoverable" href="#subscriber" title="" parentId="dd-subscriber">subscribers</a>.
       </dd>
 
-      <dt id="message-broker-connection">message broker connection <code class="placeholder">{}</code></dt>
+      <dt id="message-broker-connection">message broker connection</dt>
       <dd id="dd-message-broker-connection">
-        Cluster-level connection to a message broker, configured by a cluster admin.
+        <a class="glossary-hoverable" href="#cluster" title="" parentId="dd-cluster">Cluster</a>-level connection to a
+        <a class="glossary-hoverable" href="#message-broker" title="" parentId="dd-message-broker">message broker</a>,
+        configured by a <a class="glossary-hoverable" href="#cluster-admin-account" title=""
+          parentId="dd-cluster-admin-account">cluster admin</a>.
       </dd>
 
-      <dt id="ml-service-catalog">ML service catalog <code class="placeholder">{}</code></dt>
+      <dt id="ml-service-catalog">ML service catalog <code class="placeholder">{/algorithms}</code></dt>
       <dd id="dd-ml-service-catalog">
-        Library of versioned algorithms ready to be served for inference.
+        Library of versioned <a class="glossary-hoverable" href="#algorithm" title=""
+          parentId="dd-algorithm">algorithms</a> ready to be served for inference.
       </dd>
 
-      <dt id="model">model <code class="placeholder">{MODEL_NAME}</code></dt>
+      <dt id="model">model <code class="placeholder">{MODEL_FILE}</code></dt>
       <dd id="dd-model">
         <a class="glossary-hoverable" href="#machine-learning" title="" parentId="dd-machine-learning">ML</a> model
-        file that’s ready to be loaded into an algorithm and used for inference. Synonymous with <a
-          class="glossary-hoverable" href="#serialized-model" title="" parentId="dd-serialized-model">serialized
+        <a class="glossary-hoverable" href="#file" title="" parentId="dd-file">file</a> that’s ready to be loaded into
+        an <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">algorithm</a> and used for
+        inference. Synonymous with <a class="glossary-hoverable" href="#serialized-model" title=""
+          parentId="dd-serialized-model">serialized
           model</a> and <a class="glossary-hoverable" href="#trained-model" title="" parentId="dd-trained-model">trained
-          model</a>.
+          model</a>. Also used in a general sense to refer to an <a class="glossary-hoverable" href="#machine-learning"
+          title="" parentId="dd-machine-learning">ML</a> model.
       </dd>
 
-      <dt id="model-explainability">model explainability <code class="placeholder">{}</code></dt>
+      <dt id="model-explainability">model explainability</dt>
       <dd id="dd-model-explainability">
-        Ability to explain how a model was built and the reasons for its outputs. In some contexts this is used
-        interchangeably
-        with model interpretability.
+        Ability to explain how a <a class="glossary-hoverable" href="#model" title="" parentId="dd-model">model</a> was
+        built and the reasons for its outputs. In some contexts this is used
+        interchangeably with <a class="glossary-hoverable" href="#model-interpretability" title=""
+          parentId="dd-model-interpretability">model interpretability</a>.
       </dd>
 
-      <dt id="model-governance">model governance <code class="placeholder">{}</code></dt>
+      <dt id="model-governance">model governance</dt>
       <dd id="dd-model-governance">
-        Process for how a company controls access to models, implements policy surrounding models, and tracks activity
-        of
-        models.
+        Process for how a company controls access to <a class="glossary-hoverable" href="#model" title=""
+          parentId="dd-model">models</a>, implements policy surrounding models, and tracks activity of models.
       </dd>
 
-      <dt id="model-interpretability">model interpretability <code class="placeholder">{}</code></dt>
+      <dt id="model-interpretability">model interpretability</dt>
       <dd id="dd-model-interpretability">
-        Ability to understand the cause of a model decision. This can also refer to the ability for a human to
-        understand and
+        Ability to understand the cause of a <a class="glossary-hoverable" href="#model" title=""
+          parentId="dd-model">model</a> decision. This can also refer to the ability for a human to understand and
         predict a model’s output, or the ability to observe cause and effect by changing model parameters. In some
-        contexts this
-        is used interchangeably with model explainability.
+        contexts this is used interchangeably with <a class="glossary-hoverable" href="#model-explainability" title=""
+          parentId="dd-model-explainability">model explainability</a>.
       </dd>
 
-      <dt id="model-monitoring">model monitoring <code class="placeholder">{}</code></dt>
+      <dt id="model-monitoring">model monitoring</dt>
       <dd id="dd-model-monitoring">
-        Ability to assess a model’s performance, accuracy, drift, and errors.
+        Ability to assess a <a class="glossary-hoverable" href="#model" title="" parentId="dd-model">model's</a>
+        performance, accuracy, drift, and errors.
       </dd>
 
-      <dt id="model-observability">model observability <code class="placeholder">{}</code></dt>
+      <dt id="model-observability">model observability</dt>
       <dd id="dd-model-observability">
-        Ability to assess the state of a model through metrics and logs, and to understand and diagnose the operational
-        health of a model.
+        Ability to assess the state of a <a class="glossary-hoverable" href="#model" title=""
+          parentId="dd-model">model</a> through metrics and logs, and to understand and diagnose the operational health
+        of a model.
       </dd>
 
-      <dt id="model-validation">model validation <code class="placeholder">{}</code></dt>
+      <dt id="model-validation">model validation</dt>
       <dd id="dd-model-validation">
-        Ability to confirm that outputs of a model are acceptable given real-world inputs.
+        Ability to confirm that outputs of a <a class="glossary-hoverable" href="#model" title=""
+          parentId="dd-model">model</a> are acceptable given real-world inputs.
       </dd>
 
-      <dt id="mothership-cluster">mothership cluster <code class="placeholder">{}</code></dt>
+      <dt id="mothership-cluster">mothership cluster</dt>
       <dd id="dd-mothership-cluster">
-        Standard Algorithmia Enterprise cluster, consisting of a number of services for algorithm creation, management,
-        and
-        execution. A mothership cluster runs in an Algorithmia-installed and configured Kubernetes cluster on customer
+        Standard Algorithmia Enterprise <a class="glossary-hoverable" href="#cluster" title=""
+          parentId="dd-cluster">cluster</a>, consisting of a number of services for <a class="glossary-hoverable"
+          href="#algorithm" title="" parentId="dd-algorithm">algorithm</a> creation, management, and execution. A
+        mothership cluster runs in an Algorithmia-installed and configured Kubernetes cluster on customer
         infrastructure.
       </dd>
 
-      <dt id="node">node <code class="placeholder">{}</code></dt>
+      <dt id="node">node</dt>
       <dd id="dd-node">
-        Generic term for control plane node, general purpose node, or worker node in Algorithmia’s Kubernetes
-        environment. A
-        node is a virtualized compute resource on which Algorithmia services are run.
+        Generic term for virtualized compute resource on which Algorithmia services are run. In Algorithmia’s Kubernetes
+        environment, a node may be a <a class="glossary-hoverable" href="#control-plane-node" title=""
+          parentId="dd-control-plane-node">control plane
+          node</a>, <a class="glossary-hoverable" href="#general-purpose-node" title=""
+          parentId="dd-general-purpose-node">general purpose node</a>, or <a class="glossary-hoverable"
+          href="#worker-node" title="" parentId="dd-worker-node">worker node</a>.
       </dd>
 
-      <dt id="open-source-algorithm">open-source algorithm <code class="placeholder">{}</code></dt>
+      <dt id="open-source-algorithm">open-source algorithm</dt>
       <dd id="dd-open-source-algorithm">
-        Algorithm published with source code visible via an authenticated resource request to the cluster if it’s a
-        public
-        algorithm. If it’s a private algorithm, the source code is only visible via authenticated resource requests from
-        the
-        account owning the algorithm.
+        <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">Algorithm</a> published with
+        source code visible via an <a class="glossary-hoverable" href="#authenticated-resource-request" title=""
+          parentId="dd-authenticated-resource-request">authenticated resource request</a> to the <a
+          class="glossary-hoverable" href="#cluster" title="" parentId="dd-cluster">cluster</a> if it’s a
+        <a class="glossary-hoverable" href="#public-algorithm" title="" parentId="dd-public-algorithm">public
+          algorithm</a>. If it’s a <a class="glossary-hoverable" href="#private-algorithm" title=""
+          parentId="dd-private-algorithm">private algorithm</a>, the source code is only visible via authenticated
+        resource requests from the <a class="glossary-hoverable" href="#account" title=""
+          parentId="dd-account">account</a>
+        that owns the algorithm.
       </dd>
 
-      <dt id="orchestration-algorithm">orchestration algorithm <code class="placeholder">{}</code></dt>
+      <dt id="orchestration-algorithm">orchestration algorithm</dt>
       <dd id="dd-orchestration-algorithm">
-        Algorithm that receives an API request directly from a caller and calls other algorithms internally in a
-        pipeline.
-        Synonymous with parent algorithm and top-level algorithm.
+        <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">Algorithm</a> that receives an
+        <a class="glossary-hoverable" href="#api" title="" parentId="dd-api">API</a> request directly from a <a
+          class="glossary-hoverable" href="#caller" title="" parentId="dd-caller">caller</a> and calls other algorithms
+        internally in a <a class="glossary-hoverable" href="#algorithm-pipelining" title=""
+          parentId="dd-algorithm-pipelining">pipeline</a>. Synonymous with <a class="glossary-hoverable"
+          href="#parent-algorithm" title="" parentId="dd-parent-algorithm">parent algorithm</a> and <a
+          class="glossary-hoverable" href="#top-level-algorithm" title="" parentId="dd-top-level-algorithm">top-level
+          algorithm</a>.
       </dd>
 
-      <dt id="org-organization">org/organization <code class="placeholder">{}</code></dt>
+      <dt id="org-organization">org/organization <code class="placeholder">{ORG_NAME}</code></dt>
       <dd id="dd-org-organization">
-        Logical construct for sharing resource access with an arbitrary number of accounts on the cluster. An org must
-        have at
-        least one org admin, and orgs can’t be deleted once created. Accounts can be members of zero, one, or multiple
-        orgs.
+        Logical construct for sharing <a class="glossary-hoverable" href="#resource" title=""
+          parentId="dd-resource">resource</a> access with an arbitrary number of <a class="glossary-hoverable"
+          href="#account" title="" parentId="dd-account">accounts</a> on the <a class="glossary-hoverable"
+          href="#cluster" title="" parentId="dd-cluster">cluster</a>. An org must
+        have at least one <a class="glossary-hoverable" href="#org-admin-account" title=""
+          parentId="dd-org-admin-account">org admin</a>, and orgs can’t be deleted once created. Accounts can be members
+        of zero, one, or multiple orgs.
       </dd>
 
-      <dt id="org-admin">org admin <code class="placeholder">{}</code></dt>
-      <dd id="dd-org-admin">
-        Account that has elevated privileges within a specific org of which it’s a member. Anyone who creates an org is
+      <dt id="org-admin-account">org admin account<code class="placeholder">{ORG_ADMIN_NAME}</code></dt>
+      <dd id="dd-org-admin-account">
+        <a class="glossary-hoverable" href="#account" title="" parentId="dd-account">Account</a> that has elevated
+        privileges within a specific <a class="glossary-hoverable" href="#org-organization" title=""
+          parentId="dd-org-organization">org</a> of which it’s a member. Anyone who creates an org is
         automatically given the org admin role, and an account can be an org admin for zero, one, or multiple orgs. Org
-        admin and cluster admin roles aren’t related.
+        admin and <a class="glossary-hoverable" href="#cluster-admin-account" title=""
+          parentId="dd-cluster-admin-account">cluster admin</a> roles aren’t related.
       </dd>
 
-      <dt id="org-profile">org profile <code class="placeholder">{}</code></dt>
+      <dt id="org-profile">org profile <code class="placeholder">{/organizations/ORG_NAME}</code></dt>
       <dd id="dd-org-profile">
-        Profile page for an org.
+        Profile page for an <a class="glossary-hoverable" href="#org-organization" title=""
+          parentId="dd-org-organization">org</a>.
       </dd>
 
       <dt id="parent-algorithm">parent algorithm <code class="placeholder">{}</code></dt>
       <dd id="dd-parent-algorithm">
-        Algorithm that receives an API request directly from a caller and calls other algorithms internally in a
-        pipeline.
-        Synonymous with orchestration algorithm and top-level algorithm.
+        <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">Algorithm</a> that receives an
+        API request directly from a caller and calls other algorithms internally in a
+        <a class="glossary-hoverable" href="#algorithm-pipelining" title=""
+          parentId="dd-algorithm-pipelining">pipeline</a>. Synonymous with <a class="glossary-hoverable"
+          href="#orchestration-algorithm" title="" parentId="dd-orchestration-algorithm">orchestration algorithm</a> and
+        <a class="glossary-hoverable" href="#top-level-algorithm" title="" parentId="dd-top-level-algorithm">top-level
+          algorithm</a>.
       </dd>
 
       <dt id="password">password <code class="placeholder">{}</code></dt>
       <dd id="dd-password">
-        Authentication factor used to authenticate to access the resources associated with an account on the Algorithmia
-        platform.
+        <a class="glossary-hoverable" href="#authentication-factor" title=""
+          parentId="dd-authentication-factor">Authentication factor</a> used to <a class="glossary-hoverable"
+          href="#authentication" title="" parentId="dd-authentication">authenticate</a> to access the <a
+          class="glossary-hoverable" href="#resource" title="" parentId="dd-resource">resources</a>
+        associated with an <a class="glossary-hoverable" href="#account" title="" parentId="dd-account">account</a> on
+        an Algorithmia <a class="glossary-hoverable" href="#cluster" title="" parentId="dd-cluster">cluster</a>.
       </dd>
 
-      <dt id="platform-version">platform version <code class="placeholder">{}</code></dt>
+      <dt id="platform-version">platform version</dt>
       <dd id="dd-platform-version">
-        Semantic version of Algorithmia’s software, for example “20.4.7” or “v20.4.7”.
+        Semantic version of Algorithmia’s software, e.g., “20.4.7” or “v20.4.7”.
       </dd>
 
-      <dt id="private-algorithm">private algorithm <code class="placeholder">{}</code></dt>
+      <dt id="private-algorithm">private algorithm</dt>
       <dd id="dd-private-algorithm">
-        Algorithm published privately that can only be called by the account or org that owns the algorithm.
+        <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">Algorithm</a> published
+        privately that can only be called by the <a class="glossary-hoverable" href="#account" title=""
+          parentId="dd-account">account</a> or <a class="glossary-hoverable" href="#org-organization" title=""
+          parentId="dd-org-organization">org</a> that owns the algorithm, or from an account that's a member of an org
+        that owns the algorithm.
       </dd>
 
-      <dt id="producer">producer <code class="placeholder">{}</code></dt>
+      <dt id="producer">producer</dt>
       <dd id="dd-producer">
-        Not used. See publisher.
+        Not used. See <a class="glossary-hoverable" href="#publisher" title="" parentId="dd-publisher">publisher</a>.
       </dd>
 
-      <dt id="public-algorithm">public algorithm <code class="placeholder">{}</code></dt>
+      <dt id="public-algorithm">public algorithm</dt>
       <dd id="dd-public-algorithm">
-        Algorithm published publicly that can be called by any account or org on the cluster.
+        <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">Algorithm</a> published
+        publicly that can be called by any <a class="glossary-hoverable" href="#authentication" title=""
+          parentId="dd-authentication">authenticated</a> <a class="glossary-hoverable" href="#account" title=""
+          parentId="dd-account">account</a> on the <a class="glossary-hoverable" href="#cluster" title=""
+          parentId="dd-cluster">cluster</a>.
       </dd>
 
-      <dt id="publisher">publisher <code class="placeholder">{}</code></dt>
+      <dt id="publisher">publisher</dt>
       <dd id="dd-publisher">
-        Entity that sends records to a message broker. Synonymous with producer.
+        Entity that sends <a class="glossary-hoverable" href="#record" title="" parentId="dd-record">records</a> to a <a
+          class="glossary-hoverable" href="#message-broker" title="" parentId="dd-message-broker">message broker</a>.
+        Synonymous with <a class="glossary-hoverable" href="#producer" title="" parentId="dd-producer">producer</a>.
       </dd>
 
-      <dt id="record">record <code class="placeholder">{}</code></dt>
+      <dt id="record">record</dt>
       <dd id="dd-record">
-        Data or message sent to or retrieved from a message broker. Also used to refer to a row of data in a relational
-        database
-        table.
+        Data or message sent to or retrieved from a <a class="glossary-hoverable" href="#message-broker" title=""
+          parentId="dd-message-broker">message broker</a>. Also used to refer to a row of data in a relational
+        database table.
       </dd>
 
-      <dt id="replica">replica <code class="placeholder">{}</code></dt>
+      <dt id="replica">replica <code class="placeholder">{CALLER_NAME/ALGO_NAME/ALGO_VERSION}</code></dt>
       <dd id="dd-replica">
-        Individual instance of a specific algorithm running on a worker node.
+        Individual <a class="glossary-hoverable" href="#algorithm-instance" title=""
+          parentId="dd-algorithm-instance">instance</a> of a specific <a class="glossary-hoverable" href="#algorithm"
+          title="" parentId="dd-algorithm">algorithm</a> running on a <a class="glossary-hoverable"
+          href="#algorithm-worker-node" title="" parentId="dd-algorithm-worker-node">worker node</a>.
       </dd>
 
-      <dt id="reservation">reservation <code class="placeholder">{}</code></dt>
+      <dt id="reservation">reservation</dt>
       <dd id="dd-reservation">
-        Algorithm instance kept warm to eliminate cold-start overhead. Reservations are only configurable by cluster
-        admins.
+        <a class="glossary-hoverable" href="#algorithm-instance" title="" parentId="dd-algorithm-instance">Algorithm
+          instance</a> kept warm to eliminate cold-start overhead. Reservations are only configurable by <a
+          class="glossary-hoverable" href="#cluster-admin-account" title="" parentId="dd-cluster-admin-account">cluster
+          admins</a>.
       </dd>
 
-      <dt id="resource">resource <code class="placeholder">{}</code></dt>
+      <dt id="resource">resource</dt>
       <dd id="dd-resource">
-        Data on the Algorithmia platform. Examples include algorithms, files stored on the platform or available through
-        the
-        platform, account information, etc.
+        Data on the Algorithmia platform. Examples include <a class="glossary-hoverable" href="#algorithm" title=""
+          parentId="dd-algorithm">algorithms</a>, <a class="glossary-hoverable" href="#file" title=""
+          parentId="dd-file">files</a> stored on the platform or available through the platform, <a
+          class="glossary-hoverable" href="#account" title="" parentId="dd-account">account</a> information, etc.
       </dd>
 
-      <dt id="resource-request">resource request <code class="placeholder">{}</code></dt>
+      <dt id="resource-request">resource request</dt>
       <dd id="dd-resource-request">
-        Attempt by an identity to access a resource on the Algorithmia platform. Examples include executing an
-        algorithm,
-        publishing a new version of an algorithm, reading from or writing to a data source, etc.
+        Attempt by an <a class="glossary-hoverable" href="#identity" title="" parentId="dd-identity">identity</a> to
+        access a <a class="glossary-hoverable" href="#resource" title="" parentId="dd-resource">resource</a> on the
+        Algorithmia platform. Examples include executing an
+        <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">algorithm</a>,
+        publishing a new <a class="glossary-hoverable" href="#algorithm-version" title=""
+          parentId="dd-algorithm-version">version</a> of an algorithm, reading from or writing to a <a
+          class="glossary-hoverable" href="#data-source" title="" parentId="dd-data-source">data source</a>, etc.
       </dd>
 
-      <dt id="resource-uri">resource URI <code class="placeholder">{}</code></dt>
+      <dt id="resource-uri">resource URI <code class="placeholder">{BASE_API_URL/path/to/endpoint}</code></dt>
       <dd id="dd-resource-uri">
-        Full path at which a resource exists, equivalent to API base URL + API endpoint.
+        Full path at which a <a class="glossary-hoverable" href="#resource" title="" parentId="dd-resource">resource</a>
+        exists, equivalent to <a class="glossary-hoverable" href="#base-api-url" title="" parentId="dd-base-api-url">
+          base API URL</a> + <a class="glossary-hoverable" href="#api-endpoint" title="" parentId="dd-api-endpoint">API
+          endpoint</a>.
       </dd>
 
-      <dt id="satellite-cluster">satellite cluster <code class="placeholder">{}</code></dt>
+      <dt id="satellite-cluster">satellite cluster <code class="placeholder">{SATELLITE_ID}</code></dt>
       <dd id="dd-satellite-cluster">
-        Minimal version of Algorithmia Enterprise cluster with a subset of services, including algorithms, a RabbitMQ
-        queuing
-        system, configuration information, and an API server to handle algorithm execution requests. A satellite cluster
-        runs in
-        a customer-provided Kubernetes cluster on customer infrastructure.
+        Minimal version of Algorithmia Enterprise <a class="glossary-hoverable" href="#cluster" title=""
+          parentId="dd-cluster">cluster</a> with a subset of services, including <a class="glossary-hoverable"
+          href="#algorithm" title="" parentId="dd-algorithm">algorithms</a>, a RabbitMQ queuing system, configuration
+        information, and an <a class="glossary-hoverable" href="#api" title="" parentId="dd-api">API</a> server to
+        handle <a class="glossary-hoverable" href="#algorithm-execution-request" title=""
+          parentId="dd-algorithm-execution-request">algorithm execution requests</a>. A satellite cluster runs in a
+        customer-provided Kubernetes cluster on
+        customer infrastructure.
       </dd>
 
-      <dt id="satellite-launce-instance">satellite launce instance <code class="placeholder">{}</code></dt>
+      <dt id="satellite-launce-instance">satellite launce instance <code class="placeholder">{LAUNCH_ID}</code></dt>
       <dd id="dd-satellite-launce-instance">
-        Individual instance of a satellite deployment.
+        Individual instance of a <a class="glossary-hoverable" href="#satellite-cluster" title=""
+          parentId="dd-satellite-cluster">satellite</a> deployment.
       </dd>
 
-      <dt id="satellite-version">satellite version <code class="placeholder">{}</code></dt>
+      <dt id="satellite-version">satellite version <code class="placeholder">{SATELLITE_VERSION}</code></dt>
       <dd id="dd-satellite-version">
-        Version number associated with a specific satellite deployment. Each satellite version is configured with a
-        specific
-        list of included algorithms and authentication keys.
+        Version number associated with a specific <a class="glossary-hoverable" href="#satellite-cluster" title=""
+          parentId="dd-satellite-cluster">satellite</a> deployment. Each satellite version is configured with a
+        specific list of included <a class="glossary-hoverable" href="#algorithm" title=""
+          parentId="dd-algorithm">algorithms</a> and <a class="glossary-hoverable" href="#authentication-factor"
+          title="" parentId="dd-authentication-factor">authentication</a> keys.
       </dd>
 
-      <dt id="secret">secret <code class="placeholder">{}</code></dt>
+      <dt id="secret">secret <code class="placeholder">{SECRET_VALUE}</code></dt>
       <dd id="dd-secret">
-        Sensitive value (e.g., password, token, access key, credential, etc.) stored encrypted in the secret store and
-        accessed
-        from algorithm source code through an environment variable.
+        Sensitive value (e.g., password, token, access key, credential, etc.) stored encrypted in the <a
+          class="glossary-hoverable" href="#secret-store" title="" parentId="dd-secret-store">Secret Store</a> and
+        accessed from <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">algorithm</a>
+        source code through an environment variable.
       </dd>
 
-      <dt id="secret-store">Secret Store <code class="placeholder">{}</code></dt>
+      <dt id="secret-store">Secret Store</dt>
       <dd id="dd-secret-store">
         Secure, encrypted vault that stores sensitive information such as access keys to external services.
       </dd>
 
-      <dt id="serialized-model">serialized model <code class="placeholder">{MODEL_NAME}</code></dt>
+      <dt id="serialized-model">serialized model <code class="placeholder">{MODEL_FILE}</code></dt>
       <dd id="dd-serialized-model">
         <a class="glossary-hoverable" href="#machine-learning" title="" parentId="dd-machine-learning">ML</a> model
-        file that’s ready to be loaded into an algorithm and used for inference. Synonymous with <a
-          class="glossary-hoverable" href="#model" title="" parentId="dd-model">model</a> and <a
-          class="glossary-hoverable" href="#trained-model" title="" parentId="dd-trained-model">trained model</a>.
+        file that’s ready to be loaded into an <a class="glossary-hoverable" href="#algorithm" title=""
+          parentId="dd-algorithm">algorithm</a> and used for inference. Synonymous with <a class="glossary-hoverable"
+          href="#model" title="" parentId="dd-model">model</a> and <a class="glossary-hoverable" href="#trained-model"
+          title="" parentId="dd-trained-model">trained model</a>.
       </dd>
 
-      <dt id="service-account">service account <code class="placeholder">{}</code></dt>
+      <dt id="service-account">service account <code class="placeholder">{ACCOUNT_NAME}</code></dt>
       <dd id="dd-service-account">
-        Account not associated with a specific human.
+        <a class="glossary-hoverable" href="#account" title="" parentId="dd-account">Account</a> not associated with a
+        specific human.
       </dd>
 
-      <dt id="slot">slot <code class="placeholder">{}</code></dt>
+      <dt id="slot">slot</dt>
       <dd id="dd-slot">
-        Deprecated. See replica.
+        Deprecated. See <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">replica</a>.
       </dd>
 
-      <dt id="scm-configuration">SCM configuration <code class="placeholder">{}</code></dt>
+      <dt id="scm-configuration">SCM configuration <code class="placeholder">{SCM_CONFIG_ID}</code></dt>
       <dd id="dd-scm-configuration">
-        Cluster-level details about an SCM provider, such as provider type and URLs, configured by a cluster admin using
-        a
-        key-value pair generated within the SCM provider’s platform. There may be zero, one, or multiple SCM
-        configurations for
-        one SCM provider.
+        <a class="glossary-hoverable" href="#cluster" title="" parentId="dd-cluster">Cluster</a>-level details about an
+        <a class="glossary-hoverable" href="#scm-provider" title="" parentId="dd-scm-provider">SCM provider</a>, such as
+        provider type and URLs, configured by a <a class="glossary-hoverable" href="#cluster-admin-account" title=""
+          parentId="dd-cluster-admin-account">cluster admin</a> using a key-value pair generated within the SCM
+        provider’s platform. There may be zero, one, or multiple SCM configurations for one SCM provider.
       </dd>
 
-      <dt id="scm-connection">SCM connection <code class="placeholder">{}</code></dt>
+      <dt id="scm-connection">SCM connection</dt>
       <dd id="dd-scm-connection">
-        Account-levels details that contain credentials for connecting to an SCM provider.
+        <a class="glossary-hoverable" href="#account" title="" parentId="dd-account">Account</a>-levels details that
+        contain credentials for connecting to an <a class="glossary-hoverable" href="#scm-provider" title=""
+          parentId="dd-scm-provider">SCM provider</a>.
       </dd>
 
-      <dt id="scm-provider">SCM provider <code class="placeholder">{}</code></dt>
+      <dt id="scm-provider">SCM provider</dt>
       <dd id="dd-scm-provider">
-        Third-party SCM system to which an SCM configuration can be created for hosting algorithm source code outside of
-        the
-        Algorithmia platform. See a list of supported providers here.
+        Third-party SCM system to which an <a class="glossary-hoverable" href="#scm-configuration" title=""
+          parentId="dd-scm-configuration">SCM configuration</a> can be created for hosting <a class="glossary-hoverable"
+          href="#algorithm" title="" parentId="dd-algorithm">algorithm</a> source code outside of the Algorithmia
+        platform.
       </dd>
 
-      <dt id="source-code-management">source code management (SCM) <code class="placeholder">{}</code></dt>
+      <dt id="source-code-management">source code management (SCM)</dt>
       <dd id="dd-source-code-management">
-        Process of tracking modifications to a source code repository. Synonymous with version control. Also synonymous
-        with
-        source control management; this term is used widely in the industry but for the purpose of consistency
-        Algorithmia
-        doesn’t use this term.
+        Process of tracking modifications to a source code repository. Synonymous with version control and source
+        control management.
       </dd>
 
-      <dt id="subscriber">subscriber <code class="placeholder">{}</code></dt>
+      <dt id="subscriber">subscriber</dt>
       <dd id="dd-subscriber">
-        Entity that reads records from a message broker. Synonymous with consumer.
+        Entity that reads <a class="glossary-hoverable" href="#record" title="" parentId="dd-record">records</a> from a
+        <a class="glossary-hoverable" href="#message-broker" title="" parentId="dd-message-broker">message broker</a>.
+        Synonymous with <a class="glossary-hoverable" href="#consumer" title="" parentId="dd-consumer">consumer</a>.
       </dd>
 
-      <dt id="test-console">test console <code class="placeholder">{}</code></dt>
+      <dt id="test-console">test console</dt>
       <dd id="dd-test-console">
-        The purple console at the bottom of the Web IDE, where algorithms may be executed with sample input to test
-        their
-        functionality after building.
+        The purple console at the bottom of the <a class="glossary-hoverable" href="#web-ide" title=""
+          parentId="dd-web-ide">Web IDE</a>, where <a class="glossary-hoverable" href="#algorithm" title=""
+          parentId="dd-algorithm">algorithms</a> may be executed with sample input to test their functionality after
+        building.
       </dd>
 
-      <dt id="top-level-algorithm">top-level algorithm <code class="placeholder">{}</code></dt>
+      <dt id="top-level-algorithm">top-level algorithm</dt>
       <dd id="dd-top-level-algorithm">
-        Algorithm that receives an API request directly from a caller and calls other algorithms internally in a
-        pipeline.
-        Synonymous with orchestration algorithm and parent algorithm.
-
+        <a class="glossary-hoverable" href="#algorithm" title="" parentId="dd-algorithm">Algorithm</a> that receives an
+        <a class="glossary-hoverable" href="#api" title="" parentId="dd-api">API</a> request directly from a <a
+          class="glossary-hoverable" href="#caller" title="" parentId="dd-caller">caller</a> and calls other algorithms
+        internally in a <a class="glossary-hoverable" href="#algorithm-pipelining" title=""
+          parentId="dd-algorithm-pipelining">pipeline</a>. Synonymous with <a class="glossary-hoverable"
+          href="#orchestration-algorithm" title="" parentId="dd-orchestration-algorithm">orchestration algorithm</a> and
+        <a class="glossary-hoverable" href="#parent-algorithm" title="" parentId="dd-parent-algorithm">parent
+          algorithm</a>.
       </dd>
 
-      <dt id="topic">topic <code class="placeholder">{}</code></dt>
+      <dt id="topic">topic</dt>
       <dd id="dd-topic">
-        Feed within a message broker to which publishers send records and from which subscribers read records.
+        Feed within a <a class="glossary-hoverable" href="#message-broker" title="" parentId="dd-message-broker">message
+          broker</a> to which <a class="glossary-hoverable" href="#publisher" title=""
+          parentId="dd-publisher">publishers</a> send <a class="glossary-hoverable" href="#record" title=""
+          parentId="dd-record">records</a> and from which <a class="glossary-hoverable" href="#subscriber" title=""
+          parentId="dd-subscriber">subscribers</a> read records.
       </dd>
 
-      <dt id="trained-model">trained model <code class="placeholder">{MODEL_NAME}</code></dt>
+      <dt id="trained-model">trained model <code class="placeholder">{MODEL_FILE}</code></dt>
       <dd id="dd-trained-model">
         <a class="glossary-hoverable" href="#machine-learning" title="" parentId="dd-machine-learning">ML</a> model
-        file that’s ready to be loaded into an algorithm and used for inference. Synonymous with <a
-          class="glossary-hoverable" href="#model" title="" parentId="dd-model">model</a> and <a
-          class="glossary-hoverable" href="#serialized-model" title="" parentId="dd-serialized-model">serialized
-          model</a>.
+        file that’s ready to be loaded into an <a class="glossary-hoverable" href="#algorithm" title=""
+          parentId="dd-algorithm">algorithm</a> and used for inference. Synonymous with <a class="glossary-hoverable"
+          href="#model" title="" parentId="dd-model">model</a> and <a class="glossary-hoverable"
+          href="#serialized-model" title="" parentId="dd-serialized-model">serialized model</a>.
       </dd>
 
-      <dt id="training-center">Training Center <code class="placeholder">{}</code></dt>
+      <dt id="training-center">Training Center</dt>
       <dd id="dd-training-center">
-        Learning management system with tutorial-based training content.
+        Learning management system with tutorial-based training content, located at <a
+          href="https://training.algorithmia.com" target="_blank"
+          rel="noopener noreferrer">training.algorithmia.com</a>.
       </dd>
 
-      <dt id="user">user <code class="placeholder">{}</code></dt>
+      <dt id="user">user</dt>
       <dd id="dd-user">
         Human interacting with the Algorithmia platform. See identity.
       </dd>
 
-      <dt id="user-account">user account <code class="placeholder">{}</code></dt>
+      <dt id="user-account">user account <code class="placeholder">{ACCOUNT_NAME}</code></dt>
       <dd id="dd-user-account">
-        Account associated with a specific user.
+        <a class="glossary-hoverable" href="#account" title="" parentId="dd-account">Account</a> associated with a
+        specific user.
       </dd>
 
-      <dt id="unilog">UNILOG <code class="placeholder">{}</code></dt>
+      <dt id="unilog">UNILOG</dt>
       <dd id="dd-unilog">
         Text-based metrics visualization dashboard. Unilog data is the aggregation of application and (some) Kubernetes
         logs
-        from the various services in an Algorithmia cluster. These logs are used for debugging and stability monitoring
-        by
-        engineers, and can be accessed through Kibana by cluster admins only.
+        from the various services in an Algorithmia <a class="glossary-hoverable" href="#cluster" title=""
+          parentId="dd-cluster">cluster</a>. These logs are used for debugging and stability monitoring by engineers,
+        and can be accessed through Kibana by <a class="glossary-hoverable" href="#cluster-admin-account" title=""
+          parentId="dd-cluster-admin-account">cluster admins</a> only.
       </dd>
 
-      <dt id="warm-algorithm">warm algorithm <code class="placeholder">{}</code></dt>
+      <dt id="warm-algorithm">warm algorithm</dt>
       <dd id="dd-warm-algorithm">
-        Algorithm instance running on a worker node and ready to handle API requests.
+        Algorithm <a class="glossary-hoverable" href="#algorithm-instance" title=""
+          parentId="dd-algorithm-instance">instance</a> running on a
+        <a class="glossary-hoverable" href="#worker-node" title="" parentId="dd-worker-node">worker node</a> and ready
+        to handle <a class="glossary-hoverable" href="#api" title="" parentId="dd-api">API</a> requests.
       </dd>
 
-      <dt id="web-ide">Web IDE <code class="placeholder">{}</code></dt>
+      <dt id="web-ide">Web IDE</dt>
       <dd id="dd-web-ide">
         Algorithmia’s built-in source code editor and test console, accessible through the “Source” tab from an
-        algorithm’s
-        profile page.
+        algorithm’s profile page.
       </dd>
 
-      <dt id="worker-node">worker node <code class="placeholder">{}</code></dt>
+      <dt id="worker-node">worker node</dt>
       <dd id="dd-worker-node">
-        Compute node in Algorithmia’s Kubernetes environment on which algorithm instances are run.
+        Compute <a class="glossary-hoverable" href="#node" title="" parentId="dd-node">node</a> in Algorithmia’s
+        Kubernetes environment on which <a class="glossary-hoverable" href="#algorithm-instance" title=""
+          parentId="dd-algorithm-instance">algorithm instances</a> are run.
       </dd>
 
     </dl>
   </div>
-
-  <script>
-    // assign id to parent element, prepending "" to child element id
-    function assignParentId(parentNode) {
-      childElem = parentNode.childElem
-
-
-        .document.getElementById(childId).parentElement
-      parentElem.setAttribute("id", "" + childId)
-    }
-
-    // assign ids to all parent elements
-    function assignParentIds() {
-      terms = document.getElementsByTagName("dd")
-      for (let index = 0; index < terms.length; index++) {
-        assignParentId(terms[index]);
-
-      }
-    }
-
-
-    function assignTitle(parentId) {
-      elem = document.getElementById(parentId)
-      if (elem) {
-        return elem.innerText;
-      }
-      console.log("missing parentId: " + parentId)
-      return ""
-    }
-
-    var glossTerms = document.getElementsByClassName("glossary-hoverable");
-    for (i = 0; i < glossTerms.length; i++) {
-      currentElem = glossTerms.item(i);
-      parentId = currentElem.attributes.getNamedItem("parentId").nodeValue;
-      glossTerms.item(i).title = assignTitle(parentId);
-    }
-
-    function countIndexTerms() {
-      // pass
-    }
-
-    function countDefinitionTerms() {
-      // pass
-    }
-
-    // make sure that count of index items match count of glossary terms
-    function verifyTermCounts() {
-      // pass
-      indexCount = countIndexItems()
-      termCount = countTermItems()
-      if (indexCount !== termCount) {
-        console.log("Missing Index or Definition")
-        console.log("Index count: " + indexCount)
-        console.log("Term count: " + termCount)
-      }
-    }
-  </script>
 </body>
+<script>
+  // assign id to parent element, prepending "" to child element id
+  function assignParentId(parentNode) {
+    childElem = parentNode.childElem
+
+
+      .document.getElementById(childId).parentElement
+    parentElem.setAttribute("id", "" + childId)
+  }
+
+  // assign ids to all parent elements
+  function assignParentIds() {
+    terms = document.getElementsByTagName("dd")
+    for (let index = 0; index < terms.length; index++) {
+      assignParentId(terms[index]);
+
+    }
+  }
+
+
+  function assignTitle(parentId) {
+    elem = document.getElementById(parentId)
+    if (elem) {
+      return elem.innerText;
+    }
+    console.log("missing parentId: " + parentId)
+    return ""
+  }
+
+  var glossTerms = document.getElementsByClassName("glossary-hoverable");
+  for (i = 0; i < glossTerms.length; i++) {
+    currentElem = glossTerms.item(i);
+    parentId = currentElem.attributes.getNamedItem("parentId").nodeValue;
+    glossTerms.item(i).title = assignTitle(parentId);
+  }
+
+  function countIndexTerms() {
+    // pass
+  }
+
+  function countDefinitionTerms() {
+    // pass
+  }
+
+  // make sure that count of index items match count of glossary terms
+  function verifyTermCounts() {
+    // pass
+    indexCount = countIndexItems()
+    termCount = countTermItems()
+    if (indexCount !== termCount) {
+      console.log("Missing Index or Definition")
+      console.log("Index count: " + indexCount)
+      console.log("Term count: " + termCount)
+    }
+  }
+</script>
 
 </html>

--- a/_pages/glossary.html
+++ b/_pages/glossary.html
@@ -292,13 +292,13 @@
           parentId="dd-algorithm-pipelining">pipelined</a> together with other algorithms. The primary use case for
         algorithms on Algorithmia’s platform is to provide functionality for loading and calling <a
           class="glossary-hoverable" href="#machine-learning" title="" parentId="dd-machine-learning">ML</a> <a
-          class="glossary-hoverable" href="#model" title="" parentId="dd-model">models</a> for
-        inference, but the scope of tasks that algorithms can perform isn't constrained to this. For example,
-        algorithms can perform conventional deterministic algorithmic routines (e.g., binary search), can read and write
-        data, can be used to query or send data to an <a class="glossary-hoverable" href="#external-data-source"
-          title="" parentId="dd-external-data-source">external data source</a> such as a database, can perform utility
-        tasks such as downloading images and pre-processing structured or unstructured data, and can be configured to
-        orchestrate all of the above.
+          class="glossary-hoverable" href="#model" title="" parentId="dd-model">models</a> for inference, but the scope
+        of tasks that algorithms can perform isn't constrained to this. For example, algorithms can perform conventional
+        deterministic algorithmic routines (e.g., binary search), can read and write data, can be used to query or send
+        data to an <a class="glossary-hoverable" href="#external-data-source" title=""
+          parentId="dd-external-data-source">external data source</a> such as a database, can perform utility tasks such
+        as downloading images and pre-processing structured or unstructured data, and can be configured to orchestrate
+        all of the above.
       </dd>
 
       <dt id="algorithm-build">algorithm build <code class="placeholder">{ALGO_BUILD}</code></dt>

--- a/_pages/glossary.html
+++ b/_pages/glossary.html
@@ -286,7 +286,7 @@
 
       <dt id="algorithm">algorithm <code class="placeholder">{ALGO_NAME}</code></dt>
       <dd id="dd-algorithm">
-        Microservice on Algorithmia that accepts an input, may return an output, and may have side effects. An algorithm
+        Microservice on Algorithmia that accepts an input, returns an output, and may have side effects. An algorithm
         can only accept a JSON type as input, and if it returns an output, can only return a JSON type. Algorithms can
         be <a class="glossary-hoverable" href="#algorithm-pipelining" title=""
           parentId="dd-algorithm-pipelining">pipelined</a> together with other algorithms. The primary use case for

--- a/_pages/glossary.md
+++ b/_pages/glossary.md
@@ -1,9 +1,9 @@
 ---
-layout: article
-title: 'Glossary'
 excerpt: 'Algorithmia terminology guide'
-tags: [glossary]
+layout: article
 permalink: /glossary/
+title: 'Glossary'
+tags: [glossary]
 ---
 
 {% include_relative glossary.html %}

--- a/_pages/glossary.md
+++ b/_pages/glossary.md
@@ -1,0 +1,9 @@
+---
+layout: article
+title: 'Glossary'
+excerpt: 'Algorithmia terminology guide'
+tags: [glossary]
+permalink: /glossary/
+---
+
+{% include_relative glossary.html %}


### PR DESCRIPTION
[DOCS-238](https://algorithmia.atlassian.net/browse/DOCS-238) - create glossary page for dev center

- There are a few opening tags that don't have closing tags because Jekyll was not cooperating and was rendering the closing tags in plaintext. It seems to render just fine now, but just to note.
- Headers are not sentence case because the goal was for capitalization to not be arbitrary

## Checklist
- [x] My PR title includes a relevant Jira ticket name
- [ ] If no associated Jira ticket, my PR title is informative (individual commit messages are squashed in this repo)
- [x] Unnecessary text (notes, TODOs, etc.) has been removed
- [x] For YAML "front matter":
  - Properties are alphabetized
  - `permalink` and `redirect_from/to` properties have `/` at beginning and end (e.g., `/path/`)
- [x] Screenshots, if present, follow the [Screenshot guidelines](https://algorithmia.atlassian.net/wiki/spaces/CUSTOMERS/pages/1634861478/CFD+Style+Guide#Screenshots) which means:
  - Full browser width (browser at 100% zoom and 10-12" width)
  - Max 1000px
- [x] Grammar, style, tone, punctuation, etc. follow the Algorithmia [manual of style](https://docs.google.com/document/d/1PPVfgMkX7-EVGLPMhN1E485CAXu9QfhSLKM0lZhnZdU/edit?usp=sharing)
- [ ] Headers are “Sentence case with Proper Nouns capitalized”
- [x] Placeholder strings are `UPPER_SNAKE_CASE` and are named as in the [Glossary](https://docs.google.com/document/d/1bYs0j_a4v8LbkbS8r0x2SZ_J6mZ4sIt4w_60dq8iGh4/edit#heading=h.qov2yks2a685) where appropriate
