### PR TITLE
DOCS-295: specify that subscription ID must be provided for Azure SB

### DIFF
--- a/_pages/event-flows/azure-sb.md
+++ b/_pages/event-flows/azure-sb.md
@@ -42,12 +42,12 @@ Contact [support@algorithmia.com](mailto:support@algorithmia.com) to obtain the 
 
 #### Create a custom role in your account
 
-To begin, save the following JSON custom role definition as a local file `GuestRole.json`.
+To begin, save the following JSON custom role definition as a local file `GuestRole.json`. You'll need to replace `SUBSCRIPTION_ID` with your Azure account's unique **Subscription ID** value. This can be found under the **Subscriptions** service in the Azure portal, and it will be a UUID of the format `51a70446-0c61-4017-577a-9327a28bcb73`.
 
 ```json
 {
   "Name": "QueueReceiver",
-  "Id": "88888888-8888-8888-8888-888888888888",
+  "Id": "SUBSCRIPTION_ID",
   "IsCustom": true,
   "Description": "Can receive messages and get connection string",
   "Actions": [
@@ -61,7 +61,7 @@ To begin, save the following JSON custom role definition as a local file `GuestR
   ],
   "NotDataActions": [],
   "AssignableScopes": [
-    "/subscriptions/88888888-8888-8888-8888-888888888888"
+    "/subscriptions/SUBSCRIPTION_ID"
   ]
 }
 ```


### PR DESCRIPTION
[DOCS-295](https://algorithmia.atlassian.net/browse/DOCS-295) - add note about subscription ID

## Checklist
- [x] My PR title includes a relevant Jira ticket name
- [ ] If no associated Jira ticket, my PR title is informative (individual commit messages are squashed in this repo)
- [x] Unnecessary text (notes, TODOs, etc.) has been removed
- [x] For YAML "front matter":
  - Properties are alphabetized
  - `permalink` and `redirect_from/to` properties have `/` at beginning and end (e.g., `/path/`)
- [x] Screenshots, if present, follow the [Screenshot guidelines](https://algorithmia.atlassian.net/wiki/spaces/CUSTOMERS/pages/1634861478/CFD+Style+Guide#Screenshots) which means:
  - Full browser width (browser at 100% zoom and 10-12" width)
  - Max 1000px
- [x] Grammar, style, tone, punctuation, etc. follow the Algorithmia [manual of style](https://docs.google.com/document/d/1PPVfgMkX7-EVGLPMhN1E485CAXu9QfhSLKM0lZhnZdU/edit?usp=sharing)
- [x] Headers are “Sentence case with Proper Nouns capitalized”
- [x] Placeholder strings are `UPPER_SNAKE_CASE` and are named as in the [Glossary](https://algorithmia.com/developers/glossary) where appropriate
