### PR TITLE
Debug platform menu

### DIFF
--- a/_pages/platform-administration.md
+++ b/_pages/platform-administration.md
@@ -4,7 +4,6 @@ layout: article_page
 redirect_from:
  - /admin/
  - /administration/
- - /platform-admin/
 show_related: false
 title: "Platform Administration"
 ---

--- a/_pages/platform-administration.md
+++ b/_pages/platform-administration.md
@@ -1,9 +1,6 @@
 ---
 excerpt: "Learn how to administer an Algorithmia cluster."
 layout: article_page
-redirect_from:
- - /admin/
- - /administration/
 show_related: false
 title: "Platform Administration"
 ---


### PR DESCRIPTION
No ticket, just trying to fix the weirdness with the "platform" menu items both being highlighted on some pages. Removed some unneeded front matter redirect links and that didn't seem to fix it, but they weren't necessary and were causing extra folders in the _site directory.