### PR TITLE
remove pricing, support links from nav

### DIFF
--- a/_data/toc.yml
+++ b/_data/toc.yml
@@ -86,14 +86,14 @@
 - title: VMware
   url: /vmware/
 
-- title: Pricing
-  url: https://algorithmia.com/pricing
+# - title: Pricing
+#   url: https://algorithmia.com/pricing
 
 - title: Release Notes
   url: /release-notes/
 
-- title: Support
-  url: /support/
+# - title: Support
+#   url: /support/
 
 - title: FAQ
   url: /faqs/


### PR DESCRIPTION
No associated Jira ticket. Removing some links at request of DR legal. Support page itself will be changed, pending info from DR side, but for the moment wanted to get the links out of the nav. 
