### PR TITLE
UXENG-3620: Redirect /careers to https://www.datarobot.com/careers/

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -21,7 +21,7 @@
         <div
           class="syn-caption syn-text-secondary syn-mb-0"
         >
-          © 2020 Algorithmia Inc.
+          © 2021 Algorithmia Inc.
         </div>
 
         {% unless site.enterprise %}
@@ -88,10 +88,12 @@
             <a href="/about" class="syn-text-secondary">About</a>
           </div>
           <div class="syn-mb-8 syn-body-2">
-            <a href="/careers" class="syn-text-secondary">Careers</a
-            ><span class="syn-badge theme-secondary syn-ml-8"
-              >We're Hiring!</span
-            >
+            <a
+              class="syn-text-secondary"
+              href="https://www.datarobot.com/careers/"
+              rel="noopener noreferrer">
+              Careers at DataRobot
+            </a>
           </div>
           <div class="syn-mb-8 syn-body-2">
             <a href="https://algorithmia.com/blog" class="syn-text-secondary"


### PR DESCRIPTION
[DOCS-3620](https://algorithmia.atlassian.net/browse/DOCS-3620) - Brief description / title of ticket

Updated the "Careers" link in the dev-center footer to "Careers at DataRobot" and its URL to https://www.datarobot.com/careers/.



## Checklist
- [x] My PR title includes a relevant Jira ticket name
- [ ] If no associated Jira ticket, my PR title is informative (individual commit messages are squashed in this repo)
- [ ] Unnecessary text (notes, TODOs, etc.) has been removed
- [ ] For YAML "front matter":
  - Properties are alphabetized
  - `permalink` and `redirect_from/to` properties have `/` at beginning and end (e.g., `/path/`)
- [ ] Screenshots, if present, follow the [Screenshot guidelines](https://algorithmia.atlassian.net/wiki/spaces/CUSTOMERS/pages/1634861478/CFD+Style+Guide#Screenshots) which means:
  - Full browser width (browser at 100% zoom and 10-12" width)
  - Max 1000px
- [ ] Grammar, style, tone, punctuation, etc. follow the Algorithmia [manual of style](https://docs.google.com/document/d/1PPVfgMkX7-EVGLPMhN1E485CAXu9QfhSLKM0lZhnZdU/edit?usp=sharing)
- [ ] Headers are “Sentence case with Proper Nouns capitalized”
- [ ] Placeholder strings are `UPPER_SNAKE_CASE` and are named as in the [Glossary](https://algorithmia.com/developers/glossary) where appropriate
