### PR TITLE
[UXENG-3478] Add Node code library security vulnerability scanning to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,3 +80,15 @@ osPackages:
       allow_failure: true
   script:
     - report-os-package-security-vulnerabilities $IMAGE_TAG UXENG 'Developer Center'
+
+nodeCodeLibraries:
+  stage: scan
+  image: algorithmiahq/vulnerability-scanner:latest
+  services:
+    - docker:18-dind
+  rules:
+    - if: '$DEPENDENCY_CHECK == "true"'
+    - when: manual
+      allow_failure: true
+  script:
+    - report-node-security-vulnerabilities UXENG 'Developer Center'

--- a/README.md
+++ b/README.md
@@ -127,10 +127,11 @@ Per the [Third-Party Component Maintenance Policy](https://algorithmia.atlassian
 
 Scanning and Jira ticket creation is performed by a script:
 -   `report-os-package-security-vulnerabilities algorithmiahq/dev-center:<version> UXENG "Developer Center"` - scans OS packages
+-   `report-node-security-vulnerabilities algorithmiahq/dev-center:<version> UXENG "Developer Center"` - scans Node code libraries
 
-This script is part of the [CI-tools repository](https://github.com/algorithmiaio/ci-tools/blob/traack-add-single-image-vulnerability-scanner/vulnerabilities/tools/report-os-package-security-vulnerabilities) and is packaged for use in the `algorithmiahq/vulnerability-scanner:latest` Docker image.
+These scripts are part of the [CI-tools repository](https://github.com/algorithmiaio/ci-tools/blob/traack-add-single-image-vulnerability-scanner/vulnerabilities/tools/report-os-package-security-vulnerabilities) and are packaged for use in the `algorithmiahq/vulnerability-scanner:latest` Docker image.
 
-Running the script with `--no-jira` appended will run scanning and CLI reporting of vulnerabilities without Jira ticket creation; for example: `report-os-package-security-vulnerabilities algorithmiahq/dev-center:<version> UXENG "Developer Center" --no-jira`.
+Running a script with `--no-jira` appended will run scanning and CLI reporting of vulnerabilities without Jira ticket creation; for example: `report-os-package-security-vulnerabilities algorithmiahq/dev-center:<version> UXENG "Developer Center" --no-jira`.
 
 ## Environment variables
 


### PR DESCRIPTION
This PR puts together a concrete example of an automated method to comply with one of the required actions of [Algorithmia's new third-party component maintenance policy](https://algorithmia.atlassian.net/wiki/spaces/PLATFORM/pages/1851129905/Third-Party+Component+Maintenance+Policy#Elimination-of-high-severity-vulnerabilities) - automated, weekly scanning of third-party components for security vulnerabilities with CVE scores higher than 7.0, with Jira ticket creation for remediation of any component with one or more vulnerabilities, and scan or Jira ticket failure notifications reported into Slack #product-build-alerts.

From the change I made to the owner's manual:
"Per the [Third-Party Component Maintenance Policy](https://algorithmia.atlassian.net/wiki/spaces/PLATFORM/pages/1851129905/Third-Party+Component+Maintenance+Policy), the Developer Center uses [an automated, weekly scan](https://gitlab.com/algorithmia-eng/dev-center/-/pipeline_schedules/160002/edit) to detect security vulnerabilities with a CVE score of 7.0 or higher. Components with vulnerabilities with scores of 7.0 or greater are reported as Jira tickets into [the UXENG Jira board](https://algorithmia.atlassian.net/secure/RapidBoard.jspa?projectKey=UXENG&useStoredSettings=true&rapidView=21). All [failed scans are reported into Slack](https://gitlab.com/algorithmia-eng/dev-center/-/services/slack/edit) with a [Slack Incoming Webhook](https://algorithmia.slack.com/services/B02BP6QDDD2).

Scanning and Jira ticket creation is performed by a script:
-   `report-os-package-security-vulnerabilities algorithmiahq/dev-center:<version> UXENG "Developer Center"` - scans OS packages
-   `report-node-security-vulnerabilities algorithmiahq/dev-center:<version> UXENG "Developer Center"` - scans Node code libraries

These scripts are part of the [CI-tools repository](https://github.com/algorithmiaio/ci-tools/blob/traack-add-single-image-vulnerability-scanner/vulnerabilities/tools/report-os-package-security-vulnerabilities) and are packaged for use in the `algorithmiahq/vulnerability-scanner:latest` Docker image.

Running a script with `--no-jira` appended will run scanning and CLI reporting of vulnerabilities without Jira ticket creation; for example: `report-os-package-security-vulnerabilities algorithmiahq/dev-center:<version> UXENG "Developer Center" --no-jira`."

## Checklist
- [x] My PR title includes a relevant Jira ticket name
- [ ] If no associated Jira ticket, my PR title is informative (individual commit messages are squashed in this repo)
- [ ] Unnecessary text (notes, TODOs, etc.) has been removed
- [ ] For YAML "front matter":
  - Properties are alphabetized
  - `permalink` and `redirect_from/to` properties have `/` at beginning and end (e.g., `/path/`)
- [ ] Screenshots, if present, follow the [Screenshot guidelines](https://algorithmia.atlassian.net/wiki/spaces/CUSTOMERS/pages/1634861478/CFD+Style+Guide#Screenshots) which means:
  - Full browser width (browser at 100% zoom and 10-12" width)
  - Max 1000px
- [ ] Grammar, style, tone, punctuation, etc. follow the Algorithmia [manual of style](https://docs.google.com/document/d/1PPVfgMkX7-EVGLPMhN1E485CAXu9QfhSLKM0lZhnZdU/edit?usp=sharing)
- [ ] Headers are “Sentence case with Proper Nouns capitalized”
- [ ] Placeholder strings are `UPPER_SNAKE_CASE` and are named as in the [Glossary](https://algorithmia.com/developers/glossary) where appropriate
