### PR TITLE
DOCS-298: add versioning info

### DIFF
--- a/_pages/platform/versioning.md
+++ b/_pages/platform/versioning.md
@@ -34,7 +34,7 @@ Algorithmia's language clients support requesting a particular algorithm version
 
 If you specify the version as `<major>.<minor>.<revision>` (e.g., `util/echo/0.2.1`), you'll ensure that exactly that algorithm is used.
 
-It's recommend that you supply a fully specified [semantic version](/developers/glossary#algorithm-semantic-version) when calling an algorithm from a production service. This ensures that your application is not affected by changes in algorithm permissions or functionality.
+It's recommended that you supply a fully specified [semantic version](/developers/glossary#algorithm-semantic-version) when calling an algorithm from a production service. This ensures that your application is not affected by changes in algorithm permissions or functionality.
 {: .notice-info}
 
 #### Partially specified semantic version

--- a/_pages/platform/versioning.md
+++ b/_pages/platform/versioning.md
@@ -53,7 +53,7 @@ For algorithms that you or your organizations own and only publish privately, sp
 
 #### SHA (algorithm version hash) version
 
-For algorithms that you or your organizations own, you may specify the version using the full SHA (e.g., `4be0e18fba270e4aaa7cff20558905263f69a11b`) of a successful build. This is useful for testing your algorithms during development without needing to actually publish them. Note that on our platform we also refer to the SHA as the [algorithm version hash](/developers/glossary#algorithm-version-hash).
+For algorithms that you or your organizations own, you may specify the version using the full SHA (e.g., `4be0e18fba270e4aaa7cff20558905263f69a11b`) of a successful build. This is useful for testing your algorithms during development without needing to publish them. Note that on our platform we also refer to the SHA as the [algorithm version hash](/developers/glossary#algorithm-version-hash).
 
 ## FAQs
 

--- a/_pages/platform/versioning.md
+++ b/_pages/platform/versioning.md
@@ -10,9 +10,9 @@ tags: [basics, alg-dev-getting-started, app-dev-getting-started]
 title: "Versioning"
 ---
 
-### Versioning scheme
+### Algorithm versioning scheme
 
-Every algorithm uses the same versioning scheme: `<major>.<minor>.<revision>`. Versioning allows you the ability to update and improve an algorithm while maintaining dependable, immutable* versions to be executed. The Algorithmia platform also enforces certain restrictions based on versioning. (*Algorithmia guarantees immutability for the source code of published algorithms, but data that algorithms access does not have this immutability guarantee.)
+Algorithm versioning enables you to update and improve your algorithms while maintaining dependable, immutable* versions for execution. The Algorithmia platform uses a standard semantic versioning scheme: `<major>.<minor>.<revision>` (e.g., `0.2.1`). On our platform we also enforce certain restrictions based on versioning, which are described in the subsections below. (*Algorithmia guarantees immutability for the source code of published algorithms, but we do not have this immutability guarantee for data that algorithms access.)
 
 #### Major versions
 
@@ -20,21 +20,21 @@ Major versions are to be used when publishing breaking changes to an algorithm. 
 
 #### Minor versions
 
-Minor versions are to be used when publishing new functionality in a backward-compatible manner. New minor versions will always have the same permissions as previous minor versions within the same major version.
+Minor versions are to be used when publishing new functionality in a backward-compatible manner. New minor versions will always have the same permissions as previous minor versions (within the same major version).
 
-#### Revision versions
+#### Revisions
 
-Revision versions are to be used for publishing backward-compatible bug fixes. New revision versions always carry the same visibility as previous revisions, ensuring that existing users of an algorithm version continue to have access to that algorithm and its associated bug fixes if calling it without specifying a specific revision version (see below).
+Revisions are to be used for publishing backward-compatible bug fixes. New revisions always carry the same visibility as previous revisions, ensuring that existing users of an algorithm version continue to have access to that algorithm and its associated bug fixes if calling it without specifying a specific revision.
 
-### Versioned API calls
+### Requesting specific algorithm versions through the API
 
-Algorithmia clients support requesting a particular algorithm version by specifying the [algorithm endpoint](/developers/glossary#algorithm-endpoint) with the format `ALGO_OWNER/ALGO_NAME[/ALGO_VERSION]`, e.g., `util/echo/0.2.1`. Below are several ways that the version can be specified.
+Algorithmia's language clients support requesting a particular algorithm version by specifying the [algorithm endpoint](/developers/glossary#algorithm-endpoint) with the format `ALGO_OWNER/ALGO_NAME[/ALGO_VERSION]`, e.g., `util/echo/0.2.1`. Below are several ways that the version can be specified.
 
-#### Fully-specified semantic version
+#### Fully specified semantic version
 
 If you specify the version as `<major>.<minor>.<revision>` (e.g., `util/echo/0.2.1`), you'll ensure that exactly that algorithm is used.
 
-It's recommend that you supply a fully-specified [semantic version](/developers/glossary#algorithm-semantic-version) when calling an algorithm from a production service. This ensures that your application is not affected by changes in algorithm permissions or functionality.
+It's recommend that you supply a fully specified [semantic version](/developers/glossary#algorithm-semantic-version) when calling an algorithm from a production service. This ensures that your application is not affected by changes in algorithm permissions or functionality.
 {: .notice-info}
 
 #### Partially specified semantic version
@@ -45,30 +45,34 @@ Note that we don't support calling *privately published* algorithms using partia
 
 #### Latest public version
 
-By specifying the version as `latest` (e.g. `util/echo/latest`) or by not specifying a version at all (e.g. `util/echo`), the latest public version of the algorithm will be called. This is useful when testing or experimenting with an algorithm, and may be valuable in scenarios where you maintain both the algorithm and the application that uses it.
+By specifying the version as `latest` (e.g. `util/echo/latest`) or by not specifying a version at all (e.g. `util/echo`), the latest publicly published version of the algorithm will be called. This is useful when testing or experimenting with an algorithm, and may be valuable in scenarios where you maintain both the algorithm and the application that calls it.
 
 #### Latest private version
 
-For algorithms that you or your organizations own and only publish privately, specifying `latestPrivate` as the version allows you to call the latest private version at a constant endpoint. This is primarily useful when you maintain a private algorithm and the application that uses it.
+For algorithms that you or your organizations own and only publish privately, specifying `latestPrivate` as the version allows you to call the latest private version at a static endpoint. This is primarily useful when you maintain a private algorithm and the application that calls it.
 
 #### SHA (algorithm version hash) version
 
-For algorithms that you or your organizations own, you may specify the version using the full SHA (e.g., `4be0e18fba270e4aaa7cff20558905263f69a11b`) of a successful build. This is useful for testing your algorithms during development. Note that on our platform we also refer to the SHA as the [algorithm version hash](/developers/glossary#algorithm-version-hash).
+For algorithms that you or your organizations own, you may specify the version using the full SHA (e.g., `4be0e18fba270e4aaa7cff20558905263f69a11b`) of a successful build. This is useful for testing your algorithms during development without needing to actually publish them. Note that on our platform we also refer to the SHA as the [algorithm version hash](/developers/glossary#algorithm-version-hash).
 
 ## FAQs
 
 **Q**: <em>Can you elaborate on why you don't allow partially specified semantic versions for private algorithms?</em>
 
-**A**: Absolutely! Suppose that `User1` is a member of an organization `Org1`, and `User2` isn't. `Org1` owns an algorithm called `OrgAlgo`.
+**A**: Absolutely! As an example, let's suppose that:
 
-Let's suppose that there are these two versions of `OrgAlgo`:
+- `Org1` owns `OrgAlgo`.
+- `User1` is a member of `Org1`.
+- `User2` isn't a member of `Org1`.
 
-- `Org1/OrgAlgo/1.0.1` is published publicly on the cluster
-- `Org1/OrgAlgo/1.0.2` is published privately, accessible only to members of `Org1`
+Let's also suppose that there are these two versions of `OrgAlgo`:
+
+- `Org1/OrgAlgo/1.0.1` is published publicly; it's accessible from any authenticated account on the cluster.
+- `Org1/OrgAlgo/1.0.2` is published privately; it's accessible only to members of `Org1`.
 
 If we allowed partially specified semantic versions, the following behavior would be possible:
 
 - `User1` calls `Org1/OrgAlgo/1.0`; because they have access to the private version, their request goes to `Org1/OrgAlgo/1.0.1`.
-- `User2` calls `Org1/OrgAlgo/1.0`; because they have access only to the public version, their request goes to `Org1/OrgAlgo/1.0.2`.
+- `User2` calls `Org1/OrgAlgo/1.0`; because they only have access to the public version, their request goes to `Org1/OrgAlgo/1.0.2`.
 
-In this scenario, the users call the same endpoint but gets a different version. We avoid this unpredictable behavior by not supporting this construct at all for private algorithms.
+In this scenario, the users call the same endpoint but their requests go to different algorithm versions. We avoid this unpredictable behavior altogether by not supporting partially specified semantic versions for private algorithms.


### PR DESCRIPTION
[DOCS-298](https://algorithmia.atlassian.net/browse/DOCS-298) - update algo versioning page

Additional context/notes if appropriate (e.g., specifics about what's changing, links to epic or other PRs, etc.)

## Checklist
- [x] My PR title includes a relevant Jira ticket name
- [ ] If no associated Jira ticket, my PR title is informative (individual commit messages are squashed in this repo)
- [x] Unnecessary text (notes, TODOs, etc.) has been removed
- [x] For YAML "front matter":
  - Properties are alphabetized
  - `permalink` and `redirect_from/to` properties have `/` at beginning and end (e.g., `/path/`)
- [x] Screenshots, if present, follow the [Screenshot guidelines](https://algorithmia.atlassian.net/wiki/spaces/CUSTOMERS/pages/1634861478/CFD+Style+Guide#Screenshots) which means:
  - Full browser width (browser at 100% zoom and 10-12" width)
  - Max 1000px
- [x] Grammar, style, tone, punctuation, etc. follow the Algorithmia [manual of style](https://docs.google.com/document/d/1PPVfgMkX7-EVGLPMhN1E485CAXu9QfhSLKM0lZhnZdU/edit?usp=sharing)
- [x] Headers are “Sentence case with Proper Nouns capitalized”
- [x] Placeholder strings are `UPPER_SNAKE_CASE` and are named as in the [Glossary](https://algorithmia.com/developers/glossary) where appropriate
