### PR TITLE
add dark mode feature flag endpoint docs

### DIFF
--- a/_pages/administration/admin-config/configure-user-roles.md
+++ b/_pages/administration/admin-config/configure-user-roles.md
@@ -77,7 +77,7 @@ This action requires cluster administrator privileges. A sample API request to a
 <div class="syn-code-block">
 <pre class="code_snippet">$ curl https://CLUSTER_DOMAIN/v1/organizations \
     -X POST \
-    -H "Authorization: ADMIN_API_KEY" \
+    -H "Authorization: Simple ADMIN_API_KEY" \
     -d '{
       "org_name":"TestOrg",
       "org_label":"A Test Organization",

--- a/_pages/administration/admin-panel/algorithm-errors.md
+++ b/_pages/administration/admin-panel/algorithm-errors.md
@@ -40,7 +40,7 @@ Because of the consideration above, the user-facing errors feature is disabled b
 
 <pre class="code_snippet">curl -X PUT https://api.CLUSTER_DOMAIN/v1/admin/features/algorithm-errors \
   -H 'Content-Type: application/json'
-  -H 'Authorization: ADMIN_API_KEY'
+  -H 'Authorization: Simple ADMIN_API_KEY'
   -d '{"enabled": true}'
 </pre>
 

--- a/_pages/administration/admin-panel/ui-customization.md
+++ b/_pages/administration/admin-panel/ui-customization.md
@@ -15,3 +15,19 @@ The UI Customization page provides functionality for customizing the appearance 
 When the desired changes have been made, click "Save Changes" and refresh the page to see the changes take effect. It may take several seconds for the changes to propagate across the system.
 
 ![Admin Panel - UI Customization]({{site.url}}/developers/images/post_images/algo-images-admin/algo-1609365483178.png)
+
+## Enabling/disabling dark mode
+
+Beginning in Algorithmia version 21.3, administrators can enable dark mode at the cluster level. The feature can be enabled through the admin API with an [admin API key](/developers/platform/customizing-api-keys#admin-api-keys), using the following cURL command. Note that you must substitute `CLUSTER_DOMAIN` with your Algorithmia cluster domain name (e.g., `algorithmia.com`) and you must substitute a valid value for `ADMIN_API_KEY`.
+
+<div class="syn-code-block">
+
+<pre class="code_snippet">curl -X PUT https://api.CLUSTER_DOMAIN/v1/admin/features/dark-theme-enabled \
+  -H 'Content-Type: application/json'
+  -H 'Authorization: Simple ADMIN_API_KEY'
+  -d '{"enabled": true}'
+</pre>
+
+</div>
+
+To disable the feature, you can use the same cURL command as above, changing the payload to `{"enabled": false}`.


### PR DESCRIPTION
Adding admin docs for UI reskin dark mode; no associated Jira ticket. Also fixed a few code sample omissions.

## Checklist
- [ ] My PR title includes a relevant Jira ticket name
- [x] If no associated Jira ticket, my PR title is informative (individual commit messages are squashed in this repo)
- [x] Unnecessary text (notes, TODOs, etc.) has been removed
- [x] For YAML "front matter":
  - Properties are alphabetized
  - `permalink` and `redirect_from/to` properties have `/` at beginning and end (e.g., `/path/`)
- [x] Screenshots, if present, follow the [Screenshot guidelines](https://algorithmia.atlassian.net/wiki/spaces/CUSTOMERS/pages/1634861478/CFD+Style+Guide#Screenshots) which means:
  - Full browser width (browser at 100% zoom and 10-12" width)
  - Max 1000px
- [x] Grammar, style, tone, punctuation, etc. follow the Algorithmia [manual of style](https://docs.google.com/document/d/1PPVfgMkX7-EVGLPMhN1E485CAXu9QfhSLKM0lZhnZdU/edit?usp=sharing)
- [x] Headers are “Sentence case with Proper Nouns capitalized”
- [x] Placeholder strings are `UPPER_SNAKE_CASE` and are named as in the [Glossary](https://algorithmia.com/developers/glossary) where appropriate
