### PR TITLE
DOCS-313: update environments page

### DIFF
--- a/_pages/clients.md
+++ b/_pages/clients.md
@@ -9,7 +9,6 @@ redirect_from:
   - /algorithm-development/guides/
   - /application-development/client-guides/
   - /application-development/guides/
-  - /clients/cURL/
   - /application-development/lang-guides/
 show_related: false
 tags: [app-guide-overview]

--- a/_pages/clients/cli.md
+++ b/_pages/clients/cli.md
@@ -111,7 +111,7 @@ You can find more details about optional flags under [API Docs](/developers/api/
 
 ### Limits
 
-By default, one account can make up to {{site.data.stats.platform.max_num_algo_requests}} Algorithmia requests at the same time (this limit can be raised if needed).
+By default, one account can make up to {{site.data.stats.platform.max_num_algo_requests}} Algorithmia requests at the same time (this limit can be increased if needed).
 
 Requests are limited to a payload size of 10 MB for input and 15 MB for output. If you need to work with larger payloads, you can make use of Algorithmia's [data API](/developers/api/#data). See [considerations for transferring large data payloads](https://training.algorithmia.com/using-data-sources/688899#considerations-for-transferring-large-data-payloads) for more details.
 

--- a/_pages/clients/cli.md
+++ b/_pages/clients/cli.md
@@ -113,7 +113,7 @@ You can find more details about optional flags under [API Docs](/developers/api/
 
 By default, one account can make up to {{site.data.stats.platform.max_num_algo_requests}} Algorithmia requests at the same time (this limit can be raised if needed).
 
-Requests are limited to a payload size of 10 MB for input and 15 MB for output. If you need to work with larger payloads, you can make use of Algorithmia's [data API](/developers/api/#data), described below.
+Requests are limited to a payload size of 10 MB for input and 15 MB for output. If you need to work with larger payloads, you can make use of Algorithmia's [data API](/developers/api/#data). See [considerations for transferring large data payloads](https://training.algorithmia.com/using-data-sources/688899#considerations-for-transferring-large-data-payloads) for more details.
 
 ## Working with Algorithmia data sources
 

--- a/_pages/clients/curl.md
+++ b/_pages/clients/curl.md
@@ -159,13 +159,13 @@ $ curl https://api.algorithmia.com/v1/algo/dlib/FaceDetection/0.2.1 \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Simple STD_API_KEY' \
     -d '{
-    "images": [
+      "images": [
         {
             "url": "data://.my/img_directory/friends.jpg",
             "output": "data://.algo/temp/detected_faces.png"
         }
-    ]
-}'
+      ]
+    }'
 ```
 
 Once the algorithm execution completes, the response will contain the dimensions of the bounding boxes for any detected faces and the URI for the resulting file, which you can then download (or provide as input to another algorithm in a pipeline).

--- a/_pages/clients/curl.md
+++ b/_pages/clients/curl.md
@@ -1,150 +1,155 @@
 ---
-layout: article
-title: "CURL"
-excerpt: "Get going with the cURL client on Algorithmia."
 categories: clients
-tags: [clients]
-show_related: true
+excerpt: "Get going with the cURL client on Algorithmia."
 image:
     teaser: /language_logos/curl.svg
+layout: article
+tags: [clients]
+title: "cURL"
 redirect_from:
   - /application-development/client-guides/cURL/
   - /application-development/client-guides/curl/
   - /application-development/guides/curl/
+show_related: true
 ---
 
 {% include video-responsive.html height="560" width="315" url="https://www.youtube.com/embed/VIxCEFFmpWQ" %}
 
-The Algorithmia API lets developers manage and call algorithms, work with data in object stores using Algorithmia Data Sources, and access other features of the Algorithmia platform. All the features of the REST interface can be accessed directly over HTTPS using cURL.
+The Algorithmia API lets developers manage and call algorithms, work with data in object stores using Algorithmia data sources, and access and manage numerous other features of the Algorithmia platform. You can use cURL, an open source command-line tool, to access all features of our REST interface directly over HTTPS.
 
-This guide will cover calling an algorithm from cURL using direct user input, calling an algorithm that accesses data through Algorithmia Data Sources, and using Algorithmia's Hosted Data service. For complete details about the Algorithmia API, please refer to the [API Docs](/developers/api/?shell).
+This guide will cover calling an algorithm using cURL with direct user input, calling an algorithm that accesses data through Algorithmia's data API, and using Algorithmia's hosted data capabilities. For a comprehensive listing of the endpoints available through Algorithmia's API, please refer to our [API Docs](/developers/api/?shell).
 
-## Calling an Algorithm
+## Calling an algorithm
 
-Algorithms take three basic types of input whether they are invoked directly through the API or by using a client library: strings, JSON, and binary data. In addition, individual algorithms might have their own I/O requirements, such as using different data types for input and output, or accepting multiple types of input, so consult the input and output sections of an algorithm's documentation for specifics.
+Regardless of whether they're invoked directly through the API or through a client library, algorithms take three basic types of input: strings, JSON blobs, and binary data. Within these constraints, individual algorithms may have more specific I/O requirements as well—they may only accepting specific data types for input, or they may accept multiple input types but then use internal logic to handle those different types. Consult the **Input** and **Output** sections of an algorithm's documentation for specifics.
 
-To access the API you'll need an API key, which Algorithmia uses for fine-grained authentication across the platform. For this example, we'll use the `default-key` that was created along with your account, which has a broad set of permissions. Log in to Algorithmia and navigate to Home > [API Keys](/user#credentials) to find your key, or read the [API keys documentation](/developers/platform/customizing-api-keys) for more information. You'll provide your API key via an `Authorization` header with the prefix `Simple`.
+To access the API, you'll need an [API key](/developers/glossary#api-key), which Algorithmia uses for authentication and fine-grained resource access across the platform. Log in to Algorithmia's browser UI and navigate to **Home** &rarr; **API Keys** to locate your API key. For the examples in this guide, you can use the `default-key` that's created along with your account. This is a [standard API key](/developers/glossary#standard-api-key) with a broad set of permissions.
 
-The first algorithm we'll call is a demo version of the algorithm used in the Algorithm Development [Getting Started](/developers/algorithm-development/your-first-algo) guide, which is available at [demo/Hello](/algorithms/demo/Hello). Looking at the [algorithm's documentation](/algorithms/demo/Hello/docs), it takes a string as input and returns a string.
+As shown in the code sample below, you'll provide your API key via an `Authorization` header, replacing `STD_API_KEY` with your key and using the `Simple` prefix to specify the [authentication token](/developers/glossary#authentication-token) type. For more information on how to work with API keys, see the [API keys documentation](/developers/platform/customizing-api-keys).
 
-We can run the following cURL command to make the request:
+The first algorithm you'll call in this guide is the boilerplate [hello world](https://algorithmia.com/algorithms/demo/hello) algorithm used in the algorithm development [Getting Started](/developers/algorithm-development/your-first-algo#creating-your-first-algorithm) guide. This algorithm takes a string as input and returns a string as output. You can use the cURL command below to make the request.
 
-{% highlight bash %}
-curl https://api.algorithmia.com/v1/algo/demo/Hello \
+Note that if you're working with a private Algorithmia Enterprise cluster, you'll need to replace `algorithmia.com` with your [cluster-specific domain name](/developers/glossary#cluster-domain) and the algorithm endopint will need to be changed to `/v1/algo/ALGO_OWNER/ALGO_NAME`, where `ALGO_OWNER` is the [name of your account](/developers/glossary#algorithm-owner)) and `ALGO_NAME` is the [name of your algorithm](/developers/glossary#algorithm).
+
+```shell
+curl https://api.algorithmia.com/v1/algo/demo/hello \
     -X POST \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Simple YOUR_API_KEY' \
+    -H 'Authorization: Simple STD_API_KEY' \
     -d '"HAL 9000"'
-  {% endhighlight %}
+```
 
-Which should print the phrase, `Hello HAL 9000`.
+When executed with a valid API key, this will print the phrase `Hello HAL 9000` in your terminal.
 
-### Complex JSON Inputs
+### Complex JSON inputs
 
-Let's look at an example using a more complicated JSON input: the [nlp/LDA](https://algorithmia.com/algorithms/nlp/LDA) algorithm. The [algorithm docs](https://algorithmia.com/algorithms/nlp/LDA/docs) tell us that the algorithm takes a list of documents and returns a number of topics that are relevant to those documents. The documents can be a list of strings, a Data API file path, or a URL. We'll call this algorithm using a list of strings, following the format in the algorithm documentation:
+Let's explore an example using the more complicated JSON input associated with a [natural language processing (NLP)](https://algorithmia.com/algorithms/nlp/LDA) algorithm. This algorithm takes a list of documents and returns a number of topics that are relevant to those documents. The documents can be a list of strings, a [data URI](/developers/glossary#data-uri), or a URL. Suppose you want to call this algorithm using a list of strings; you could achieve this with the cURL command below.
 
-{% highlight bash %}
-curl https://api.algorithmia.com/v1/algo/nlp/LDA/1.0.0 \
+```shell
+curl https://api.CLUSTER_DOMAIN/v1/algo/nlp/LDA/1.0.0 \
     -X POST \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Simple YOUR_API_KEY' \
-    -d '{"docsList": ["It'\''s apple picking season","The apples are ready for picking"]}'
-{% endhighlight %}
+    -H 'Authorization: Simple STD_API_KEY' \
+    -d '{
+      "docsList": [
+        "It is apple picking season",
+        "The apples are ready for picking"
+      ]
+    }'
+```
 
-The output will be similar to `[{'picking': 2}, {'apple': 1}, {'apples': 1, 'ready': 1}, {'season': 1}]`, which is the list of relevant words and the number of occurrences.
+The output is in the format `[{'picking': 2}, {'apple': 1}, {'apples': 1, 'ready': 1}, {'season': 1}]`, which is the list of relevant words and the number of occurrences of each.
 
-You might have noticed that in this example we included a version number when instantiating the algorithm. Pinning your code to a specific version of the algorithm can be especially important in a production environment where the underlying implementation might change from version to version.
+Notice that in the command above, the API endpoint includes a version number `ALGO_VERSION`. We recommend providing a [fully specified semantic version](/developers/platform/versioning#fully-specified-semantic-version) to indicate exactly which version of algorithm you're requesting. This becomes particularly important in production environments to ensure that the correct version is being executed, as the underlying implementation might change between versions.
 
-### Request Options
+### Request options
 
-The API exposes options that can configure algorithm requests. This includes support for changing the timeout or indicating that the API should include stdout in the response. From cURL, we can provide these options as URL parameters. In the following example, we set the timeout to 60 seconds and disable `stdout` in the response:
+The API exposes options for configuring algorithm requests. This includes support for changing the execution timeout or indicating that the API should include `stdout` in the response. With cURL, you can provide these options as URL parameters. The example below shows how to set the timeout to 60 seconds and disable `stdout` in the response for the hello world algorithm from above.
 
-{% highlight bash %}
-curl 'https://api.algorithmia.com/v1/algo/demo/Hello?timeout=60&stdout=false' \
+```shell
+curl 'https://api.algorithmia.com/v1/algo/demo/hello?timeout=60&stdout=false' \
     -X POST \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Simple YOUR_API_KEY' \
+    -H 'Authorization: Simple STD_API_KEY' \
     -d '"HAL 9001"'
-{% endhighlight %}
+```
 
-You can find more details in [API Docs](/developers/api/?shell) > [Invoke an Algorithm](/developers/api/?shell#invoke-an-algorithm).
+You can find more details under [API Docs](/developers/api/?shell) &rarr; [Invoke an Algorithm](/developers/api/?shell#invoke-an-algorithm).
 
-### Error Handling
+### Error handling
 
-To be able to better develop across languages, Algorithmia has created a set of standardized errors that can be returned by either the platform or by the algorithm being run. If an error occurs while invoking the API, the HTTP response will include an error field with more information:
+To be able to better develop across languages, we've created a set of standardized error classes that can be returned by either the platform itself or by the individual algorithm being run. If an error occurs while invoking the API, the HTTP response will include an `error` field with error information.
 
-{% highlight bash %}
-curl https://api.algorithmia.com/v1/algo/util/whoopsWrongAlgo \
+```shell
+curl https://api.algorithmia.com/v1/algo/ALGO_OWNER/DOES_NOT_EXIST \
     -X POST \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Simple YOUR_API_KEY' \
+    -H 'Authorization: Simple STD_API_KEY' \
     -d '"Hello, world"'
-{% endhighlight %}
+```
 
-Response: `{"error":{"message":"algorithm algo://util/whoopsWrongAlgo/ not found"}}`
+When this hypothetical `DOES_NOT_EXIST` algorithm is called, it returns the response `{"error": {"message": "algorithm algo://ALGO_OWNER/DOES_NOT_EXIST not found"}}`, indicating that the platform couldn't locate the algorithm resource.
 
-You can read more about [Error Handling](/developers/algorithm-development/algorithm-errors) in the [Algorithm Development](/developers/algorithm-development) section of the dev center.
+To learn how to handle errors elagantly and expressively in your own algorithms, see [Error Handling](/developers/algorithm-development/algorithm-errors).
 
 ### Limits
 
-Your account can make up to {{site.data.stats.platform.max_num_algo_requests}} Algorithmia requests at the same time (this limit <a href="mailto:support@algorithmia.com?subject=Request to raise max algorithm request limit">can be raised</a> if needed).
+By default, one account can make up to {{site.data.stats.platform.max_num_algo_requests}} concurrent [algorithm execution requests](/developers/glossary#algorithm-execution-request) (this limit can be increased if needed).
 
-Algorithm requests have a payload size limit of 10MB for input and 15MB for output. If you need to work with larger amounts of data, you can make use of the Algorithmia [Data API](/developers/api/#data).
+Requests are limited to a payload size of 10 MB for input and 15 MB for output. If you need to work with larger payloads, you can make use of Algorithmia's [data API](/developers/api/#data). See [considerations for transferring large data payloads](https://training.algorithmia.com/using-data-sources/688899#considerations-for-transferring-large-data-payloads) for more details.
 
-## Working with Algorithmia Data Sources
+## Working with Algorithmia data sources
 
-For some algorithms, passing input to the algorithm at request time is sufficient, while others might have larger data requirements or need to preserve state between calls. Application developers can use Algorithmia's [Hosted Data](/developers/data/hosted) to store data as text, JSON, or binary, and access it via the Algorithmia [Data API](/developers/api/?shell#data).
+For some algorithms, passing input data at request time is sufficient. However, for algorithms with larger data payload requirements, and for those that require preservation of state between calls, it may be convenient or necessary to use Algorithmia's various [data sources](/developers/glossary#data-source) to store text, JSON, or binary data and then access it via the Algorithmia's [data API](/developers/api/?shell#data) at run time.
 
-The Data API defines [connectors](/developers/api/?shell#connectors) to a variety of storage providers, including Algorithmia [Hosted Data](/developers/data/hosted), Amazon S3, Google Cloud Storage, Azure Storage Blobs, and Dropbox. After creating a connection in Data Sources, you can use the API to create, update, and delete directories and files and manage permissions across providers by making use of [Data URIs](/developers/api/#data-uris) in your code.
+The data API defines [connectors](/developers/api/?shell#connectors) to a variety of storage providers, including Algorithmia [hosted data](/developers/data/hosted), Amazon S3, Azure Blob Storage, Google Cloud Storage, and Dropbox. After creating a connection in the browser UI under **Data Sources** or through the data API, you can use the API to create, update, and delete directories and files and manage permissions across storage providers.
 
-In this example, we'll upload an image to Algorithmia's [Hosted Data](/developers/data/hosted) storage provider, and use the [dlib/FaceDetection](https://algorithmia.com/algorithms/dlib/FaceDetection) algorithm to detect any faces in the image. The algorithm will create a new copy of the image with bounding boxes drawn around the detected faces, and then return a JSON object with details about the dimensions of the bounding boxes and a URI where you can download the resulting image.
+In this example, you'll upload an image to Algorithmia's [hosted data](/developers/data/hosted) storage provider and then use a [face detection](https://algorithmia.com/algorithms/dlib/FaceDetection) algorithm to detect any faces in the image. According to the algorithm's [documentation](https://algorithmia.com/algorithms/dlib/FaceDetection/docs), the algorithm creates a new copy of the image with bounding boxes drawn around the detected faces, and then returns a JSON object with a `detected_faces` property listing the coordinates of the bounding boxes where faces were found, as well as a `url` field listing a data URI where the resulting image can be downloaded.
 
-### Create a Data Collection
+### Create a data collection
 
-The documentation for "Face Detection" says that it takes a URL or a Data URI of the image to be processed, and a Data URI where the algorithm can store the result. We'll create a directory to host the input image, then update its [permissions](/developers/api/#update-collection-acl) so that it's publicly accessible by issuing a `PATCH` request with the appropriate ACL:
+The [documentation](https://algorithmia.com/algorithms/dlib/FaceDetection/docs) for the face detection algorithm says that as input it takes a URL or a data URI of the image to be processed, and a data URI where the algorithm can store the result. We'll first execute a `POST` request to create a directory to host the input image. Then, we'll execute a `PATCH` request with the appropriate ACL to update the directory's [permissions](/developers/api/#update-collection-acl) so that it's publicly accessible.
 
-{% highlight bash %}
+```shell
 curl 'https://api.algorithmia.com/v1/data/.my' \
     -X POST \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Simple YOUR_API_KEY' \
+    -H 'Authorization: Simple STD_API_KEY' \
     -d '{"name": "img_directory"}'
-{% endhighlight %}
+```
 
-Response: `{"result":"data://.my/img_directory"}`
+The response indicates the URI of the new collection: `{"result": "data://.my/img_directory"}`
 
-{% highlight bash %}
+```shell
 curl 'https://api.algorithmia.com/v1/connector/data/.my/img_directory' \
     -X PATCH \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Simple YOUR_API_KEY' \
+    -H 'Authorization: Simple STD_API_KEY' \
     -d '{"acl": {"read": ["user://*"]} }'
-{% endhighlight %}
+```
 
-Instead of your username you can also use '.my' when calling algorithms. For more information about the '.my' pseudonym check out the [Hosted Data Guide]({{site.baseurl}}/data/hosted).
+Note that, as demonstrated above, instead of your account name you can also use `.my` when calling algorithms. For more information about the `.my` pseudonym, see the [hosted data docs]({{site.baseurl}}/data/hosted).
 {: .notice-info}
 
-### Upload Data to your Data Collection
+### Upload data to your data collection
 
-Now we're ready to upload an image file for processing. For this example, we'll use [this photo of a group of friends](https://unsplash.com/photos/Q_Sei-TqSlc). Download the image and save it locally as `friends.jpg`. 
+Now you're ready to upload an image file for processing. For this example, you can use [this photo of a group of friends](https://unsplash.com/photos/Q_Sei-TqSlc). Download the image and save it locally as `friends.jpg`, and then upload the local file to the data collection using the following `PUT` command.
 
-Then upload your local file to the data collection using the `PUT` method:
-
-{% highlight bash %}
+```shell
 curl 'https://api.algorithmia.com/v1/connector/data/.my/img_directory/friends.jpg' \
     -X PUT \
-    -H 'Authorization: Simple YOUR_API_KEY' \
-    --data-binary @friends.jpg
-{% endhighlight %}
+    -H 'Authorization: Simple STD_API_KEY' \
+    --data-binary @PATH/TO/LOCAL_DIRECTORY/friends.jpg
+```
 
-This method call will replace a file if it already exists at the specified location. If you wish to avoid replacing a file, check if the file exists before using this method.
+**NOTE**: This method call will replace a file if it already exists at the specified location. If you wish to avoid replacing a file, check if the file exists before using this method.
 {: .notice-warning}
 
-Confirm that the file was created by navigating to Algorithmia's [Hosted Data Source](/data/hosted) and finding your data collection and file.
+Confirm that the file was created by navigating to **Data Sources** in the browser UI and finding the data collection and file.
 
-You can also upload your data through the UI on Algorithmia's [Hosted Data Source](/data/hosted). For instructions on how to do this go to the [Hosted Data Guide]({{site.baseurl}}/data/hosted).
+You can also upload your data through the Algorithmia's browser UI; see the [hosted data docs](/developers/data/hosted) for details.
 
-### Call the Algorithm
+### Call the algorithm
 
 Once the file has been uploaded, you are ready to call the algorithm, providing the inputs as specified in the [FaceDetection documentation](https://algorithmia.com/algorithms/dlib/FaceDetection/docs)—an image URI (which is stored in `img_file` in the code above) and a URI for the image output:
 
@@ -152,7 +157,7 @@ Once the file has been uploaded, you are ready to call the algorithm, providing 
 curl https://api.algorithmia.com/v1/algo/dlib/FaceDetection/0.2.1 \
     -X POST \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Simple YOUR_API_KEY' \
+    -H 'Authorization: Simple STD_API_KEY' \
     -d '{
     "images": [
         {
@@ -175,7 +180,7 @@ The URI included in the algorithm output uses the `.algo` shortcut, so we'll nee
 
 {% highlight bash %}
 curl -O https://api.algorithmia.com/v1/connector/data/.algo/dlib/FaceDetection/temp/detected_faces.png \
-    -H 'Authorization: Simple YOUR_API_KEY'
+    -H 'Authorization: Simple STD_API_KEY'
 {% endhighlight %}
 
 ## Additional Functionality

--- a/_pages/clients/curl.md
+++ b/_pages/clients/curl.md
@@ -179,8 +179,8 @@ The URI included in the algorithm output uses the `.algo` shortcut, so we'll nee
 
 ```shell
 $ curl https://api.algorithmia.com/v1/connector/data/.algo/dlib/FaceDetection/temp/detected_faces.png \
+    -H 'Authorization: Simple STD_API_KEY' \
     -O # save image locally with remote file name
-    -H 'Authorization: Simple STD_API_KEY'
 ```
 
 ## Additional Functionality

--- a/_pages/clients/curl.md
+++ b/_pages/clients/curl.md
@@ -32,7 +32,7 @@ The first algorithm you'll call in this guide is the boilerplate [hello world](h
 Note that if you're working with a private Algorithmia Enterprise cluster, you'll need to replace `algorithmia.com` with your [cluster-specific domain name](/developers/glossary#cluster-domain) and the algorithm endopint will need to be changed to `/v1/algo/ALGO_OWNER/ALGO_NAME`, where `ALGO_OWNER` is the [name of your account](/developers/glossary#algorithm-owner)) and `ALGO_NAME` is the [name of your algorithm](/developers/glossary#algorithm).
 
 ```shell
-curl https://api.algorithmia.com/v1/algo/demo/hello \
+$ curl https://api.algorithmia.com/v1/algo/demo/hello \
     -X POST \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Simple STD_API_KEY' \
@@ -46,7 +46,7 @@ When executed with a valid API key, this will print the phrase `Hello HAL 9000` 
 Let's explore an example using the more complicated JSON input associated with a [natural language processing (NLP)](https://algorithmia.com/algorithms/nlp/LDA) algorithm. This algorithm takes a list of documents and returns a number of topics that are relevant to those documents. The documents can be a list of strings, a [data URI](/developers/glossary#data-uri), or a URL. Suppose you want to call this algorithm using a list of strings; you could achieve this with the cURL command below.
 
 ```shell
-curl https://api.CLUSTER_DOMAIN/v1/algo/nlp/LDA/1.0.0 \
+$ curl https://api.CLUSTER_DOMAIN/v1/algo/nlp/LDA/1.0.0 \
     -X POST \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Simple STD_API_KEY' \
@@ -67,7 +67,7 @@ Notice that in the command above, the API endpoint includes a version number `AL
 The API exposes options for configuring algorithm requests. This includes support for changing the execution timeout or indicating that the API should include `stdout` in the response. With cURL, you can provide these options as URL parameters. The example below shows how to set the timeout to 60 seconds and disable `stdout` in the response for the hello world algorithm from above.
 
 ```shell
-curl 'https://api.algorithmia.com/v1/algo/demo/hello?timeout=60&stdout=false' \
+$ curl 'https://api.algorithmia.com/v1/algo/demo/hello?timeout=60&stdout=false' \
     -X POST \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Simple STD_API_KEY' \
@@ -81,7 +81,7 @@ You can find more details under [API Docs](/developers/api/?shell) &rarr; [Invok
 To be able to better develop across languages, we've created a set of standardized error classes that can be returned by either the platform itself or by the individual algorithm being run. If an error occurs while invoking the API, the HTTP response will include an `error` field with error information.
 
 ```shell
-curl https://api.algorithmia.com/v1/algo/ALGO_OWNER/DOES_NOT_EXIST \
+$ curl https://api.algorithmia.com/v1/algo/ALGO_OWNER/DOES_NOT_EXIST \
     -X POST \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Simple STD_API_KEY' \
@@ -111,7 +111,7 @@ In this example, you'll upload an image to Algorithmia's [hosted data](/develope
 The [documentation](https://algorithmia.com/algorithms/dlib/FaceDetection/docs) for the face detection algorithm says that as input it takes a URL or a data URI of the image to be processed, and a data URI where the algorithm can store the result. We'll first execute a `POST` request to create a directory to host the input image. Then, we'll execute a `PATCH` request with the appropriate ACL to update the directory's [permissions](/developers/api/#update-collection-acl) so that it's publicly accessible.
 
 ```shell
-curl 'https://api.algorithmia.com/v1/data/.my' \
+$ curl 'https://api.algorithmia.com/v1/data/.my' \
     -X POST \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Simple STD_API_KEY' \
@@ -121,7 +121,7 @@ curl 'https://api.algorithmia.com/v1/data/.my' \
 The response indicates the URI of the new collection: `{"result": "data://.my/img_directory"}`
 
 ```shell
-curl 'https://api.algorithmia.com/v1/connector/data/.my/img_directory' \
+$ curl 'https://api.algorithmia.com/v1/connector/data/.my/img_directory' \
     -X PATCH \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Simple STD_API_KEY' \
@@ -136,7 +136,7 @@ Note that, as demonstrated above, instead of your account name you can also use 
 Now you're ready to upload an image file for processing. For this example, you can use [this photo of a group of friends](https://unsplash.com/photos/Q_Sei-TqSlc). Download the image and save it locally as `friends.jpg`, and then upload the local file to the data collection using the following `PUT` command.
 
 ```shell
-curl 'https://api.algorithmia.com/v1/connector/data/.my/img_directory/friends.jpg' \
+$ curl 'https://api.algorithmia.com/v1/connector/data/.my/img_directory/friends.jpg' \
     -X PUT \
     -H 'Authorization: Simple STD_API_KEY' \
     --data-binary @PATH/TO/LOCAL_DIRECTORY/friends.jpg
@@ -153,8 +153,8 @@ You can also upload your data through the Algorithmia's browser UI; see the [hos
 
 Once the file has been uploaded, you are ready to call the algorithm, providing the inputs as specified in the [FaceDetection documentation](https://algorithmia.com/algorithms/dlib/FaceDetection/docs)—an image URI (which is stored in `img_file` in the code above) and a URI for the image output:
 
-{% highlight bash %}
-curl https://api.algorithmia.com/v1/algo/dlib/FaceDetection/0.2.1 \
+```shell
+$ curl https://api.algorithmia.com/v1/algo/dlib/FaceDetection/0.2.1 \
     -X POST \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Simple STD_API_KEY' \
@@ -166,27 +166,27 @@ curl https://api.algorithmia.com/v1/algo/dlib/FaceDetection/0.2.1 \
         }
     ]
 }'
+```
 
-{% endhighlight %}
+Once the algorithm execution completes, the response will contain the dimensions of the bounding boxes for any detected faces and the URI for the resulting file, which you can then download (or provide as input to another algorithm in a pipeline).
 
-Once the algorithm has completed, the response will contain the dimensions of the bounding boxes for any detected faces and the URI for the resulting file, which you can then download (or provide as input to another algorithm in a pipeline).
-
-Algorithms can create and store data in folders named with the algorithm name in the Algorithm Data collection. To access this folder from within an executing algorithm, the `.algo` shortcut can be used, as in the input example above. When accessing data from a client context, the algorithm author and name can be used along with the `.algo` shortcut to download data, in the format `data://.algo/author/algoName/folder/fileName`.
+Algorithms can create and store data in folders named with the algorithm name in the algorithm data collection. To access files in this location from within an executing algorithm, the `.algo` shortcut can be used, as in the input example above. When accessing data from a client context, the algorithm owner and name can be used along with the `.algo` shortcut to download data, in the format `data://.algo/ALGO_OWNER/ALGO_NAME/COLLECTION_NAME/FILE_NAME`.
 {: .notice-info}
 
 ### Download the resulting file
 
 The URI included in the algorithm output uses the `.algo` shortcut, so we'll need to modify it slightly to download the file by adding the algorithm name and author. We can then attempt to download the file and write it to disk:
 
-{% highlight bash %}
-curl -O https://api.algorithmia.com/v1/connector/data/.algo/dlib/FaceDetection/temp/detected_faces.png \
+```shell
+$ curl https://api.algorithmia.com/v1/connector/data/.algo/dlib/FaceDetection/temp/detected_faces.png \
+    -O # save image locally with remote file name
     -H 'Authorization: Simple STD_API_KEY'
-{% endhighlight %}
+```
 
 ## Additional Functionality
 
-In addition to the functionality covered in this guide, the API provides a complete interface to the Algorithmia platform, including [managing algorithms](/developers/algorithm-development/algorithm-management), administering [organizations](/developers/platform/organizations), and working with [source control](/developers/algorithm-development/source-code-management). You can also visit the [API Docs](/developers/api) to view the complete API specification.
+In addition to the functionality covered in this guide, the API provides a complete interface to the Algorithmia platform, including [managing algorithms](/developers/algorithm-development/algorithm-management), administering [organizations](/developers/platform/organizations), and working with external [source code management](/developers/algorithm-development/source-code-management) providers. You can also visit the [API Docs](/developers/api) to view the complete API specification.
 
 ## Next Steps
 
-If you'd like to use a particular programming language for accessing the Algorithmia platform, you can refer to the rest of our [Client Guides](https://algorithmia.com/developers/clients), or if you're a data scientist or developer who will be building and deploying new algorithms, you can move on to the [Algorithm Development > Getting Started](/developers/algorithm-development/your-first-algo/) guide.
+If you'd like to use a particular programming language for accessing the Algorithmia platform, you can refer to the rest of our [Client Guides](https://algorithmia.com/developers/clients). If you'll be building and deploying new algorithms on the platform, , you can move on to the [Algorithm Development > Getting Started](/developers/algorithm-development/your-first-algo/) guide.

--- a/_pages/event-flows/azure-eh.md
+++ b/_pages/event-flows/azure-eh.md
@@ -14,7 +14,10 @@ title: "Azure Event Hubs"
 
 This guide will walk you through setting up an algorithm to send messages to [Azure Event Hubs (EH)](https://azure.microsoft.com/services/event-hubs/), Azure's high-throughput data-streaming and event-ingestion service. Once configured, you can create workflows in which your algorithms publish data to an event hub, unlocking downstream storage, processing, and analytics capabilities on Azure.
 
-Because Algorithmia doesn't currently have a native integration with Azure Event Hubs, you can use one of Microsoft's official SDKs, for example the `azure-eventhub` [Python client library](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-python-get-started-send) or the `azure-messaging-eventhubs` [Java client library](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-java-get-started-send) to send and receive messages from within your algorithms. The workflow demonstrated here uses the Python SDK, which is [available on PyPI](https://pypi.org/project/azure-eventhub/), to send messages. To see our other message broker integrations, see [Event Flows](/developers/event-flows).
+Because Algorithmia doesn't currently have a native Event Flows integration with Azure Event Hubs, you can use one of Microsoft's official SDKs, for example the `azure-eventhub` [Python client library](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-python-get-started-send) or the `azure-messaging-eventhubs` [Java client library](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-java-get-started-send) to send and receive messages from within your algorithms. The workflow demonstrated here uses the Python SDK, which is [available on PyPI](https://pypi.org/project/azure-eventhub/), to send messages. To see our other message broker integrations, see [Event Flows](/developers/event-flows).
+
+**NOTE:** Although we currently don't support Azure Event Hubs natively for Event Flows, beginning in Algorithmia version 20.5.57 you can use Event Hubs as a message broker for [Algorithmia Insights](/developers/monitoring-and-observability/insights).
+{: .notice-info}
 
 ## Event Flow configuration overview
 
@@ -58,7 +61,7 @@ Endpoint=sb://test-azure-eh-namespace.servicebus.windows.net/;SharedAccessKeyNam
 **NOTE:** The steps in this section are to be completed on Algorithmia, from within the browser user interface (UI) or through the API.
 {: .notice-info}
 
-As noted above, in this workflow we're using Microsoft's `azure-eventhub` Python SDK to send messages to Event Hubs from within an algorithm. For more information on how to use this library to send and receive messages, see Microsoft's [Quickstart Guide](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-python-get-started-send).
+As noted above, in this workflow we're using Microsoft's `azure-eventhub` Python SDK to send messages to EH from within an algorithm. For more information on how to use this library to send and receive messages, see Microsoft's [Quickstart Guide](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-python-get-started-send).
 
 ### Create an algorithm
 

--- a/_pages/event-flows/azure-eh.md
+++ b/_pages/event-flows/azure-eh.md
@@ -34,6 +34,9 @@ The process of configuring Event Flows with an EH message broker involves multip
 
 ### Creating an Event Hubs namespace and an event hub
 
+**NOTE:** If you're familiar with the [Apache Kafka](/developers/event-flows/apache-kafka) platform, it can be helpful to understand the name mapping between Kafka and Event Hubs. In simple terms, an Event Hubs namespace is analogous to a Kafka cluster, and an event hub is analogous to a Kafka topic.
+{: .notice-info}
+
 To begin, create an event hub [using the Azure portal](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-create) or [using the Azure CLI](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-quickstart-cli). This will entail first deploying an Event Hubs namespace and then creating an event hub within the namespace. Because we'll be sending messages using the Python SDK directly from an algorithm and not natively through Algorithmia's internal infrastructure, the event hub can exist in any Azure account to which you have access. In other words, the Azure account in which the event hub is created doesn't need to be the account running the Algorithmia platform, and no additional permission-configuration steps are required.
 
 ### Gathering required parameters

--- a/_pages/model-deployment/environments.md
+++ b/_pages/model-deployment/environments.md
@@ -12,6 +12,9 @@ tags: [algo-model-guide]
 title:  "Algorithm Environments"
 ---
 
+**NOTE:** The list of currently available environments, previously hosted on this page, can now be found on our [Training Center](https://training.algorithmia.com/developing-python-algorithms-in-a-local-ide/906833).
+{: .notice-info}
+
 ## Overview
 Algorithmia supports seven languages for writing algorithms: Python, R, Java, Scala, Ruby, Rust, and JavaScript. When you create an algorithm, you must select one of these languages.
 
@@ -33,49 +36,4 @@ However, we recommend not doing this, and instead choosing the appropriate prede
 
 The algorithm runtime environment you select should match up as closely as possible with your code dependencies, in order to provide the most streamlined development experience and the best algorithm performance. With the base environment selected, you can then add any other required dependencies in whichever way is standard for your language.
 
-The matrix below lists the algorithm environments that are currently available on every Algorithmia installation. To create an algorithm with a predefined environment through the API, see [Using a Predefined Language Environment](https://training.algorithmia.com/enterprise-20-2-developing-python-algorithms-in-a-local-ide/698050#predefined-environment).
-
-<div class="syn-styles-supported">
-  <div class="syn-table-container scrollable-x" markdown="1">
-
-{:.syn-table.condensed}
-|Environment|Language|Framework|Pinned Dependencies|CUDA/cuDNN|Base Image|
-|---|---|---|---|---|---|
-|python37|Python 3.7|--|--|--|algorithmiahq/ubuntu:18.04|
-|python37-gpu|Python 3.7|--|--|9.0 / 7|nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04|
-|pytorch-1.4.x|Python 3.7.1|PyTorch 1.4|numpy==1.16.0|10.1 / 7|nvidia/cuda:10.1-cudnn7-devel-ubuntu16.04|
-|pytorch-1.5.x|Python 3.7.1|PyTorch 1.5|numpy==1.16.0|10.2 / 7|nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04|
-|pytorch-1.6.x|Python 3.7.1|PyTorch 1.6|numpy==1.16.0|10.2 / 7|nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04|
-|spacy-2.0.18|Python 3.7.1|Spacy 2.0.18|--|--|ubuntu:16.04|
-|tensorflow-gpu-1.14|Python 3.7|Tensorflow 1.14|keras==2.1.4|10.0 / 7|nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04|
-|tensorflow-gpu-2.1|Python 3.7|Tensorflow 2.1|keras==2.3.1|10.1 / 7|nvidia/cuda:10.1-cudnn7-devel-ubuntu16.04|
-|tensorflow-gpu-2.3|Python 3.7|Tensorflow 2.3|--|10.1 / 7|nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04|
-|selenium3.141.x-python|Python 3.7.1|Selenium 3.141.0|phantomjs==2.1.1, chromedriver==2.41, geckodriver==0.26.0|--|ubuntu:16.04|
-|python27|Python 2.7.15|--|--|--|ubuntu:16.04|
-|python27-cuda90-cudnn7|Python 2.7.15|--|--|9.0 / 7|nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04|
-
-  </div>
-</div>
-
-We’re always adding new optimized runtime environments to support our customers using the latest language and framework versions. Therefore, in addition to those listed above, we also have the following environments available to our Enterprise customers. **If there is a specific environment listed below that you'd like to use, or if you need a custom environment that isn't available, please ask your customer success manager** so that we can get it built and installed on your cluster.
-
-<div class="syn-styles-supported">
-  <div class="syn-table-container scrollable-x" markdown="1">
-
-{:.syn-table.condensed}
-|Environment|Language|Framework|Pinned Dependencies|CUDA/cuDNN|Base Image|
-|---|---|---|---|---|---|
-|allennlp-0.8|Python 3.7|AllenNLP 0.8|spacy==2.0.18, pytorch==1.0.0||ubuntu:16.04|
-|apex-0.1|Python 3.7|Apex 0.1|pytorch==1.3|10.1 / 7|nvidia/cuda:10.1-cudnn7-devel-ubuntu16.04|
-|mxnet-cu90-1.3.1|Python 3.7|MXNet 1.3.1|--|9.0 / 7|nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04|
-|pytorch-1.0.0|Python 3.7|PyTorch 1.0.0|--|9.0 / 7|nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04|
-|tensorrt-6.0-cuda10.0|Python 3.7 |TensorRT 6.0.x||10.0 / 7|nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04|
-|python36|Python 3.6|--|--|--|algorithmiahq/ubuntu:16.04|
-|python36-gpu|Python 3.6|--|--|9.0 / 7|nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04|
-|tensorflow-gpu-1.12|Python 3.6|TensorFlow 1.12|keras==2.1.4|9.0 / 7|nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04|
-|r36|R 3.6|--|--|--|algorithmiahq/ubuntu:16.04|
-|scala-2-sbt-1.3.3|Scala 2.x|--|--|--|algorithmiahq/ubuntu:16.04|
-|java11|Java 11.0|--|--|--|algorithmiahq/ubuntu:20.04|
-
-  </div>
-</div>
+For a list of the algorithm environments that are currently available, see the [Currently available environments](https://training.algorithmia.com/developing-python-algorithms-in-a-local-ide/906833). To create an algorithm with a predefined environment through the API, see [Using a predefined language environment](https://training.algorithmia.com/developing-python-algorithms-in-a-local-ide/698050#predefined-environment).

--- a/_pages/monitoring-and-observability/insights.md
+++ b/_pages/monitoring-and-observability/insights.md
@@ -27,7 +27,7 @@ Algorithmia Insights is currently supported for [Python 3.x](/developers/algorit
 Algorithmia Insights metrics fall into two categories:
 
 - **Operational metrics** include (but are not limited to) execution time, request ID, algorithm owner, algorithm name, algorithm version, timestamp, etc. When Algorithmia Insights is enabled for a particular algorithm version, these metrics are automatically collected and reported without any additional action necessary on behalf of the algorithm developer.
-- **Inference-related metrics** are defined in the algorithm source code itself. Each metric is defined by a title (e.g, `"cute_cats_detected"`) and the numeric value associated with that parameter in the code (e.g., the variable `cute_cats_detected`, which in this case hopefully evaluates to a large number like `24`). Multiple inference-related metrics can be reported at one time (see [Restrictions](#restrictions) below). Furthermore, because  metrics reporting is all defined within the code itself, the exact set of metrics reported does not need to be the same from one algorithm execution to another.
+- **Inference-related metrics** are defined in the algorithm source code itself. Each metric is defined by a title (e.g, `"cute_cats_detected"`) and the numeric value associated with that parameter in the code (e.g., the variable `cute_cats_detected`, which in this case hopefully evaluates to a large number like `24`). Multiple inference-related metrics can be reported at one time (see [Restrictions](#restrictions) below). Furthermore, because metrics reporting is all defined within the code itself, the exact set of metrics reported does not need to be the same from one algorithm execution to another.
 
 ## Setting up Algorithmia Insights on your cluster
 

--- a/_pages/monitoring-and-observability/insights.md
+++ b/_pages/monitoring-and-observability/insights.md
@@ -16,70 +16,63 @@ title: "Algorithmia Insights"
 This feature is available to [Algorithmia Enterprise](/enterprise) users only.
 {: .notice-enterprise}
 
-Algorithmia Insights is an algorithm metrics pipeline providing you access to your algorithm metrics payload for each algorithm session so you can measure, monitor, and manage your algorithms in production.
+Algorithmia Insights is an algorithm metrics pipelining tool that enables you to send your algorithms' operational and inference metrics to external monitoring, observability, and alerting platforms so that you can measure, monitor, and manage your algorithms in production.
 
-With Algorithmia Insights you'll be able to opt in to exporting your algorithm's operational metrics to external monitoring and alerting tools. This means you'll be able to monitor your algorithm's execution time as well as capture any model inference metrics you expose from your algorithm's output such as predictions or accuracy. Any metrics you opt to collect will be captured and exported in a payload and, with help from a Platform Administrator, can be connected to your external systems for monitoring and alerting.
+Once Insights is configured on your cluster, you'll be able to opt in to the feature for each version of each algorithm, every time you go through the publishing step. When enabled, Insights will automatically stream select algorithm data to an external message broker, from which these data can be consumed by external platforms. Insights automatically sends algorithm operational data, such as algorithm execution time, and you can granularly specify any model inference metrics you'd like to send as well, from within your algorithm source code. These data can be prediction or accuracy values, or even intermediate values that aren't exposed in your algorithm's actual output payload.
 
-Algorithmia Insights currently supports [Python 3.x](../clients/python#publishing-algorithmia-insights), [R](../clients/r#publishing-algorithmia-insights), and [Java](../clients/java#publishing-algorithmia-insights) algorithms and [Apache Kafka](https://kafka.apache.org/) as a destination for metrics.
+Algorithmia Insights is currently supported for [Python 3.x](/developers/algorithm-development/languages/python#publishing-algorithmia-insights), [R](/developers/algorithm-development/languages/r#publishing-algorithmia-insights), and [Java](/developers/algorithm-development/languages/java#publishing-algorithmia-insights) algorithms, and you can use [Apache Kafka](https://kafka.apache.org/) or [Azure Event Hubs](https://azure.microsoft.com/services/event-hubs/) as a broker for metrics.
 
 ### Types of Algorithmia Insights metrics
 
 Algorithmia Insights metrics fall into two categories:
 
-- Operational metrics
-- Inference-related metrics
-
-**Operational metrics** include (but are not limited to) execution time, request ID, algorithm owner, algorithm name, algorithm version, timestamp, etc. When Algorithmia Insights is turned on for a particular algorithm version, these are automatically collected and reported without any additional action necessary on the part of the algorithm author or manager.
-
-**Inference-related metrics** are defined by the algorithm author in algorithm code. Each metric is defined by a title, like `cute_cats_detected`, and a numeric value, like `24`. Multiple inference-related metrics can be reported at one time, and the set of metrics reported does not need to be the same from one algorithm execution to another.
+- **Operational metrics** include (but are not limited to) execution time, request ID, algorithm owner, algorithm name, algorithm version, timestamp, etc. When Algorithmia Insights is enabled for a particular algorithm version, these metrics are automatically collected and reported without any additional action necessary on behalf of the algorithm developer.
+- **Inference-related metrics** are defined in the algorithm source code itself. Each metric is defined by a title (e.g, `"cute_cats_detected"`) and the numeric value associated with that parameter in the code (e.g., the variable `cute_cats_detected`, which in this case hopefully evaluates to a large number like `24`). Multiple inference-related metrics can be reported at one time (see [Restrictions](#restrictions) below). Furthermore, because  metrics reporting is all defined within the code itself, the exact set of metrics reported does not need to be the same from one algorithm execution to another.
 
 ## Setting up Algorithmia Insights on your cluster
 
-The Kafka connection required for Insights is a global configuration on your Algorithmia cluster. If Insights isn't already available on your cluster, ask your cluster admin to [configure a connection to Kafka](https://training.algorithmia.com/exploring-the-admin-panel/687275).
+The external broker connection required for Insights is a global configuration on your Algorithmia cluster. If Insights isn't already available on your cluster, ask your cluster admin to [configure a broker connection](https://training.algorithmia.com/exploring-the-admin-panel/687275).
 
 ## Using Algorithmia Insights in an algorithm
 
 Each algorithm in your Algorithmia cluster has independent settings for whether to collect and report Algorithmia Insights. Additionally, each published version of your algorithm can have Algorithmia Insights turned on or off.
 
-### Creating inference-related metrics for your algorithm
+### Reporting inference-related metrics from your algorithm source code
 
-Algorithmia [client libraries](../clients) are used to report inference-related metrics that you create inside of your algorithm code. Please see the "Publishing Algorithmia Insights" section of the appropriate [client library guide](../clients) for the language that you're using.
+To learn how to add Insights reporting to your algorithm source code, see the respective guide for your algorithm development language. Insights is supported for [Python 3.x](/developers/algorithm-development/languages/python#publishing-algorithmia-insights), [R](/developers/algorithm-development/languages/r#publishing-algorithmia-insights), and [Java](/developers/algorithm-development/languages/java#publishing-algorithmia-insights) algorithms.
 
 #### Restrictions
 
-You can report up to 25 metrics in your code. The Algorithmia Platform will report additional metrics that do not count towards these 25.
-
-Additionally, the total size of your metrics data (keys and values) must not exceed 25 kilobytes.
-
-Finally, there are several reserved metric names that must not be used by client code, as they will conflict with automatically created metrics for each algorithm execution:
-
-- `request_id`
-- `timestamp`
-- `duration_milliseconds`
-- `algorithm_owner`
-- `algorithm_name`
-- `algorithm_version`
+- **Maximum count**: You can report up to 25 metrics from within an algorithm. The operational metrics that the Algorithmia platform reports automatically don't count towards these 25.
+- **Maximum payload size**: The total size of your metrics payload (combined keys plus values) must not exceed 25 KB.
+- **Reserved names**: You must not use the following strings to report your metrics in your algorithm code, because they'll conflict with names used by the platform itself:
+  - `request_id`
+  - `timestamp`
+  - `duration_milliseconds`
+  - `algorithm_owner`
+  - `algorithm_name`
+  - `algorithm_version`
 
 ### Enabling Algorithmia Insights for an algorithm version
 
-Enabling Algorithmia Insights for an algorithm version happens during [algorithm publishing](../algorithm-development/your-first-algo/#publish-your-algorithm).
+Enabling Algorithmia Insights for an algorithm version happens during the [algorithm publishing](/developers/algorithm-development/your-first-algo/#publishing-your-algorithm) step.
 
-When using the web UI publishing workflow, a toggle will appear to enable Algorithmia Insights for the specific algorithm version that you are publishing.
+When using the browser UI publishing workflow, you'll have the option to enable Algorithmia Insights for the specific algorithm version that you're publishing, as shown below.
 
 ![Image of algorithm publish UI with Algorithmia Insights checkbox](/developers/images/algorithmia-enterprise/algorithmia-insights/web-ui-publish.png)
 
-When using the HTTP API or client libraries to publish your algorithm, passing the key value pair `"insights_enabled":true` in the `settings` hash will enable Algorithmia Insights for your algorithm. For example, when using [cURL](../clients/curl):
+When using the HTTP API or client libraries to publish your algorithm, passing the key-value pair `"insights_enabled": true` in the algorithm's `settings` will enable Algorithmia Insights for your algorithm, as demonstrated in the following [cURL](/developers/clients/curl) command.
 
-{% highlight bash %}
-curl -H 'Authorization: Simple YOUR_API_KEY' https://<algorithmia-cluster-host>/v1/algorithms/<algorithm-owner>/<algorithm-name>/version --data-binary '{"settings":{"insights_enabled":true}}'
-{% endhighlight %}
+```shell
+$ curl https://CLUSTER_DOMAIN/v1/algorithms/ALGO_OWNER/ALGO_NAME/versions \
+  -H 'Authorization: Simple STD_API_KEY' \
+  -d '{"settings": {"insights_enabled": true}}'
+```
 
-Once you've published your algorithm with Algorithmia Insights enabled, all executions of that specific version of the algorithm will trigger your Algorithmia Insights to be collected and reported to the Kafka broker that your Algorithmia Platform Administrator has set up.
+Once you've published your algorithm with Algorithmia Insights enabled, all executions of that specific version of the algorithm will trigger the specified metrics to be collected and reported to the external message broker that your [Algorithmia cluster admin has configured](#setting-up-algorithmia-insights-on-your-cluster).
 
 ### Viewing Algorithmia Insights status for algorithm versions
 
-The "Versions" tab of the algorithm page shows which published versions of that algorithm have Algorithmia Insights enabled:
+Navigate to the **Versions** tab of an algorithm's profile page to see which published versions of that algorithm have Insights enabled.
 
 ![Image of algorithm versions page with Algorithmia Insights flag highlighted](/developers/images/algorithmia-enterprise/algorithmia-insights/web-ui-versions.png)
-
-If you're new to Algorithmia and would like to learn more about our product and the Algorithmia Insights metrics pipeline, please [contact our sales team](https://info.algorithmia.com/contact-sales). We'd love to hear from you!


### PR DESCRIPTION
[DOCS-313](https://algorithmia.atlassian.net/browse/DOCS-313) - update environments page, move tables to Training Center

Also fixed issues on:
- Insights page
- cURL page
- Event Hubs page

## Checklist
- [x] My PR title includes a relevant Jira ticket name
- [ ] If no associated Jira ticket, my PR title is informative (individual commit messages are squashed in this repo)
- [x] Unnecessary text (notes, TODOs, etc.) has been removed
- [x] For YAML "front matter":
  - Properties are alphabetized
  - `permalink` and `redirect_from/to` properties have `/` at beginning and end (e.g., `/path/`)
- [x] Screenshots, if present, follow the [Screenshot guidelines](https://algorithmia.atlassian.net/wiki/spaces/CUSTOMERS/pages/1634861478/CFD+Style+Guide#Screenshots) which means:
  - Full browser width (browser at 100% zoom and 10-12" width)
  - Max 1000px
- [x] Grammar, style, tone, punctuation, etc. follow the Algorithmia [manual of style](https://docs.google.com/document/d/1PPVfgMkX7-EVGLPMhN1E485CAXu9QfhSLKM0lZhnZdU/edit?usp=sharing)
- [x] Headers are “Sentence case with Proper Nouns capitalized”
- [x] Placeholder strings are `UPPER_SNAKE_CASE` and are named as in the [Glossary](https://algorithmia.com/developers/glossary) where appropriate
